### PR TITLE
37-create-endpoint-for-login-and-logout

### DIFF
--- a/app/api/auth/login/__tests__/route.test.ts
+++ b/app/api/auth/login/__tests__/route.test.ts
@@ -1,0 +1,158 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+
+// Mock next/headers (imported transitively by lib/supabase/server)
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() => ({ getAll: vi.fn(() => []), set: vi.fn() })),
+}));
+
+const mockSignInWithPassword = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { signInWithPassword: mockSignInWithPassword } })
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeInvalidJsonRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{ not valid json",
+  });
+}
+
+const validBody = {
+  email: "player@example.com",
+  password: "securepass",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/auth/login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Success cases --------------------------------------------------------
+
+  it("returns 200 with message and user_id on valid login", async () => {
+    mockSignInWithPassword.mockResolvedValue({
+      data: { user: { id: "abc-123" }, session: {} },
+      error: null,
+    });
+
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.user_id).toBe("abc-123");
+    expect(json.message).toMatch(/login successful/i);
+  });
+
+  it("calls signInWithPassword with correct credentials", async () => {
+    mockSignInWithPassword.mockResolvedValue({
+      data: { user: { id: "abc-123" }, session: {} },
+      error: null,
+    });
+
+    await POST(makeRequest(validBody));
+
+    expect(mockSignInWithPassword).toHaveBeenCalledWith({
+      email: validBody.email,
+      password: validBody.password,
+    });
+  });
+
+  // --- Validation errors ----------------------------------------------------
+
+  it("returns 400 for malformed JSON body", async () => {
+    const res = await POST(makeInvalidJsonRequest());
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 listing all missing required fields", async () => {
+    const res = await POST(makeRequest({}));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/email/);
+    expect(json.error).toMatch(/password/);
+  });
+
+  it("returns 400 listing only the missing fields", async () => {
+    const res = await POST(makeRequest({ email: "x@x.com" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/password/);
+    expect(json.error).not.toMatch(/email/);
+  });
+
+  it("returns 400 for an invalid email format", async () => {
+    const res = await POST(makeRequest({ ...validBody, email: "not-an-email" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/invalid email/i);
+  });
+
+  // --- Supabase error handling ----------------------------------------------
+
+  it("returns 401 for invalid credentials", async () => {
+    mockSignInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Invalid login credentials" },
+    });
+
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.error).toMatch(/invalid email or password/i);
+  });
+
+  it("returns 403 when email is not confirmed", async () => {
+    mockSignInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Email not confirmed" },
+    });
+
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json.error).toMatch(/email not confirmed/i);
+  });
+
+  it("returns 400 for other Supabase errors", async () => {
+    mockSignInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Something went wrong" },
+    });
+
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("Something went wrong");
+  });
+});

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,76 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const { email, password } = body as LoginRequest;
+
+  // Validate required fields
+  const missing: string[] = [];
+  if (!email) missing.push("email");
+  if (!password) missing.push("password");
+
+  if (missing.length > 0) {
+    return NextResponse.json(
+      { error: `Missing required fields: ${missing.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  // Basic email format validation
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return NextResponse.json(
+      { error: "Invalid email format" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    if (error.message?.toLowerCase().includes("invalid login credentials")) {
+      return NextResponse.json(
+        { error: "Invalid email or password" },
+        { status: 401 }
+      );
+    }
+
+    if (error.message?.toLowerCase().includes("email not confirmed")) {
+      return NextResponse.json(
+        { error: "Email not confirmed. Please check your inbox." },
+        { status: 403 }
+      );
+    }
+
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json(
+    {
+      message: "Login successful",
+      user_id: data.user?.id ?? null,
+    },
+    { status: 200 }
+  );
+}

--- a/app/api/auth/logout/__tests__/route.test.ts
+++ b/app/api/auth/logout/__tests__/route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+
+// Mock next/headers (imported transitively by lib/supabase/server)
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() => ({ getAll: vi.fn(() => []), set: vi.fn() })),
+}));
+
+const mockSignOut = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { signOut: mockSignOut } })
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/auth/logout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Success cases --------------------------------------------------------
+
+  it("returns 200 with success message on valid logout", async () => {
+    mockSignOut.mockResolvedValue({ error: null });
+
+    const res = await POST();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.message).toMatch(/logged out/i);
+  });
+
+  it("calls signOut once", async () => {
+    mockSignOut.mockResolvedValue({ error: null });
+
+    await POST();
+
+    expect(mockSignOut).toHaveBeenCalledOnce();
+  });
+
+  // --- Supabase error handling ----------------------------------------------
+
+  it("returns 400 when Supabase signOut fails", async () => {
+    mockSignOut.mockResolvedValue({
+      error: { message: "Something went wrong" },
+    });
+
+    const res = await POST();
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("Something went wrong");
+  });
+});

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const supabase = await createClient();
+
+  const { error } = await supabase.auth.signOut();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json(
+    { message: "Logged out successfully" },
+    { status: 200 }
+  );
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/auth/login` — validates email/password, calls `signInWithPassword`, returns 200/401/403/400
- Add `POST /api/auth/logout` — calls `signOut`, returns 200/400
- Unit tests written first (TDD) with full coverage for validation and Supabase error cases (12 tests total)

## Test plan
- [x] All 56 tests pass (`npm test`)
- [x] 401 returned for invalid credentials
- [x] 403 returned for unconfirmed email
- [x] 400 returned for missing/invalid fields and other Supabase errors
- [x] 200 returned with `user_id` on successful login
- [x] 200 returned on successful logout

🤖 Generated with [Claude Code](https://claude.com/claude-code)