### PR TITLE
feat: create login and forgot-password screens

### DIFF
--- a/app/_components/NavBar.tsx
+++ b/app/_components/NavBar.tsx
@@ -2,21 +2,87 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
 import { closeDrawer, getIsDrawerOpen, openDrawer } from "@/lib/nav-bar-state";
+import { createClient } from "@/lib/supabase/client";
 
 const NAV_LINKS = [
   { href: "/become-organizer", label: "Become an Organizer", ghost: true },
 ];
 
+type AuthUser = {
+  email: string;
+  fullName: string;
+  initials: string;
+};
+
 export default function NavBar() {
   const pathname = usePathname();
+  const router = useRouter();
   const [drawerState, setDrawerState] = useState(() =>
     closeDrawer(openDrawer(pathname ?? "")),
   );
   const drawerRef = useRef<HTMLDivElement>(null);
   const drawerOpen = getIsDrawerOpen(drawerState, pathname ?? "");
+
+  const [authUser, setAuthUser] = useState<AuthUser | null>(null);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Fetch auth state on every route change
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data }) => {
+      if (!data.user) {
+        setAuthUser(null);
+        return;
+      }
+      const meta = data.user.user_metadata ?? {};
+      const firstName: string = meta.first_name ?? meta.firstName ?? "";
+      const lastName: string = meta.last_name ?? meta.lastName ?? "";
+      const initials =
+        [firstName[0], lastName[0]].filter(Boolean).join("").toUpperCase() ||
+        (data.user.email?.[0]?.toUpperCase() ?? "?");
+      setAuthUser({
+        email: data.user.email ?? "",
+        fullName:
+          [firstName, lastName].filter(Boolean).join(" ") ||
+          (data.user.email ?? ""),
+        initials,
+      });
+    });
+  }, [pathname]);
+
+  // Close dropdown on outside click or Escape
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function onMouseDown(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setDropdownOpen(false);
+      }
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setDropdownOpen(false);
+    }
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [dropdownOpen]);
+
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    setAuthUser(null);
+    setDropdownOpen(false);
+    router.push("/login");
+  }
 
   // Prevent body scroll when drawer is open
   useEffect(() => {
@@ -41,7 +107,7 @@ export default function NavBar() {
     <>
       <nav className="bg-(--color-bg-sunken) border-b border-(--color-border) sticky top-0 z-50">
         <div className="max-w-300 mx-auto px-10 flex items-center justify-between h-16">
-          {/* Brand logo — always redirects to /tournaments, never shrinks */}
+          {/* Brand logo */}
           <Link href="/tournaments" className="flex items-center shrink-0">
             <Image
               src="/mct-logo-horizontal.svg"
@@ -58,17 +124,86 @@ export default function NavBar() {
               <Link
                 key={href}
                 href={href}
-                className={ghost ? "nav-link" : `nav-link${pathname === href ? " nav-link--active" : ""}`}
+                className={
+                  ghost
+                    ? "nav-link"
+                    : `nav-link${pathname === href ? " nav-link--active" : ""}`
+                }
               >
                 {label}
               </Link>
             ))}
-            <Link href="/login" className="nav-btn-login">
-              Login
-            </Link>
-            <Link href="/sign-up" className="nav-btn-signup">
-              Sign Up
-            </Link>
+
+            {authUser ? (
+              <>
+                <Link
+                  href="/tournaments"
+                  className={`nav-link${pathname === "/tournaments" ? " nav-link--active" : ""}`}
+                >
+                  My Tournaments
+                </Link>
+
+                {/* Avatar + dropdown */}
+                <div className="relative ml-2" ref={dropdownRef}>
+                  <button
+                    className={`nav-avatar${dropdownOpen ? " nav-avatar--open" : ""}`}
+                    onClick={() => setDropdownOpen((v) => !v)}
+                    aria-label="Account menu"
+                    aria-expanded={dropdownOpen}
+                  >
+                    {authUser.initials}
+                  </button>
+
+                  {dropdownOpen && (
+                    <div className="nav-dropdown">
+                      <div className="nav-dropdown-user">
+                        <p className="nav-dropdown-name">{authUser.fullName}</p>
+                        <p className="nav-dropdown-email">{authUser.email}</p>
+                      </div>
+                      <div>
+                        <Link
+                          href="/profile"
+                          className="nav-dropdown-item"
+                          onClick={() => setDropdownOpen(false)}
+                        >
+                          My Profile
+                        </Link>
+                        <Link
+                          href="/tournaments"
+                          className="nav-dropdown-item"
+                          onClick={() => setDropdownOpen(false)}
+                        >
+                          My Registrations
+                        </Link>
+                        <Link
+                          href="/settings"
+                          className="nav-dropdown-item"
+                          onClick={() => setDropdownOpen(false)}
+                        >
+                          Settings
+                        </Link>
+                      </div>
+                      <div className="nav-dropdown-divider" />
+                      <button
+                        className="nav-dropdown-item nav-dropdown-item--danger"
+                        onClick={handleSignOut}
+                      >
+                        Sign Out
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                <Link href="/login" className="nav-btn-login">
+                  Login
+                </Link>
+                <Link href="/sign-up" className="nav-btn-signup">
+                  Sign Up
+                </Link>
+              </>
+            )}
           </div>
 
           {/* Hamburger button — visible on small screens only */}
@@ -147,20 +282,50 @@ export default function NavBar() {
               {label}
             </Link>
           ))}
-          <Link
-            href="/login"
-            className="nav-drawer-btn-login"
-            onClick={() => setDrawerState((current) => closeDrawer(current))}
-          >
-            Login
-          </Link>
-          <Link
-            href="/sign-up"
-            className="nav-drawer-btn-signup"
-            onClick={() => setDrawerState((current) => closeDrawer(current))}
-          >
-            Sign Up
-          </Link>
+
+          {authUser ? (
+            <>
+              <Link
+                href="/tournaments"
+                onClick={() =>
+                  setDrawerState((current) => closeDrawer(current))
+                }
+                className={`nav-drawer-link${pathname === "/tournaments" ? " nav-drawer-link--active" : ""}`}
+              >
+                My Tournaments
+              </Link>
+              <button
+                className="nav-drawer-btn-login mt-4"
+                onClick={async () => {
+                  setDrawerState((current) => closeDrawer(current));
+                  await handleSignOut();
+                }}
+              >
+                Sign Out
+              </button>
+            </>
+          ) : (
+            <>
+              <Link
+                href="/login"
+                className="nav-drawer-btn-login"
+                onClick={() =>
+                  setDrawerState((current) => closeDrawer(current))
+                }
+              >
+                Login
+              </Link>
+              <Link
+                href="/sign-up"
+                className="nav-drawer-btn-signup"
+                onClick={() =>
+                  setDrawerState((current) => closeDrawer(current))
+                }
+              >
+                Sign Up
+              </Link>
+            </>
+          )}
         </div>
       </div>
     </>

--- a/app/auth/callback/__tests__/route.test.ts
+++ b/app/auth/callback/__tests__/route.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  exchangeCodeForSession: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { exchangeCodeForSession: mocks.exchangeCodeForSession } })
+  ),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: { redirect: mocks.redirect },
+}));
+
+import { GET } from "../route";
+
+function makeRequest(path: string): Request {
+  return new Request(`https://mychessstour.com${path}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.redirect.mockReturnValue(new Response());
+  mocks.exchangeCodeForSession.mockResolvedValue({ error: null });
+});
+
+describe("GET /auth/callback", () => {
+  it("redirects to error page when no code is present", async () => {
+    await GET(makeRequest("/auth/callback"));
+
+    expect(mocks.redirect).toHaveBeenCalledWith(
+      expect.stringContaining("/forgot-password?error=invalid_link"),
+    );
+  });
+
+  it("calls exchangeCodeForSession with the code", async () => {
+    await GET(makeRequest("/auth/callback?code=abc123"));
+
+    expect(mocks.exchangeCodeForSession).toHaveBeenCalledWith("abc123");
+  });
+
+  it("redirects to next param on successful session exchange", async () => {
+    await GET(makeRequest("/auth/callback?code=abc123&next=/update-password"));
+
+    expect(mocks.redirect).toHaveBeenCalledWith(
+      expect.stringContaining("/update-password"),
+    );
+  });
+
+  it("redirects to / when next param is absent (default)", async () => {
+    await GET(makeRequest("/auth/callback?code=abc123"));
+
+    expect(mocks.redirect).toHaveBeenCalledWith(
+      "https://mychessstour.com/",
+    );
+  });
+
+  it("redirects to error page when exchange fails", async () => {
+    mocks.exchangeCodeForSession.mockResolvedValue({ error: { message: "Invalid code" } });
+
+    await GET(makeRequest("/auth/callback?code=badcode"));
+
+    expect(mocks.redirect).toHaveBeenCalledWith(
+      expect.stringContaining("/forgot-password?error=invalid_link"),
+    );
+  });
+});

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/forgot-password?error=invalid_link`);
+}

--- a/app/forgot-password/__tests__/actions.test.ts
+++ b/app/forgot-password/__tests__/actions.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted so they run before imports
+// ---------------------------------------------------------------------------
+
+const mockResetPasswordForEmail = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: { resetPasswordForEmail: mockResetPasswordForEmail },
+    }),
+  ),
+}));
+
+import { forgotPassword, INITIAL_FORGOT_PASSWORD_STATE } from "../actions";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFormData(data: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(data)) fd.append(k, v);
+  return fd;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResetPasswordForEmail.mockResolvedValue({ data: {}, error: null });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("forgotPassword action", () => {
+  // --- INITIAL_FORGOT_PASSWORD_STATE export ---------------------------------
+
+  it("exports INITIAL_FORGOT_PASSWORD_STATE with correct shape", () => {
+    expect(INITIAL_FORGOT_PASSWORD_STATE).toEqual({
+      error: null,
+      submitted: false,
+    });
+  });
+
+  // --- Validation errors ----------------------------------------------------
+
+  it("returns error when email is empty", async () => {
+    const fd = makeFormData({ email: "" });
+    const result = await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(result.error).toBeDefined();
+    expect(result.submitted).toBe(false);
+    expect(mockResetPasswordForEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns error when email is invalid", async () => {
+    const fd = makeFormData({ email: "not-an-email" });
+    const result = await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(result.error).toMatch(/email/i);
+    expect(result.submitted).toBe(false);
+    expect(mockResetPasswordForEmail).not.toHaveBeenCalled();
+  });
+
+  // --- Success cases --------------------------------------------------------
+
+  it("returns submitted=true for a valid email", async () => {
+    const fd = makeFormData({ email: "user@example.com" });
+    const result = await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(result.error).toBeNull();
+    expect(result.submitted).toBe(true);
+  });
+
+  it("calls supabase resetPasswordForEmail with correct email", async () => {
+    const fd = makeFormData({ email: "user@example.com" });
+    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
+      "user@example.com",
+      expect.objectContaining({ redirectTo: expect.stringContaining("/auth/callback") }),
+    );
+  });
+
+  it("trims whitespace from email", async () => {
+    const fd = makeFormData({ email: "  user@example.com  " });
+    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
+      "user@example.com",
+      expect.any(Object),
+    );
+  });
+
+  it("returns submitted=true even when supabase returns an error (prevents email enumeration)", async () => {
+    mockResetPasswordForEmail.mockResolvedValue({
+      data: null,
+      error: { message: "User not found" },
+    });
+
+    const fd = makeFormData({ email: "unknown@example.com" });
+    const result = await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(result.submitted).toBe(true);
+    expect(result.error).toBeNull();
+  });
+});

--- a/app/forgot-password/__tests__/actions.test.ts
+++ b/app/forgot-password/__tests__/actions.test.ts
@@ -4,17 +4,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mocks — hoisted so they run before imports
 // ---------------------------------------------------------------------------
 
-const mockResetPasswordForEmail = vi.fn();
-
-vi.mock("@/lib/supabase/server", () => ({
-  createClient: vi.fn(() =>
-    Promise.resolve({
-      auth: { resetPasswordForEmail: mockResetPasswordForEmail },
-    }),
-  ),
+const mocks = vi.hoisted(() => ({
+  generateLink: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
 }));
 
-import { forgotPassword, INITIAL_FORGOT_PASSWORD_STATE } from "../actions";
+vi.mock("@/lib/supabase/admin", () => ({
+  supabaseAdmin: {
+    auth: {
+      admin: {
+        generateLink: mocks.generateLink,
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendPasswordResetEmail: mocks.sendPasswordResetEmail,
+}));
+
+import { forgotPassword } from "../actions";
+import { INITIAL_FORGOT_PASSWORD_STATE } from "../types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -28,7 +38,11 @@ function makeFormData(data: Record<string, string>): FormData {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockResetPasswordForEmail.mockResolvedValue({ data: {}, error: null });
+  mocks.generateLink.mockResolvedValue({
+    data: { properties: { action_link: "https://supabase.example.com/auth/v1/verify?token=abc" } },
+    error: null,
+  });
+  mocks.sendPasswordResetEmail.mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -53,7 +67,7 @@ describe("forgotPassword action", () => {
 
     expect(result.error).toBeDefined();
     expect(result.submitted).toBe(false);
-    expect(mockResetPasswordForEmail).not.toHaveBeenCalled();
+    expect(mocks.generateLink).not.toHaveBeenCalled();
   });
 
   it("returns error when email is invalid", async () => {
@@ -62,10 +76,46 @@ describe("forgotPassword action", () => {
 
     expect(result.error).toMatch(/email/i);
     expect(result.submitted).toBe(false);
-    expect(mockResetPasswordForEmail).not.toHaveBeenCalled();
+    expect(mocks.generateLink).not.toHaveBeenCalled();
+  });
+
+  // --- generateLink params --------------------------------------------------
+
+  it("calls generateLink with correct params", async () => {
+    const fd = makeFormData({ email: "user@example.com" });
+    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(mocks.generateLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "recovery",
+        email: "user@example.com",
+        options: expect.objectContaining({
+          redirectTo: expect.stringContaining("/auth/callback"),
+        }),
+      }),
+    );
+  });
+
+  it("redirectTo contains /auth/callback and /update-password", async () => {
+    const fd = makeFormData({ email: "user@example.com" });
+    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    const callArg = mocks.generateLink.mock.calls[0][0];
+    expect(callArg.options.redirectTo).toContain("/auth/callback");
+    expect(callArg.options.redirectTo).toContain("/update-password");
   });
 
   // --- Success cases --------------------------------------------------------
+
+  it("sends email on success", async () => {
+    const fd = makeFormData({ email: "user@example.com" });
+    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(mocks.sendPasswordResetEmail).toHaveBeenCalledWith(
+      "user@example.com",
+      "https://supabase.example.com/auth/v1/verify?token=abc",
+    );
+  });
 
   it("returns submitted=true for a valid email", async () => {
     const fd = makeFormData({ email: "user@example.com" });
@@ -75,28 +125,10 @@ describe("forgotPassword action", () => {
     expect(result.submitted).toBe(true);
   });
 
-  it("calls supabase resetPasswordForEmail with correct email", async () => {
-    const fd = makeFormData({ email: "user@example.com" });
-    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+  // --- Silent error (email enumeration protection) -------------------------
 
-    expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
-      "user@example.com",
-      expect.objectContaining({ redirectTo: expect.stringContaining("/auth/callback") }),
-    );
-  });
-
-  it("trims whitespace from email", async () => {
-    const fd = makeFormData({ email: "  user@example.com  " });
-    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
-
-    expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
-      "user@example.com",
-      expect.any(Object),
-    );
-  });
-
-  it("returns submitted=true even when supabase returns an error (prevents email enumeration)", async () => {
-    mockResetPasswordForEmail.mockResolvedValue({
+  it("silently ignores generateLink errors (enum protection)", async () => {
+    mocks.generateLink.mockResolvedValue({
       data: null,
       error: { message: "User not found" },
     });
@@ -106,5 +138,49 @@ describe("forgotPassword action", () => {
 
     expect(result.submitted).toBe(true);
     expect(result.error).toBeNull();
+  });
+
+  it("does not send email when generateLink errors", async () => {
+    mocks.generateLink.mockResolvedValue({
+      data: null,
+      error: { message: "User not found" },
+    });
+
+    const fd = makeFormData({ email: "unknown@example.com" });
+    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(mocks.sendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  it("does not send email when action_link is missing", async () => {
+    mocks.generateLink.mockResolvedValue({
+      data: { properties: { action_link: undefined } },
+      error: null,
+    });
+
+    const fd = makeFormData({ email: "user@example.com" });
+    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(mocks.sendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  // --- Whitespace trimming --------------------------------------------------
+
+  it("trims whitespace from email", async () => {
+    const fd = makeFormData({ email: "  user@example.com  " });
+    await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(mocks.generateLink).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "user@example.com" }),
+    );
+  });
+
+  // --- Always submitted=true for valid email --------------------------------
+
+  it("always returns submitted=true for valid email", async () => {
+    const fd = makeFormData({ email: "user@example.com" });
+    const result = await forgotPassword(INITIAL_FORGOT_PASSWORD_STATE, fd);
+
+    expect(result.submitted).toBe(true);
   });
 });

--- a/app/forgot-password/__tests__/page.test.ts
+++ b/app/forgot-password/__tests__/page.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/_components/NavBar", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../_components/ForgotPasswordForm", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+import ForgotPasswordPage from "../page";
+
+describe("ForgotPasswordPage", () => {
+  it("returns a non-null React element", () => {
+    const result = ForgotPasswordPage();
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+
+  it("has a min-h-screen container", () => {
+    const result = ForgotPasswordPage() as Record<string, unknown>;
+    const props = result.props as Record<string, unknown>;
+    expect(props.className).toContain("min-h-screen");
+  });
+
+  it("exports metadata with a title containing MY Chess Tour", async () => {
+    const mod = await import("../page");
+    expect(mod.metadata).toBeDefined();
+    expect((mod.metadata as { title: string }).title).toContain("MY Chess Tour");
+  });
+});

--- a/app/forgot-password/_components/ForgotPasswordForm.tsx
+++ b/app/forgot-password/_components/ForgotPasswordForm.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { useActionState } from "react";
-import { forgotPassword, INITIAL_FORGOT_PASSWORD_STATE } from "../actions";
+import { forgotPassword } from "../actions";
+import { INITIAL_FORGOT_PASSWORD_STATE } from "../types";
 
 export default function ForgotPasswordForm() {
   const [state, formAction, pending] = useActionState(
@@ -15,18 +16,16 @@ export default function ForgotPasswordForm() {
     return (
       <div className="auth-page">
         <div className="centered-col">
-          <div className="auth-card card card--featured" style={{ textAlign: "center" }}>
+          <div className="auth-card card card--featured text-center">
             <div
-              style={{ fontSize: "2rem", marginBottom: "1rem" }}
+              className="font-[2rem] mb-4"
               role="img"
               aria-label="Email sent"
             >
               📬
             </div>
-            <h1 className="auth-heading" style={{ marginBottom: "0.5rem" }}>
-              Check Your Email
-            </h1>
-            <p className="auth-subheading" style={{ marginBottom: "2.5rem" }}>
+            <h1 className="auth-heading mb-2">Check Your Email</h1>
+            <p className="auth-subheading mb-10">
               If an account with that email exists, we&apos;ve sent a password
               reset link. It expires in 1 hour.
             </p>
@@ -85,8 +84,7 @@ export default function ForgotPasswordForm() {
 
             <button
               type="submit"
-              className="btn-primary"
-              style={{ marginTop: "1rem" }}
+              className="btn-primary mt-4"
               disabled={pending}
               aria-disabled={pending}
             >

--- a/app/forgot-password/_components/ForgotPasswordForm.tsx
+++ b/app/forgot-password/_components/ForgotPasswordForm.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import Link from "next/link";
+import { useActionState } from "react";
+import { forgotPassword, INITIAL_FORGOT_PASSWORD_STATE } from "../actions";
+
+export default function ForgotPasswordForm() {
+  const [state, formAction, pending] = useActionState(
+    forgotPassword,
+    INITIAL_FORGOT_PASSWORD_STATE,
+  );
+
+  // Success screen
+  if (state.submitted) {
+    return (
+      <div className="auth-page">
+        <div className="centered-col">
+          <div className="auth-card card card--featured" style={{ textAlign: "center" }}>
+            <div
+              style={{ fontSize: "2rem", marginBottom: "1rem" }}
+              role="img"
+              aria-label="Email sent"
+            >
+              📬
+            </div>
+            <h1 className="auth-heading" style={{ marginBottom: "0.5rem" }}>
+              Check Your Email
+            </h1>
+            <p className="auth-subheading" style={{ marginBottom: "2.5rem" }}>
+              If an account with that email exists, we&apos;ve sent a password
+              reset link. It expires in 1 hour.
+            </p>
+            <Link href="/login" className="btn-primary">
+              Back to Sign In
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Default form screen
+  return (
+    <div className="auth-page">
+      <div className="centered-col">
+        <div className="auth-card card card--featured">
+          <div className="auth-card-header">
+            <span className="auth-logo">MY Chess Tour</span>
+            <h1 className="auth-heading">Reset Password</h1>
+            <p className="auth-subheading">
+              Enter your email to receive a reset link
+            </p>
+            <hr className="divider-gold" />
+          </div>
+
+          {state.error && (
+            <div className="error-banner" role="alert">
+              <span className="text-sm shrink-0 mt-px" aria-hidden="true">
+                ⚠
+              </span>
+              <p className="error-text">{state.error}</p>
+            </div>
+          )}
+
+          <form action={formAction}>
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="email">
+                  Email Address
+                </label>
+              </div>
+              <input
+                id="email"
+                name="email"
+                className="input"
+                type="email"
+                placeholder="you@example.com"
+                autoComplete="email"
+                required
+              />
+              <p className="input-hint">
+                A secure reset link will be sent — valid for 1 hour
+              </p>
+            </div>
+
+            <button
+              type="submit"
+              className="btn-primary"
+              style={{ marginTop: "1rem" }}
+              disabled={pending}
+              aria-disabled={pending}
+            >
+              {pending ? "Sending\u2026" : "Send Reset Link"}
+            </button>
+          </form>
+
+          <p className="auth-footer mt-lg">
+            Remembered it? <Link href="/login">Back to sign in</Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/forgot-password/_components/__tests__/ForgotPasswordForm.test.tsx
+++ b/app/forgot-password/_components/__tests__/ForgotPasswordForm.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("../actions", () => ({
+  forgotPassword: vi.fn(),
+}));
+
+let mockState = {
+  error: null as string | null,
+  submitted: false,
+};
+const mockFormAction = vi.fn();
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useActionState: (_action: unknown, _initial: unknown) => [mockState, mockFormAction, false],
+  };
+});
+
+import ForgotPasswordForm from "../ForgotPasswordForm";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CLEAN_STATE = { error: null, submitted: false };
+
+afterEach(() => {
+  cleanup();
+  Object.assign(mockState, CLEAN_STATE);
+});
+
+beforeEach(() => {
+  Object.assign(mockState, CLEAN_STATE);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ForgotPasswordForm", () => {
+  // --- Default form rendering ------------------------------------------------
+
+  it("renders the Reset Password heading", () => {
+    render(<ForgotPasswordForm />);
+    expect(screen.getByText("Reset Password")).toBeDefined();
+  });
+
+  it("renders email input", () => {
+    render(<ForgotPasswordForm />);
+    expect(screen.getByLabelText("Email Address")).toBeDefined();
+  });
+
+  it("renders Send Reset Link button", () => {
+    render(<ForgotPasswordForm />);
+    expect(screen.getByRole("button", { name: "Send Reset Link" })).toBeDefined();
+  });
+
+  it("renders Back to sign in link pointing to /login", () => {
+    render(<ForgotPasswordForm />);
+    const link = screen.getByText("Back to sign in") as HTMLAnchorElement;
+    expect(link.href).toContain("/login");
+  });
+
+  it("shows reset link validity hint", () => {
+    render(<ForgotPasswordForm />);
+    expect(screen.getByText(/valid for 1 hour/i)).toBeDefined();
+  });
+
+  // --- Error state ----------------------------------------------------------
+
+  it("shows error banner when state has an error", () => {
+    mockState.error = "Please enter a valid email address.";
+    render(<ForgotPasswordForm />);
+    expect(screen.getByRole("alert")).toBeDefined();
+  });
+
+  it("shows error message text in banner", () => {
+    mockState.error = "Please enter a valid email address.";
+    render(<ForgotPasswordForm />);
+    expect(screen.getByText(/Please enter a valid email address/)).toBeDefined();
+  });
+
+  it("does not show error banner in clean state", () => {
+    render(<ForgotPasswordForm />);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // --- Success state --------------------------------------------------------
+
+  it("shows Check Your Email heading after submission", () => {
+    mockState.submitted = true;
+    render(<ForgotPasswordForm />);
+    expect(screen.getByText("Check Your Email")).toBeDefined();
+  });
+
+  it("shows Back to Sign In link on success screen", () => {
+    mockState.submitted = true;
+    render(<ForgotPasswordForm />);
+    expect(screen.getByText("Back to Sign In")).toBeDefined();
+  });
+
+  it("does not show the form after submission", () => {
+    mockState.submitted = true;
+    render(<ForgotPasswordForm />);
+    expect(screen.queryByRole("button", { name: "Send Reset Link" })).toBeNull();
+    expect(screen.queryByLabelText("Email Address")).toBeNull();
+  });
+});

--- a/app/forgot-password/_components/__tests__/ForgotPasswordForm.test.tsx
+++ b/app/forgot-password/_components/__tests__/ForgotPasswordForm.test.tsx
@@ -22,12 +22,13 @@ let mockState = {
   submitted: false,
 };
 const mockFormAction = vi.fn();
+let mockPending = false;
 
 vi.mock("react", async () => {
   const actual = await vi.importActual<typeof import("react")>("react");
   return {
     ...actual,
-    useActionState: (_action: unknown, _initial: unknown) => [mockState, mockFormAction, false],
+    useActionState: (_action: unknown, _initial: unknown) => [mockState, mockFormAction, mockPending],
   };
 });
 
@@ -42,10 +43,12 @@ const CLEAN_STATE = { error: null, submitted: false };
 afterEach(() => {
   cleanup();
   Object.assign(mockState, CLEAN_STATE);
+  mockPending = false;
 });
 
 beforeEach(() => {
   Object.assign(mockState, CLEAN_STATE);
+  mockPending = false;
 });
 
 // ---------------------------------------------------------------------------
@@ -119,5 +122,15 @@ describe("ForgotPasswordForm", () => {
     render(<ForgotPasswordForm />);
     expect(screen.queryByRole("button", { name: "Send Reset Link" })).toBeNull();
     expect(screen.queryByLabelText("Email Address")).toBeNull();
+  });
+
+  // --- Pending state --------------------------------------------------------
+
+  it("shows Sending text and disables button when pending", () => {
+    mockPending = true;
+    render(<ForgotPasswordForm />);
+    const button = screen.getByRole("button", { name: /Sending/i });
+    expect(button).toBeDefined();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/app/forgot-password/_components/__tests__/ForgotPasswordForm.test.tsx
+++ b/app/forgot-password/_components/__tests__/ForgotPasswordForm.test.tsx
@@ -13,6 +13,16 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+vi.mock("@/lib/supabase/admin", () => ({
+  supabaseAdmin: {
+    auth: { admin: { generateLink: vi.fn() } },
+  },
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendPasswordResetEmail: vi.fn(),
+}));
+
 vi.mock("../actions", () => ({
   forgotPassword: vi.fn(),
 }));

--- a/app/forgot-password/actions.ts
+++ b/app/forgot-password/actions.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { validateForgotPasswordForm } from "@/lib/auth-validation";
+import { createClient } from "@/lib/supabase/server";
+
+export type ForgotPasswordState = {
+  error: string | null;
+  submitted: boolean;
+};
+
+export const INITIAL_FORGOT_PASSWORD_STATE: ForgotPasswordState = {
+  error: null,
+  submitted: false,
+};
+
+export async function forgotPassword(
+  _prevState: ForgotPasswordState,
+  formData: FormData,
+): Promise<ForgotPasswordState> {
+  const email = formData.get("email")?.toString().trim() ?? "";
+
+  const { errors, isValid } = validateForgotPasswordForm(email);
+
+  if (!isValid) {
+    const firstError = errors.email ?? "Please enter a valid email address.";
+    return { error: firstError, submitted: false };
+  }
+
+  const supabase = await createClient();
+
+  // Always succeed to prevent email enumeration attacks
+  await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?type=recovery`,
+  });
+
+  return { error: null, submitted: true };
+}

--- a/app/forgot-password/actions.ts
+++ b/app/forgot-password/actions.ts
@@ -1,7 +1,8 @@
 "use server";
 
 import { validateForgotPasswordForm } from "@/lib/auth-validation";
-import { createClient } from "@/lib/supabase/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { sendPasswordResetEmail } from "@/lib/email";
 import { ForgotPasswordState } from "./types";
 
 export async function forgotPassword(
@@ -17,12 +18,17 @@ export async function forgotPassword(
     return { error: firstError, submitted: false };
   }
 
-  const supabase = await createClient();
+  const redirectTo = `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?type=recovery`;
+  const { data, error } = await supabaseAdmin.auth.admin.generateLink({
+    type: "recovery",
+    email,
+    options: { redirectTo },
+  });
 
   // Always succeed to prevent email enumeration attacks
-  await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?type=recovery`,
-  });
+  if (!error && data.properties.action_link) {
+    await sendPasswordResetEmail(email, data.properties.action_link);
+  }
 
   return { error: null, submitted: true };
 }

--- a/app/forgot-password/actions.ts
+++ b/app/forgot-password/actions.ts
@@ -2,16 +2,7 @@
 
 import { validateForgotPasswordForm } from "@/lib/auth-validation";
 import { createClient } from "@/lib/supabase/server";
-
-export type ForgotPasswordState = {
-  error: string | null;
-  submitted: boolean;
-};
-
-export const INITIAL_FORGOT_PASSWORD_STATE: ForgotPasswordState = {
-  error: null,
-  submitted: false,
-};
+import { ForgotPasswordState } from "./types";
 
 export async function forgotPassword(
   _prevState: ForgotPasswordState,

--- a/app/forgot-password/actions.ts
+++ b/app/forgot-password/actions.ts
@@ -18,7 +18,7 @@ export async function forgotPassword(
     return { error: firstError, submitted: false };
   }
 
-  const redirectTo = `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?type=recovery`;
+  const redirectTo = `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?next=/update-password`;
   const { data, error } = await supabaseAdmin.auth.admin.generateLink({
     type: "recovery",
     email,

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,16 @@
+import NavBar from "@/app/_components/NavBar";
+import ForgotPasswordForm from "./_components/ForgotPasswordForm";
+
+export const metadata = {
+  title: "Reset Password — MY Chess Tour",
+  description: "Reset your MY Chess Tour account password.",
+};
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="min-h-screen bg-(--color-bg-base)">
+      <NavBar />
+      <ForgotPasswordForm />
+    </div>
+  );
+}

--- a/app/forgot-password/types.ts
+++ b/app/forgot-password/types.ts
@@ -1,0 +1,9 @@
+export type ForgotPasswordState = {
+  error: string | null;
+  submitted: boolean;
+};
+
+export const INITIAL_FORGOT_PASSWORD_STATE: ForgotPasswordState = {
+  error: null,
+  submitted: false,
+};

--- a/app/globals.css
+++ b/app/globals.css
@@ -1113,6 +1113,47 @@
     box-shadow: 0 4px 20px rgba(201, 168, 76, 0.25);
   }
 
+  /* ── Confirm / locked screens ── */
+  .confirm-icon {
+    width: 3.75rem;
+    height: 3.75rem;
+    border-radius: 50%;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-raised);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 1.5rem;
+    font-size: 1.5rem;
+  }
+  .confirm-icon--danger {
+    border-color: #5a2a14;
+    background: rgba(90, 30, 10, 0.15);
+  }
+  .confirm-title {
+    font-family: var(--font-cinzel);
+    font-size: 1.375rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--color-text-primary);
+    margin-bottom: 0.5rem;
+    text-align: center;
+  }
+  .confirm-body {
+    font-family: var(--font-lato);
+    font-weight: 300;
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+    margin-bottom: 2.5rem;
+    text-align: center;
+  }
+  .confirm-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
   /* ── Skeleton shimmer ── */
   .skeleton-shimmer {
     background: linear-gradient(

--- a/app/globals.css
+++ b/app/globals.css
@@ -1017,6 +1017,92 @@
     border: 1px solid rgba(43, 122, 75, 0.3);
   }
 
+  /* ── Navbar avatar & dropdown ── */
+  .nav-avatar {
+    width: 2.125rem;
+    height: 2.125rem;
+    border-radius: 50%;
+    background: var(--color-gold-ghost);
+    border: 1px solid var(--color-gold-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-cinzel);
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-gold-bright);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition:
+      border-color 0.2s ease,
+      box-shadow 0.2s ease;
+    background: none;
+  }
+  .nav-avatar:hover,
+  .nav-avatar--open {
+    border-color: var(--color-gold-bright);
+    box-shadow: 0 4px 20px rgba(201, 168, 76, 0.25);
+  }
+
+  .nav-dropdown {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    width: 13.75rem;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-gold);
+    border-radius: 4px;
+    box-shadow: 0 6px 28px rgba(201, 168, 76, 0.4);
+    z-index: 99;
+    overflow: hidden;
+  }
+
+  .nav-dropdown-user {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .nav-dropdown-name {
+    font-family: var(--font-cinzel);
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    letter-spacing: 0.04em;
+  }
+  .nav-dropdown-email {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+    margin-top: 0.125rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .nav-dropdown-item {
+    padding: 0.625rem 1rem;
+    font-size: 0.8125rem;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    transition: background 0.15s ease;
+  }
+  .nav-dropdown-item:hover {
+    background: rgba(201, 168, 76, 0.04);
+  }
+  .nav-dropdown-item--danger {
+    color: #e0916e;
+  }
+  .nav-dropdown-divider {
+    height: 1px;
+    background: var(--color-border);
+  }
+
   /* ── Navbar auth buttons ── */
   .nav-btn-login {
     font-family: var(--font-cinzel);

--- a/app/login/__tests__/actions.test.ts
+++ b/app/login/__tests__/actions.test.ts
@@ -36,7 +36,8 @@ vi.mock("next/navigation", () => ({
   redirect: mocks.redirect,
 }));
 
-import { login, INITIAL_LOGIN_STATE } from "../actions";
+import { login } from "../actions";
+import { INITIAL_LOGIN_STATE } from "../types";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/app/login/__tests__/actions.test.ts
+++ b/app/login/__tests__/actions.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — use vi.hoisted so variables are available when factories run
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  exists: vi.fn(),
+  ttl: vi.fn(),
+  incr: vi.fn(),
+  expire: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+  signInWithPassword: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock("@/lib/redis", () => ({
+  redis: {
+    exists: mocks.exists,
+    ttl: mocks.ttl,
+    incr: mocks.incr,
+    expire: mocks.expire,
+    set: mocks.set,
+    del: mocks.del,
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { signInWithPassword: mocks.signInWithPassword } }),
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+}));
+
+import { login, INITIAL_LOGIN_STATE } from "../actions";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFormData(data: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(data)) fd.append(k, v);
+  return fd;
+}
+
+const VALID = {
+  email: "user@example.com",
+  password: "anypassword",
+  keepSignedIn: "on",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: account not locked
+  mocks.exists.mockResolvedValue(0);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("login action", () => {
+  // --- INITIAL_LOGIN_STATE export -------------------------------------------
+
+  it("exports INITIAL_LOGIN_STATE with correct shape", () => {
+    expect(INITIAL_LOGIN_STATE).toEqual({
+      error: null,
+      attemptsRemaining: null,
+      locked: false,
+      lockedSeconds: null,
+    });
+  });
+
+  // --- Validation errors (no Redis / Supabase calls) -----------------------
+
+  it("returns error when email is empty", async () => {
+    const fd = makeFormData({ email: "", password: "pw", keepSignedIn: "on" });
+    const result = await login(INITIAL_LOGIN_STATE, fd);
+    expect(result.error).toMatch(/email/i);
+    expect(mocks.exists).not.toHaveBeenCalled();
+  });
+
+  it("returns error when password is empty", async () => {
+    const fd = makeFormData({ email: "user@example.com", password: "" });
+    const result = await login(INITIAL_LOGIN_STATE, fd);
+    expect(result.error).toMatch(/password/i);
+    expect(mocks.exists).not.toHaveBeenCalled();
+  });
+
+  it("returns error when email is invalid", async () => {
+    const fd = makeFormData({ email: "not-an-email", password: "pw" });
+    const result = await login(INITIAL_LOGIN_STATE, fd);
+    expect(result.error).toBeDefined();
+    expect(result.locked).toBe(false);
+  });
+
+  // --- Account already locked -----------------------------------------------
+
+  it("returns locked state when account is already locked", async () => {
+    mocks.exists.mockResolvedValue(1);
+    mocks.ttl.mockResolvedValue(840);
+
+    const fd = makeFormData(VALID);
+    const result = await login(INITIAL_LOGIN_STATE, fd);
+
+    expect(result.locked).toBe(true);
+    expect(result.lockedSeconds).toBe(840);
+    expect(result.attemptsRemaining).toBe(0);
+    expect(mocks.signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  // --- Auth failures (rate limiting) ----------------------------------------
+
+  it("returns remaining attempts after first failed attempt", async () => {
+    mocks.signInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Invalid login credentials" },
+    });
+    mocks.incr.mockResolvedValue(1);
+
+    const fd = makeFormData(VALID);
+    const result = await login(INITIAL_LOGIN_STATE, fd);
+
+    expect(result.error).toMatch(/incorrect email or password/i);
+    expect(result.attemptsRemaining).toBe(4);
+    expect(result.locked).toBe(false);
+  });
+
+  it("returns correct remaining attempts after multiple failures", async () => {
+    mocks.signInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Invalid login credentials" },
+    });
+    mocks.incr.mockResolvedValue(3);
+
+    const fd = makeFormData(VALID);
+    const result = await login(INITIAL_LOGIN_STATE, fd);
+
+    expect(result.attemptsRemaining).toBe(2);
+    expect(result.locked).toBe(false);
+  });
+
+  it("locks account after max attempts (5th failure)", async () => {
+    mocks.signInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Invalid login credentials" },
+    });
+    mocks.incr.mockResolvedValue(5);
+
+    const fd = makeFormData(VALID);
+    const result = await login(INITIAL_LOGIN_STATE, fd);
+
+    expect(result.locked).toBe(true);
+    expect(result.lockedSeconds).toBe(900);
+    expect(result.attemptsRemaining).toBe(0);
+    expect(mocks.set).toHaveBeenCalled();
+    expect(mocks.del).toHaveBeenCalled();
+  });
+
+  it("sets expire on attempts key after a failed attempt", async () => {
+    mocks.signInWithPassword.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Invalid login credentials" },
+    });
+    mocks.incr.mockResolvedValue(1);
+
+    const fd = makeFormData(VALID);
+    await login(INITIAL_LOGIN_STATE, fd);
+
+    expect(mocks.expire).toHaveBeenCalled();
+  });
+
+  // --- Successful login ------------------------------------------------------
+
+  it("clears attempt keys and redirects on successful login", async () => {
+    mocks.signInWithPassword.mockResolvedValue({
+      data: { user: { id: "abc-123" }, session: {} },
+      error: null,
+    });
+
+    const fd = makeFormData(VALID);
+    await login(INITIAL_LOGIN_STATE, fd);
+
+    expect(mocks.del).toHaveBeenCalledTimes(2);
+    expect(mocks.redirect).toHaveBeenCalledWith("/tournaments");
+  });
+
+  it("calls supabase signInWithPassword with correct credentials", async () => {
+    mocks.signInWithPassword.mockResolvedValue({
+      data: { user: { id: "abc-123" }, session: {} },
+      error: null,
+    });
+
+    const fd = makeFormData(VALID);
+    await login(INITIAL_LOGIN_STATE, fd);
+
+    expect(mocks.signInWithPassword).toHaveBeenCalledWith({
+      email: VALID.email,
+      password: VALID.password,
+    });
+  });
+
+  it("trims whitespace from email before using it", async () => {
+    mocks.signInWithPassword.mockResolvedValue({
+      data: { user: { id: "abc-123" }, session: {} },
+      error: null,
+    });
+
+    const fd = makeFormData({ email: "  user@example.com  ", password: "anypassword" });
+    await login(INITIAL_LOGIN_STATE, fd);
+
+    expect(mocks.signInWithPassword).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "user@example.com" }),
+    );
+  });
+});

--- a/app/login/__tests__/page.test.ts
+++ b/app/login/__tests__/page.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/_components/NavBar", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../_components/LoginForm", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+import LoginPage from "../page";
+
+describe("LoginPage", () => {
+  it("returns a non-null React element", () => {
+    const result = LoginPage();
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+
+  it("has a min-h-screen container", () => {
+    const result = LoginPage() as Record<string, unknown>;
+    const props = result.props as Record<string, unknown>;
+    expect(props.className).toContain("min-h-screen");
+  });
+
+  it("exports metadata with a title containing MY Chess Tour", async () => {
+    const mod = await import("../page");
+    expect(mod.metadata).toBeDefined();
+    expect((mod.metadata as { title: string }).title).toContain("MY Chess Tour");
+  });
+});

--- a/app/login/_components/LoginForm.tsx
+++ b/app/login/_components/LoginForm.tsx
@@ -2,23 +2,30 @@
 
 import Link from "next/link";
 import { useActionState, useState } from "react";
-import { login, INITIAL_LOGIN_STATE } from "../actions";
+import { login } from "../actions";
+import { INITIAL_LOGIN_STATE } from "../types";
 
 export default function LoginForm() {
-  const [state, formAction, pending] = useActionState(login, INITIAL_LOGIN_STATE);
+  const [state, formAction, pending] = useActionState(
+    login,
+    INITIAL_LOGIN_STATE,
+  );
   const [showPassword, setShowPassword] = useState(false);
 
   // Screen 2C — Account Locked
   if (state.locked) {
-    const minutes = state.lockedSeconds ? Math.ceil(state.lockedSeconds / 60) : 15;
+    const minutes = state.lockedSeconds
+      ? Math.ceil(state.lockedSeconds / 60)
+      : 15;
     return (
       <div className="auth-page">
         <div className="centered-col">
-          <div
-            className="auth-card card"
-            style={{ textAlign: "center", maxWidth: "25rem", margin: "0 auto" }}
-          >
-            <div className="confirm-icon confirm-icon--danger" role="img" aria-label="Account locked">
+          <div className="auth-card card text-center max-w-100 mx-0 my-auto">
+            <div
+              className="confirm-icon confirm-icon--danger"
+              role="img"
+              aria-label="Account locked"
+            >
               🔒
             </div>
             <h1 className="confirm-title">Account Locked</h1>
@@ -27,13 +34,7 @@ export default function LoginForm() {
               temporarily locked.
               <br />
               <br />
-              <strong
-                style={{
-                  fontFamily: "var(--font-cinzel)",
-                  color: "var(--color-gold-muted)",
-                  letterSpacing: "0.05em",
-                }}
-              >
+              <strong className="font-(--font-cinzel) text-(--color-gold-muted) tracking-wider">
                 Unlocks in ~{minutes} minute{minutes !== 1 ? "s" : ""}
               </strong>
             </p>
@@ -43,8 +44,7 @@ export default function LoginForm() {
               </Link>
               <a
                 href="mailto:mychesstour@gmail.com"
-                className="btn-secondary"
-                style={{ marginTop: "0.5rem", display: "block", textAlign: "center" }}
+                className="btn-secondary mt-2 block text-center"
               >
                 Contact Support
               </a>
@@ -74,16 +74,17 @@ export default function LoginForm() {
               </span>
               <p className="error-text">
                 {state.error}
-                {state.attemptsRemaining !== null && state.attemptsRemaining > 0 && (
-                  <>
-                    {" "}
-                    <strong>
-                      {state.attemptsRemaining} attempt
-                      {state.attemptsRemaining !== 1 ? "s" : ""} remaining
-                    </strong>{" "}
-                    before your account is temporarily locked.
-                  </>
-                )}
+                {state.attemptsRemaining !== null &&
+                  state.attemptsRemaining > 0 && (
+                    <>
+                      {" "}
+                      <strong>
+                        {state.attemptsRemaining} attempt
+                        {state.attemptsRemaining !== 1 ? "s" : ""} remaining
+                      </strong>{" "}
+                      before your account is temporarily locked.
+                    </>
+                  )}
               </p>
             </div>
           )}
@@ -136,14 +137,11 @@ export default function LoginForm() {
                   />
                 </button>
               </div>
-              {state.error && (
-                <p className="input-hint error">Password is incorrect</p>
-              )}
             </div>
 
             {/* Remember me + Forgot password */}
             <div className="remember-forgot-row">
-              <div className="check-row" style={{ marginBottom: 0 }}>
+              <div className="check-row mb-0">
                 <input
                   id="keepSignedIn"
                   name="keepSignedIn"
@@ -153,8 +151,7 @@ export default function LoginForm() {
                 />
                 <label
                   htmlFor="keepSignedIn"
-                  className="check-label"
-                  style={{ fontSize: "0.75rem" }}
+                  className="check-label font-[0.75rem]"
                 >
                   Keep me signed in
                 </label>
@@ -175,8 +172,7 @@ export default function LoginForm() {
           </form>
 
           <p className="auth-footer mt-lg">
-            Don&apos;t have an account?{" "}
-            <Link href="/sign-up">Create one</Link>
+            Don&apos;t have an account? <Link href="/sign-up">Create one</Link>
           </p>
         </div>
       </div>

--- a/app/login/_components/LoginForm.tsx
+++ b/app/login/_components/LoginForm.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import Link from "next/link";
+import { useActionState, useState } from "react";
+import { login, INITIAL_LOGIN_STATE } from "../actions";
+
+export default function LoginForm() {
+  const [state, formAction, pending] = useActionState(login, INITIAL_LOGIN_STATE);
+  const [showPassword, setShowPassword] = useState(false);
+
+  // Screen 2C — Account Locked
+  if (state.locked) {
+    const minutes = state.lockedSeconds ? Math.ceil(state.lockedSeconds / 60) : 15;
+    return (
+      <div className="auth-page">
+        <div className="centered-col">
+          <div
+            className="auth-card card"
+            style={{ textAlign: "center", maxWidth: "25rem", margin: "0 auto" }}
+          >
+            <div className="confirm-icon confirm-icon--danger" role="img" aria-label="Account locked">
+              🔒
+            </div>
+            <h1 className="confirm-title">Account Locked</h1>
+            <p className="confirm-body">
+              Too many failed sign-in attempts. Your account has been
+              temporarily locked.
+              <br />
+              <br />
+              <strong
+                style={{
+                  fontFamily: "var(--font-cinzel)",
+                  color: "var(--color-gold-muted)",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                Unlocks in ~{minutes} minute{minutes !== 1 ? "s" : ""}
+              </strong>
+            </p>
+            <div className="confirm-actions">
+              <Link href="/forgot-password" className="btn-primary">
+                Reset Password
+              </Link>
+              <a
+                href="mailto:mychesstour@gmail.com"
+                className="btn-secondary"
+                style={{ marginTop: "0.5rem", display: "block", textAlign: "center" }}
+              >
+                Contact Support
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Screen 2A / 2B — Login form (clean or with errors)
+  return (
+    <div className="auth-page">
+      <div className="centered-col">
+        <div className="auth-card card card--featured">
+          <div className="auth-card-header">
+            <span className="auth-logo">MY Chess Tour</span>
+            <h1 className="auth-heading">Welcome Back</h1>
+            <p className="auth-subheading">Sign in to your account</p>
+            <hr className="divider-gold" />
+          </div>
+
+          {state.error && (
+            <div className="error-banner" role="alert">
+              <span className="text-sm shrink-0 mt-px" aria-hidden="true">
+                ⚠
+              </span>
+              <p className="error-text">
+                {state.error}
+                {state.attemptsRemaining !== null && state.attemptsRemaining > 0 && (
+                  <>
+                    {" "}
+                    <strong>
+                      {state.attemptsRemaining} attempt
+                      {state.attemptsRemaining !== 1 ? "s" : ""} remaining
+                    </strong>{" "}
+                    before your account is temporarily locked.
+                  </>
+                )}
+              </p>
+            </div>
+          )}
+
+          <form action={formAction}>
+            {/* Email */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="email">
+                  Email Address
+                </label>
+              </div>
+              <input
+                id="email"
+                name="email"
+                className="input"
+                type="email"
+                placeholder="you@example.com"
+                autoComplete="email"
+                required
+              />
+            </div>
+
+            {/* Password */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="password">
+                  Password
+                </label>
+              </div>
+              <div className="input-wrap">
+                <input
+                  id="password"
+                  name="password"
+                  className={`input input--icon${state.error ? " input-error" : ""}`}
+                  type={showPassword ? "text" : "password"}
+                  placeholder="Your password"
+                  autoComplete="current-password"
+                  required
+                />
+                <button
+                  type="button"
+                  className="eye-btn"
+                  onClick={() => setShowPassword((v) => !v)}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                >
+                  <span
+                    className={showPassword ? "eye-off-icon" : "eye-icon"}
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+              {state.error && (
+                <p className="input-hint error">Password is incorrect</p>
+              )}
+            </div>
+
+            {/* Remember me + Forgot password */}
+            <div className="remember-forgot-row">
+              <div className="check-row" style={{ marginBottom: 0 }}>
+                <input
+                  id="keepSignedIn"
+                  name="keepSignedIn"
+                  type="checkbox"
+                  className="checkbox"
+                  defaultChecked
+                />
+                <label
+                  htmlFor="keepSignedIn"
+                  className="check-label"
+                  style={{ fontSize: "0.75rem" }}
+                >
+                  Keep me signed in
+                </label>
+              </div>
+              <Link href="/forgot-password" className="forgot-link">
+                Forgot password?
+              </Link>
+            </div>
+
+            <button
+              type="submit"
+              className="btn-primary"
+              disabled={pending}
+              aria-disabled={pending}
+            >
+              {pending ? "Signing In\u2026" : "Sign In"}
+            </button>
+          </form>
+
+          <p className="auth-footer mt-lg">
+            Don&apos;t have an account?{" "}
+            <Link href="/sign-up">Create one</Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/login/_components/__tests__/LoginForm.test.tsx
+++ b/app/login/_components/__tests__/LoginForm.test.tsx
@@ -218,10 +218,11 @@ describe("LoginForm", () => {
 
   // --- Error hint on password input -----------------------------------------
 
-  it("shows password incorrect hint when error is set", () => {
+  it("adds input-error class to password input when error is set", () => {
     mockState.error = "Incorrect email or password.";
     mockState.attemptsRemaining = 3;
     render(<LoginForm />);
-    expect(screen.getByText("Password is incorrect")).toBeDefined();
+    const input = screen.getByLabelText("Password") as HTMLInputElement;
+    expect(input.className).toContain("input-error");
   });
 });

--- a/app/login/_components/__tests__/LoginForm.test.tsx
+++ b/app/login/_components/__tests__/LoginForm.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, act } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted so they run before imports
+// ---------------------------------------------------------------------------
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("../actions", () => ({
+  login: vi.fn(),
+}));
+
+// Control state returned by useActionState
+let mockState = {
+  error: null as string | null,
+  attemptsRemaining: null as number | null,
+  locked: false,
+  lockedSeconds: null as number | null,
+};
+const mockFormAction = vi.fn();
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useActionState: (_action: unknown, _initial: unknown) => [mockState, mockFormAction, false],
+  };
+});
+
+import LoginForm from "../LoginForm";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CLEAN_STATE = {
+  error: null,
+  attemptsRemaining: null,
+  locked: false,
+  lockedSeconds: null,
+};
+
+afterEach(() => {
+  cleanup();
+  Object.assign(mockState, CLEAN_STATE);
+});
+
+beforeEach(() => {
+  Object.assign(mockState, CLEAN_STATE);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LoginForm", () => {
+  // --- Rendering (clean state) -----------------------------------------------
+
+  it("renders email input", () => {
+    render(<LoginForm />);
+    expect(screen.getByLabelText("Email Address")).toBeDefined();
+  });
+
+  it("renders password input", () => {
+    render(<LoginForm />);
+    expect(screen.getByLabelText("Password")).toBeDefined();
+  });
+
+  it("renders Sign In submit button", () => {
+    render(<LoginForm />);
+    expect(screen.getByRole("button", { name: "Sign In" })).toBeDefined();
+  });
+
+  it("renders Keep me signed in checkbox checked by default", () => {
+    render(<LoginForm />);
+    const checkbox = screen.getByLabelText("Keep me signed in") as HTMLInputElement;
+    expect(checkbox).toBeDefined();
+    expect(checkbox.defaultChecked).toBe(true);
+  });
+
+  it("renders Forgot password link pointing to /forgot-password", () => {
+    render(<LoginForm />);
+    const link = screen.getByText("Forgot password?") as HTMLAnchorElement;
+    expect(link.href).toContain("/forgot-password");
+  });
+
+  it("renders create account link pointing to /sign-up", () => {
+    render(<LoginForm />);
+    const link = screen.getByText("Create one") as HTMLAnchorElement;
+    expect(link.href).toContain("/sign-up");
+  });
+
+  // --- Error state (2B) -------------------------------------------------------
+
+  it("shows error banner when state has error", () => {
+    mockState.error = "Incorrect email or password.";
+    mockState.attemptsRemaining = 2;
+    render(<LoginForm />);
+    expect(screen.getByRole("alert")).toBeDefined();
+  });
+
+  it("shows error message text in error banner", () => {
+    mockState.error = "Incorrect email or password.";
+    mockState.attemptsRemaining = 2;
+    render(<LoginForm />);
+    expect(screen.getByText(/Incorrect email or password/)).toBeDefined();
+  });
+
+  it("shows attempts remaining when attemptsRemaining is set", () => {
+    mockState.error = "Incorrect email or password.";
+    mockState.attemptsRemaining = 2;
+    render(<LoginForm />);
+    expect(screen.getByText(/2 attempts remaining/)).toBeDefined();
+  });
+
+  it("shows singular attempt when attemptsRemaining is 1", () => {
+    mockState.error = "Incorrect email or password.";
+    mockState.attemptsRemaining = 1;
+    render(<LoginForm />);
+    expect(screen.getByText(/1 attempt remaining/)).toBeDefined();
+  });
+
+  it("does not show error banner in clean state", () => {
+    render(<LoginForm />);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // --- Locked state (2C) -------------------------------------------------------
+
+  it("shows Account Locked heading when locked is true", () => {
+    mockState.locked = true;
+    mockState.lockedSeconds = 900;
+    render(<LoginForm />);
+    expect(screen.getByText("Account Locked")).toBeDefined();
+  });
+
+  it("shows Reset Password button on locked screen", () => {
+    mockState.locked = true;
+    mockState.lockedSeconds = 900;
+    render(<LoginForm />);
+    expect(screen.getByText("Reset Password")).toBeDefined();
+  });
+
+  it("does not show the login form when locked", () => {
+    mockState.locked = true;
+    mockState.lockedSeconds = 900;
+    render(<LoginForm />);
+    expect(screen.queryByLabelText("Email Address")).toBeNull();
+    expect(screen.queryByLabelText("Password")).toBeNull();
+  });
+
+  // --- Password toggle -------------------------------------------------------
+
+  it("password input starts as type password", () => {
+    render(<LoginForm />);
+    const input = screen.getByLabelText("Password") as HTMLInputElement;
+    expect(input.type).toBe("password");
+  });
+
+  it("toggles password to text type when eye button clicked", async () => {
+    render(<LoginForm />);
+    const input = screen.getByLabelText("Password") as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Show password"));
+    });
+    expect(input.type).toBe("text");
+  });
+
+  it("toggles password back to password type on second click", async () => {
+    render(<LoginForm />);
+    const input = screen.getByLabelText("Password") as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Show password"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Hide password"));
+    });
+    expect(input.type).toBe("password");
+  });
+});

--- a/app/login/_components/__tests__/LoginForm.test.tsx
+++ b/app/login/_components/__tests__/LoginForm.test.tsx
@@ -25,12 +25,13 @@ let mockState = {
   lockedSeconds: null as number | null,
 };
 const mockFormAction = vi.fn();
+let mockPending = false;
 
 vi.mock("react", async () => {
   const actual = await vi.importActual<typeof import("react")>("react");
   return {
     ...actual,
-    useActionState: (_action: unknown, _initial: unknown) => [mockState, mockFormAction, false],
+    useActionState: (_action: unknown, _initial: unknown) => [mockState, mockFormAction, mockPending],
   };
 });
 
@@ -50,10 +51,12 @@ const CLEAN_STATE = {
 afterEach(() => {
   cleanup();
   Object.assign(mockState, CLEAN_STATE);
+  mockPending = false;
 });
 
 beforeEach(() => {
   Object.assign(mockState, CLEAN_STATE);
+  mockPending = false;
 });
 
 // ---------------------------------------------------------------------------
@@ -185,5 +188,40 @@ describe("LoginForm", () => {
       fireEvent.click(screen.getByLabelText("Hide password"));
     });
     expect(input.type).toBe("password");
+  });
+
+  // --- Locked state with null lockedSeconds (2C fallback) -------------------
+
+  it("shows ~15 minutes when lockedSeconds is null", () => {
+    mockState.locked = true;
+    mockState.lockedSeconds = null;
+    render(<LoginForm />);
+    expect(screen.getByText(/~15 minute/)).toBeDefined();
+  });
+
+  it("shows Contact Support link on locked screen", () => {
+    mockState.locked = true;
+    mockState.lockedSeconds = 900;
+    render(<LoginForm />);
+    expect(screen.getByText("Contact Support")).toBeDefined();
+  });
+
+  // --- Pending state ---------------------------------------------------------
+
+  it("shows Signing In text and disables button when pending", () => {
+    mockPending = true;
+    render(<LoginForm />);
+    const button = screen.getByRole("button", { name: /Signing In/i });
+    expect(button).toBeDefined();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // --- Error hint on password input -----------------------------------------
+
+  it("shows password incorrect hint when error is set", () => {
+    mockState.error = "Incorrect email or password.";
+    mockState.attemptsRemaining = 3;
+    render(<LoginForm />);
+    expect(screen.getByText("Password is incorrect")).toBeDefined();
   });
 });

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -1,0 +1,82 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { validateLoginForm } from "@/lib/auth-validation";
+import { createClient } from "@/lib/supabase/server";
+import { redis } from "@/lib/redis";
+
+const MAX_ATTEMPTS = 5;
+const LOCK_DURATION_SECONDS = 15 * 60; // 15 minutes
+
+export type LoginState = {
+  error: string | null;
+  attemptsRemaining: number | null;
+  locked: boolean;
+  lockedSeconds: number | null;
+};
+
+export const INITIAL_LOGIN_STATE: LoginState = {
+  error: null,
+  attemptsRemaining: null,
+  locked: false,
+  lockedSeconds: null,
+};
+
+export async function login(
+  _prevState: LoginState,
+  formData: FormData,
+): Promise<LoginState> {
+  const email = formData.get("email")?.toString().trim() ?? "";
+  const password = formData.get("password")?.toString() ?? "";
+  const keepSignedIn = formData.get("keepSignedIn") === "on";
+
+  const { errors, isValid } = validateLoginForm({ email, password, keepSignedIn });
+
+  if (!isValid) {
+    const firstError = errors.email ?? errors.password ?? "Please fill in all required fields.";
+    return { error: firstError, attemptsRemaining: null, locked: false, lockedSeconds: null };
+  }
+
+  const lockKey = `login:lock:${email.toLowerCase()}`;
+  const attemptsKey = `login:attempts:${email.toLowerCase()}`;
+
+  const isLocked = await redis.exists(lockKey);
+  if (isLocked) {
+    const ttl = await redis.ttl(lockKey);
+    return { error: null, attemptsRemaining: 0, locked: true, lockedSeconds: ttl };
+  }
+
+  const supabase = await createClient();
+  const { error: authError } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (authError) {
+    const attempts = await redis.incr(attemptsKey);
+    await redis.expire(attemptsKey, LOCK_DURATION_SECONDS);
+
+    const remaining = Math.max(0, MAX_ATTEMPTS - attempts);
+
+    if (remaining === 0) {
+      await redis.set(lockKey, 1, { ex: LOCK_DURATION_SECONDS });
+      await redis.del(attemptsKey);
+      return {
+        error: null,
+        attemptsRemaining: 0,
+        locked: true,
+        lockedSeconds: LOCK_DURATION_SECONDS,
+      };
+    }
+
+    return {
+      error: "Incorrect email or password.",
+      attemptsRemaining: remaining,
+      locked: false,
+      lockedSeconds: null,
+    };
+  }
+
+  // Success — clear any failed-attempt tracking
+  await redis.del(attemptsKey);
+  await redis.del(lockKey);
+
+  redirect("/tournaments");
+}

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -4,23 +4,10 @@ import { redirect } from "next/navigation";
 import { validateLoginForm } from "@/lib/auth-validation";
 import { createClient } from "@/lib/supabase/server";
 import { redis } from "@/lib/redis";
+import type { LoginState } from "./types";
 
 const MAX_ATTEMPTS = 5;
 const LOCK_DURATION_SECONDS = 15 * 60; // 15 minutes
-
-export type LoginState = {
-  error: string | null;
-  attemptsRemaining: number | null;
-  locked: boolean;
-  lockedSeconds: number | null;
-};
-
-export const INITIAL_LOGIN_STATE: LoginState = {
-  error: null,
-  attemptsRemaining: null,
-  locked: false,
-  lockedSeconds: null,
-};
 
 export async function login(
   _prevState: LoginState,

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,16 @@
+import NavBar from "@/app/_components/NavBar";
+import LoginForm from "./_components/LoginForm";
+
+export const metadata = {
+  title: "Sign In — MY Chess Tour",
+  description: "Sign in to your MY Chess Tour account.",
+};
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen bg-(--color-bg-base)">
+      <NavBar />
+      <LoginForm />
+    </div>
+  );
+}

--- a/app/login/types.ts
+++ b/app/login/types.ts
@@ -1,0 +1,13 @@
+export type LoginState = {
+  error: string | null;
+  attemptsRemaining: number | null;
+  locked: boolean;
+  lockedSeconds: number | null;
+};
+
+export const INITIAL_LOGIN_STATE: LoginState = {
+  error: null,
+  attemptsRemaining: null,
+  locked: false,
+  lockedSeconds: null,
+};

--- a/app/update-password/__tests__/actions.test.ts
+++ b/app/update-password/__tests__/actions.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted so they run before imports
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  updateUser: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { updateUser: mocks.updateUser } })
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+}));
+
+import { updatePassword } from "../actions";
+import { INITIAL_UPDATE_PASSWORD_STATE } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFormData(data: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(data)) fd.append(k, v);
+  return fd;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.updateUser.mockResolvedValue({ error: null });
+  // redirect in Next.js throws a special error internally; simulate that
+  mocks.redirect.mockImplementation(() => {
+    throw new Error("NEXT_REDIRECT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("INITIAL_UPDATE_PASSWORD_STATE", () => {
+  it("has correct shape", () => {
+    expect(INITIAL_UPDATE_PASSWORD_STATE).toEqual({
+      error: null,
+      fieldErrors: {},
+    });
+  });
+});
+
+describe("updatePassword action", () => {
+  // --- Validation errors ----------------------------------------------------
+
+  it("returns password fieldError when password is empty", async () => {
+    const fd = makeFormData({ password: "", confirmPassword: "" });
+    const result = await updatePassword(INITIAL_UPDATE_PASSWORD_STATE, fd);
+
+    expect(result.fieldErrors.password).toBeDefined();
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns password fieldError when password is weak", async () => {
+    const fd = makeFormData({ password: "weak", confirmPassword: "weak" });
+    const result = await updatePassword(INITIAL_UPDATE_PASSWORD_STATE, fd);
+
+    expect(result.fieldErrors.password).toBeDefined();
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns confirmPassword fieldError when confirmPassword is empty", async () => {
+    const fd = makeFormData({ password: "Strong1!", confirmPassword: "" });
+    const result = await updatePassword(INITIAL_UPDATE_PASSWORD_STATE, fd);
+
+    expect(result.fieldErrors.confirmPassword).toBeDefined();
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it("returns confirmPassword fieldError when passwords do not match", async () => {
+    const fd = makeFormData({ password: "Strong1!", confirmPassword: "Different1!" });
+    const result = await updatePassword(INITIAL_UPDATE_PASSWORD_STATE, fd);
+
+    expect(result.fieldErrors.confirmPassword).toBeDefined();
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  // --- Supabase error -------------------------------------------------------
+
+  it("returns error state when supabase returns an error", async () => {
+    mocks.updateUser.mockResolvedValue({ error: { message: "Auth session missing" } });
+
+    const fd = makeFormData({ password: "Strong1!", confirmPassword: "Strong1!" });
+    const result = await updatePassword(INITIAL_UPDATE_PASSWORD_STATE, fd);
+
+    expect(result.error).toBe("Auth session missing");
+    expect(result.fieldErrors).toEqual({});
+  });
+
+  // --- Success cases --------------------------------------------------------
+
+  it("calls updateUser with the correct password on success", async () => {
+    const fd = makeFormData({ password: "Strong1!", confirmPassword: "Strong1!" });
+
+    await expect(
+      updatePassword(INITIAL_UPDATE_PASSWORD_STATE, fd)
+    ).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.updateUser).toHaveBeenCalledWith({ password: "Strong1!" });
+  });
+
+  it("calls redirect to /login on success", async () => {
+    const fd = makeFormData({ password: "Strong1!", confirmPassword: "Strong1!" });
+
+    await expect(
+      updatePassword(INITIAL_UPDATE_PASSWORD_STATE, fd)
+    ).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mocks.redirect).toHaveBeenCalledWith("/login");
+  });
+});

--- a/app/update-password/__tests__/page.test.ts
+++ b/app/update-password/__tests__/page.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/_components/NavBar", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../_components/UpdatePasswordForm", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+import UpdatePasswordPage from "../page";
+
+describe("UpdatePasswordPage", () => {
+  it("returns a non-null React element", () => {
+    const result = UpdatePasswordPage();
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+
+  it("has a min-h-screen container", () => {
+    const result = UpdatePasswordPage() as Record<string, unknown>;
+    const props = result.props as Record<string, unknown>;
+    expect(props.className).toContain("min-h-screen");
+  });
+
+  it("exports metadata with title containing MY Chess Tour", async () => {
+    const mod = await import("../page");
+    expect(mod.metadata).toBeDefined();
+    expect((mod.metadata as { title: string }).title).toContain("MY Chess Tour");
+  });
+});

--- a/app/update-password/_components/UpdatePasswordForm.tsx
+++ b/app/update-password/_components/UpdatePasswordForm.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useActionState, useState } from "react";
+import { updatePassword } from "../actions";
+import { INITIAL_UPDATE_PASSWORD_STATE } from "../types";
+
+export default function UpdatePasswordForm() {
+  const [state, formAction, pending] = useActionState(
+    updatePassword,
+    INITIAL_UPDATE_PASSWORD_STATE,
+  );
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  return (
+    <div className="auth-page">
+      <div className="centered-col">
+        <div className="auth-card card card--featured">
+          <div className="auth-card-header">
+            <span className="auth-logo">MY Chess Tour</span>
+            <h1 className="auth-heading">New Password</h1>
+            <p className="auth-subheading">Choose a strong password for your account</p>
+            <hr className="divider-gold" />
+          </div>
+
+          {state.error && (
+            <div className="error-banner" role="alert">
+              <span className="text-sm shrink-0 mt-px" aria-hidden="true">⚠</span>
+              <p className="error-text">{state.error}</p>
+            </div>
+          )}
+
+          <form action={formAction}>
+            {/* New password */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="password">
+                  New Password
+                </label>
+              </div>
+              <div className="input-wrap">
+                <input
+                  id="password"
+                  name="password"
+                  className={`input input--icon${state.fieldErrors.password ? " input-error" : ""}`}
+                  type={showPassword ? "text" : "password"}
+                  placeholder="At least 8 characters"
+                  autoComplete="new-password"
+                  required
+                />
+                <button
+                  type="button"
+                  className="eye-btn"
+                  onClick={() => setShowPassword((v) => !v)}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                >
+                  <span
+                    className={showPassword ? "eye-off-icon" : "eye-icon"}
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+              {state.fieldErrors.password && (
+                <p className="input-hint error">{state.fieldErrors.password}</p>
+              )}
+            </div>
+
+            {/* Confirm password */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="confirmPassword">
+                  Confirm Password
+                </label>
+              </div>
+              <div className="input-wrap">
+                <input
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  className={`input input--icon${state.fieldErrors.confirmPassword ? " input-error" : ""}`}
+                  type={showConfirm ? "text" : "password"}
+                  placeholder="Repeat your new password"
+                  autoComplete="new-password"
+                  required
+                />
+                <button
+                  type="button"
+                  className="eye-btn"
+                  onClick={() => setShowConfirm((v) => !v)}
+                  aria-label={showConfirm ? "Hide password" : "Show password"}
+                >
+                  <span
+                    className={showConfirm ? "eye-off-icon" : "eye-icon"}
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+              {state.fieldErrors.confirmPassword && (
+                <p className="input-hint error">{state.fieldErrors.confirmPassword}</p>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              className="btn-primary"
+              disabled={pending}
+              aria-disabled={pending}
+            >
+              {pending ? "Updating\u2026" : "Update Password"}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/update-password/_components/__tests__/UpdatePasswordForm.test.tsx
+++ b/app/update-password/_components/__tests__/UpdatePasswordForm.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted so they run before imports
+// ---------------------------------------------------------------------------
+
+vi.mock("../actions", () => ({
+  updatePassword: vi.fn(),
+}));
+
+let mockState = {
+  error: null as string | null,
+  fieldErrors: {} as { password?: string; confirmPassword?: string },
+};
+const mockFormAction = vi.fn();
+let mockPending = false;
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useActionState: (_action: unknown, _initial: unknown) => [mockState, mockFormAction, mockPending],
+  };
+});
+
+import UpdatePasswordForm from "../UpdatePasswordForm";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CLEAN_STATE = {
+  error: null as string | null,
+  fieldErrors: {} as { password?: string; confirmPassword?: string },
+};
+
+afterEach(() => {
+  cleanup();
+  Object.assign(mockState, CLEAN_STATE);
+  mockState.fieldErrors = {};
+  mockPending = false;
+});
+
+beforeEach(() => {
+  Object.assign(mockState, CLEAN_STATE);
+  mockState.fieldErrors = {};
+  mockPending = false;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("UpdatePasswordForm", () => {
+  // --- Default form rendering ------------------------------------------------
+
+  it("renders New Password heading", () => {
+    render(<UpdatePasswordForm />);
+    expect(screen.getByRole("heading", { name: "New Password" })).toBeDefined();
+  });
+
+  it("renders password input", () => {
+    render(<UpdatePasswordForm />);
+    expect(screen.getByLabelText("New Password")).toBeDefined();
+  });
+
+  it("renders confirm password input", () => {
+    render(<UpdatePasswordForm />);
+    expect(screen.getByLabelText("Confirm Password")).toBeDefined();
+  });
+
+  it("renders Update Password submit button", () => {
+    render(<UpdatePasswordForm />);
+    expect(screen.getByRole("button", { name: "Update Password" })).toBeDefined();
+  });
+
+  // --- Error state ----------------------------------------------------------
+
+  it("shows error banner when state has error", () => {
+    mockState.error = "Something went wrong.";
+    render(<UpdatePasswordForm />);
+    expect(screen.getByRole("alert")).toBeDefined();
+  });
+
+  it("shows password field error", () => {
+    mockState.fieldErrors = { password: "Password does not meet the requirements" };
+    render(<UpdatePasswordForm />);
+    expect(screen.getByText("Password does not meet the requirements")).toBeDefined();
+  });
+
+  it("shows confirmPassword field error", () => {
+    mockState.fieldErrors = { confirmPassword: "Passwords do not match" };
+    render(<UpdatePasswordForm />);
+    expect(screen.getByText("Passwords do not match")).toBeDefined();
+  });
+
+  it("does not show error banner in clean state", () => {
+    render(<UpdatePasswordForm />);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // --- Password toggle -------------------------------------------------------
+
+  it("password input starts as type password", () => {
+    render(<UpdatePasswordForm />);
+    const input = screen.getByLabelText("New Password") as HTMLInputElement;
+    expect(input.type).toBe("password");
+  });
+
+  it("confirm password starts as type password", () => {
+    render(<UpdatePasswordForm />);
+    const input = screen.getByLabelText("Confirm Password") as HTMLInputElement;
+    expect(input.type).toBe("password");
+  });
+
+  it("toggles password to text when first eye button clicked", async () => {
+    render(<UpdatePasswordForm />);
+    const input = screen.getByLabelText("New Password") as HTMLInputElement;
+    const buttons = screen.getAllByLabelText("Show password");
+
+    await act(async () => {
+      fireEvent.click(buttons[0]);
+    });
+
+    expect(input.type).toBe("text");
+  });
+
+  it("toggles confirmPassword to text when second eye button clicked", async () => {
+    render(<UpdatePasswordForm />);
+    const input = screen.getByLabelText("Confirm Password") as HTMLInputElement;
+    const buttons = screen.getAllByLabelText("Show password");
+
+    await act(async () => {
+      fireEvent.click(buttons[1]);
+    });
+
+    expect(input.type).toBe("text");
+  });
+
+  // --- Pending state --------------------------------------------------------
+
+  it("shows Updating text and disables button when pending", () => {
+    mockPending = true;
+    render(<UpdatePasswordForm />);
+    const button = screen.getByRole("button", { name: /Updating/i });
+    expect(button).toBeDefined();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // --- input-error class ----------------------------------------------------
+
+  it("adds input-error class to password when fieldErrors.password is set", () => {
+    mockState.fieldErrors = { password: "Password does not meet the requirements" };
+    render(<UpdatePasswordForm />);
+    const input = screen.getByLabelText("New Password") as HTMLInputElement;
+    expect(input.className).toContain("input-error");
+  });
+
+  it("adds input-error class to confirmPassword when fieldErrors.confirmPassword is set", () => {
+    mockState.fieldErrors = { confirmPassword: "Passwords do not match" };
+    render(<UpdatePasswordForm />);
+    const input = screen.getByLabelText("Confirm Password") as HTMLInputElement;
+    expect(input.className).toContain("input-error");
+  });
+});

--- a/app/update-password/actions.ts
+++ b/app/update-password/actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { validateUpdatePasswordForm } from "@/lib/auth-validation";
+import { createClient } from "@/lib/supabase/server";
+import type { UpdatePasswordState } from "./types";
+
+export async function updatePassword(
+  _prevState: UpdatePasswordState,
+  formData: FormData,
+): Promise<UpdatePasswordState> {
+  const password = formData.get("password")?.toString() ?? "";
+  const confirmPassword = formData.get("confirmPassword")?.toString() ?? "";
+
+  const { errors, isValid } = validateUpdatePasswordForm(password, confirmPassword);
+
+  if (!isValid) {
+    return { error: null, fieldErrors: errors };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.updateUser({ password });
+
+  if (error) {
+    return { error: error.message, fieldErrors: {} };
+  }
+
+  redirect("/login");
+}

--- a/app/update-password/page.tsx
+++ b/app/update-password/page.tsx
@@ -1,0 +1,16 @@
+import NavBar from "@/app/_components/NavBar";
+import UpdatePasswordForm from "./_components/UpdatePasswordForm";
+
+export const metadata = {
+  title: "New Password — MY Chess Tour",
+  description: "Set a new password for your MY Chess Tour account.",
+};
+
+export default function UpdatePasswordPage() {
+  return (
+    <div className="min-h-screen bg-(--color-bg-base)">
+      <NavBar />
+      <UpdatePasswordForm />
+    </div>
+  );
+}

--- a/app/update-password/types.ts
+++ b/app/update-password/types.ts
@@ -1,0 +1,12 @@
+export type UpdatePasswordState = {
+  error: string | null;
+  fieldErrors: {
+    password?: string;
+    confirmPassword?: string;
+  };
+};
+
+export const INITIAL_UPDATE_PASSWORD_STATE: UpdatePasswordState = {
+  error: null,
+  fieldErrors: {},
+};

--- a/lib/__tests__/auth-validation.test.ts
+++ b/lib/__tests__/auth-validation.test.ts
@@ -9,6 +9,7 @@ import {
   validateForgotPasswordForm,
   validateLoginForm,
   validateRegistrationForm,
+  validateUpdatePasswordForm,
 } from "../auth-validation";
 
 describe("validateEmail", () => {
@@ -300,5 +301,37 @@ describe("validateForgotPasswordForm", () => {
   it("returns isValid false when email is invalid", () => {
     const { isValid } = validateForgotPasswordForm("not-valid");
     expect(isValid).toBe(false);
+  });
+});
+
+describe("validateUpdatePasswordForm", () => {
+  it("returns error when password is empty", () => {
+    const { errors } = validateUpdatePasswordForm("", "");
+    expect(errors.password).toBeDefined();
+  });
+
+  it("returns error when password does not meet requirements", () => {
+    const { errors } = validateUpdatePasswordForm("weak", "weak");
+    expect(errors.password).toBeDefined();
+  });
+
+  it("returns error when confirmPassword is empty but password is strong", () => {
+    const { errors } = validateUpdatePasswordForm("Strong1!", "");
+    expect(errors.confirmPassword).toBeDefined();
+  });
+
+  it("returns error when passwords do not match", () => {
+    const { errors } = validateUpdatePasswordForm("Strong1!", "Different1!");
+    expect(errors.confirmPassword).toBeDefined();
+  });
+
+  it("returns isValid=true when password meets all requirements and confirmPassword matches", () => {
+    const { isValid } = validateUpdatePasswordForm("Strong1!", "Strong1!");
+    expect(isValid).toBe(true);
+  });
+
+  it("returns no errors when all requirements met", () => {
+    const { errors } = validateUpdatePasswordForm("Strong1!", "Strong1!");
+    expect(Object.keys(errors)).toHaveLength(0);
   });
 });

--- a/lib/__tests__/auth-validation.test.ts
+++ b/lib/__tests__/auth-validation.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
   checkPasswordRequirements,
   getPasswordStrength,
+  isLoginFormSubmittable,
   isRegistrationFormSubmittable,
   validateEmail,
+  validateForgotPasswordForm,
+  validateLoginForm,
   validateRegistrationForm,
 } from "../auth-validation";
 
@@ -203,5 +206,99 @@ describe("isRegistrationFormSubmittable", () => {
 
   it("returns false when terms not accepted", () => {
     expect(isRegistrationFormSubmittable({ ...validFields, termsAccepted: false })).toBe(false);
+  });
+});
+
+describe("validateLoginForm", () => {
+  const validFields = {
+    email: "ahmad@example.com",
+    password: "anypassword",
+    keepSignedIn: true,
+  };
+
+  it("returns isValid true for valid fields", () => {
+    const { isValid } = validateLoginForm(validFields);
+    expect(isValid).toBe(true);
+  });
+
+  it("returns no errors for valid fields", () => {
+    const { errors } = validateLoginForm(validFields);
+    expect(Object.keys(errors)).toHaveLength(0);
+  });
+
+  it("returns email error when email is empty", () => {
+    const { errors } = validateLoginForm({ ...validFields, email: "" });
+    expect(errors.email).toBeDefined();
+  });
+
+  it("returns email error when email is invalid", () => {
+    const { errors } = validateLoginForm({ ...validFields, email: "not-valid" });
+    expect(errors.email).toBeDefined();
+  });
+
+  it("returns password error when password is empty", () => {
+    const { errors } = validateLoginForm({ ...validFields, password: "" });
+    expect(errors.password).toBeDefined();
+  });
+
+  it("returns isValid false when any field is invalid", () => {
+    const { isValid } = validateLoginForm({ ...validFields, email: "bad" });
+    expect(isValid).toBe(false);
+  });
+
+  it("accepts keepSignedIn as false", () => {
+    const { isValid } = validateLoginForm({ ...validFields, keepSignedIn: false });
+    expect(isValid).toBe(true);
+  });
+});
+
+describe("isLoginFormSubmittable", () => {
+  const validFields = {
+    email: "ahmad@example.com",
+    password: "anypassword",
+    keepSignedIn: true,
+  };
+
+  it("returns true for valid complete fields", () => {
+    expect(isLoginFormSubmittable(validFields)).toBe(true);
+  });
+
+  it("returns false when email is invalid", () => {
+    expect(isLoginFormSubmittable({ ...validFields, email: "bad" })).toBe(false);
+  });
+
+  it("returns false when email is empty", () => {
+    expect(isLoginFormSubmittable({ ...validFields, email: "" })).toBe(false);
+  });
+
+  it("returns false when password is empty", () => {
+    expect(isLoginFormSubmittable({ ...validFields, password: "" })).toBe(false);
+  });
+});
+
+describe("validateForgotPasswordForm", () => {
+  it("returns isValid true for a valid email", () => {
+    const { isValid } = validateForgotPasswordForm("user@example.com");
+    expect(isValid).toBe(true);
+  });
+
+  it("returns no errors for a valid email", () => {
+    const { errors } = validateForgotPasswordForm("user@example.com");
+    expect(Object.keys(errors)).toHaveLength(0);
+  });
+
+  it("returns email error when email is empty", () => {
+    const { errors } = validateForgotPasswordForm("");
+    expect(errors.email).toBeDefined();
+  });
+
+  it("returns email error when email is invalid", () => {
+    const { errors } = validateForgotPasswordForm("not-valid");
+    expect(errors.email).toBeDefined();
+  });
+
+  it("returns isValid false when email is invalid", () => {
+    const { isValid } = validateForgotPasswordForm("not-valid");
+    expect(isValid).toBe(false);
   });
 });

--- a/lib/__tests__/email.test.ts
+++ b/lib/__tests__/email.test.ts
@@ -18,7 +18,7 @@ vi.mock("resend", () => ({
   Resend: vi.fn(function () { return { emails: { send: mockSend } }; }),
 }));
 
-import { sendVerificationEmail } from "../email";
+import { sendPasswordResetEmail, sendVerificationEmail } from "../email";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -96,6 +96,70 @@ describe("sendVerificationEmail", () => {
   it("resolves without a value when send succeeds", async () => {
     await expect(
       sendVerificationEmail("player@example.com", "ABC123")
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("sendPasswordResetEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadFileSync.mockReturnValue('<html><a href="{{resetLink}}">reset</a>{{resetLink}}</html>');
+    mockSend.mockResolvedValue({ error: null });
+  });
+
+  // --- Template loading -----------------------------------------------------
+
+  it("loads the reset-password.html template from the filesystem", async () => {
+    await sendPasswordResetEmail("player@example.com", "https://example.com/reset");
+
+    expect(mockReadFileSync).toHaveBeenCalledOnce();
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("reset-password.html"),
+      "utf-8"
+    );
+  });
+
+  // --- Link injection -------------------------------------------------------
+
+  it("replaces all {{resetLink}} placeholders with the actual link", async () => {
+    const link = "https://example.com/reset?token=abc";
+    await sendPasswordResetEmail("player@example.com", link);
+
+    const { html } = mockSend.mock.calls[0][0];
+    expect(html).not.toContain("{{resetLink}}");
+    expect(html).toContain(link);
+  });
+
+  // --- Email fields ---------------------------------------------------------
+
+  it("sends to the correct email address", async () => {
+    await sendPasswordResetEmail("player@example.com", "https://example.com/reset");
+
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "player@example.com" })
+    );
+  });
+
+  it("includes a subject mentioning reset (case-insensitive)", async () => {
+    await sendPasswordResetEmail("player@example.com", "https://example.com/reset");
+
+    const { subject } = mockSend.mock.calls[0][0];
+    expect(subject).toMatch(/reset/i);
+  });
+
+  // --- Error handling -------------------------------------------------------
+
+  it("throws when Resend returns an error", async () => {
+    mockSend.mockResolvedValue({ error: { message: "Sending failed" } });
+
+    await expect(
+      sendPasswordResetEmail("player@example.com", "https://example.com/reset")
+    ).rejects.toThrow(/sending failed/i);
+  });
+
+  it("resolves without a value when send succeeds", async () => {
+    await expect(
+      sendPasswordResetEmail("player@example.com", "https://example.com/reset")
     ).resolves.toBeUndefined();
   });
 });

--- a/lib/auth-validation.ts
+++ b/lib/auth-validation.ts
@@ -105,3 +105,58 @@ export function isRegistrationFormSubmittable(fields: RegistrationFields): boole
     fields.termsAccepted
   );
 }
+
+// ── Login ──────────────────────────────────────────────────────────────────
+
+export type LoginFields = {
+  email: string;
+  password: string;
+  keepSignedIn: boolean;
+};
+
+export type LoginErrors = {
+  email?: string;
+  password?: string;
+};
+
+export function validateLoginForm(
+  fields: LoginFields,
+): { errors: LoginErrors; isValid: boolean } {
+  const errors: LoginErrors = {};
+
+  if (!fields.email.trim()) {
+    errors.email = "Email address is required";
+  } else if (!validateEmail(fields.email)) {
+    errors.email = "Please enter a valid email address";
+  }
+
+  if (!fields.password) {
+    errors.password = "Password is required";
+  }
+
+  return { errors, isValid: Object.keys(errors).length === 0 };
+}
+
+export function isLoginFormSubmittable(fields: LoginFields): boolean {
+  return validateEmail(fields.email) && fields.password.length > 0;
+}
+
+// ── Forgot Password ────────────────────────────────────────────────────────
+
+export type ForgotPasswordErrors = {
+  email?: string;
+};
+
+export function validateForgotPasswordForm(
+  email: string,
+): { errors: ForgotPasswordErrors; isValid: boolean } {
+  const errors: ForgotPasswordErrors = {};
+
+  if (!email.trim()) {
+    errors.email = "Email address is required";
+  } else if (!validateEmail(email)) {
+    errors.email = "Please enter a valid email address";
+  }
+
+  return { errors, isValid: Object.keys(errors).length === 0 };
+}

--- a/lib/auth-validation.ts
+++ b/lib/auth-validation.ts
@@ -143,6 +143,36 @@ export function isLoginFormSubmittable(fields: LoginFields): boolean {
 
 // ── Forgot Password ────────────────────────────────────────────────────────
 
+export type UpdatePasswordErrors = {
+  password?: string;
+  confirmPassword?: string;
+};
+
+export function validateUpdatePasswordForm(
+  password: string,
+  confirmPassword: string,
+): { errors: UpdatePasswordErrors; isValid: boolean } {
+  const errors: UpdatePasswordErrors = {};
+
+  const reqs = checkPasswordRequirements(password);
+  const allReqsMet = Object.values(reqs).every(Boolean);
+  if (!password) {
+    errors.password = "Password is required";
+  } else if (!allReqsMet) {
+    errors.password = "Password does not meet the requirements";
+  }
+
+  if (!confirmPassword) {
+    errors.confirmPassword = "Please confirm your password";
+  } else if (password !== confirmPassword) {
+    errors.confirmPassword = "Passwords do not match";
+  }
+
+  return { errors, isValid: Object.keys(errors).length === 0 };
+}
+
+// ── Forgot Password ────────────────────────────────────────────────────────
+
 export type ForgotPasswordErrors = {
   email?: string;
 };

--- a/lib/email-templates/reset-password.html
+++ b/lib/email-templates/reset-password.html
@@ -199,12 +199,12 @@
           a new password and get back in the game.
         </p>
 
-        <a href="{{ .ConfirmationURL }}" class="cta-btn">Reset Password</a>
+        <a href="{{resetLink}}" class="cta-btn">Reset Password</a>
 
         <p class="fallback">
           If the button above doesn't work, copy and paste<br />
           the link below into your browser:<br />
-          <a href="{{ .ConfirmationURL }}">{{ .ConfirmationURL }}</a>
+          <a href="{{resetLink}}">{{resetLink}}</a>
         </p>
       </div>
 

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -27,3 +27,19 @@ export async function sendVerificationEmail(email: string, code: string) {
     throw new Error(`Failed to send verification email: ${error.message}`);
   }
 }
+
+export async function sendPasswordResetEmail(email: string, resetLink: string) {
+  const html = loadTemplate("reset-password.html").replace(/\{\{resetLink\}\}/g, resetLink);
+
+  const { error } = await resend.emails.send({
+    from: FROM_ADDRESS,
+    to: email,
+    subject: "Reset your MY Chess Tour password",
+    html,
+  });
+
+  if (error) {
+    console.error("Failed to send password reset email:", error);
+    throw new Error(`Failed to send password reset email: ${error.message}`);
+  }
+}


### PR DESCRIPTION
Implements login and authentication screens as specified in issue #139.

## Changes

### Login / Forgot Password (original)
- `/login` page with LoginForm (screens 2A, 2B, 2C): email/password inputs, keep-signed-in checkbox, forgot-password link, error banner with attempt countdown, account-locked screen
- `/forgot-password` page with ForgotPasswordForm (screen 2D): email input, success confirmation screen
- Login server action with Redis-based rate limiting (5 attempts, 15-min lockout)
- `validateLoginForm`, `isLoginFormSubmittable`, `validateForgotPasswordForm` added to `lib/auth-validation.ts`
- New CSS classes: `confirm-icon`, `confirm-title`, `confirm-body`, `confirm-actions`

### Password Reset Flow
- Forgot-password server action migrated from Supabase `resetPasswordForEmail` to Resend: uses `supabaseAdmin.auth.admin.generateLink` (service key) to get the reset link, then sends a branded email via Resend
- `/auth/callback` route: exchanges Supabase PKCE code for session and redirects to `next` param (e.g. `/update-password`)
- `/update-password` page with UpdatePasswordForm: two password fields with eye-toggle, field-level validation, success redirect to `/login`
- `validateUpdatePasswordForm` added to `lib/auth-validation.ts`
- `sendPasswordResetEmail` added to `lib/email.ts`

### Auth-aware Navbar
- NavBar fetches auth state on every route change via `supabase.auth.getUser()`
- Authenticated: shows "My Tournaments" link + avatar button with initials + account dropdown (My Profile, My Registrations, Settings, Sign Out)
- Unauthenticated: shows Login + Sign Up buttons (unchanged)
- Mobile drawer: same conditional rendering
- New CSS classes: `nav-avatar`, `nav-avatar--open`, `nav-dropdown`, `nav-dropdown-user`, `nav-dropdown-name`, `nav-dropdown-email`, `nav-dropdown-item`, `nav-dropdown-item--danger`, `nav-dropdown-divider`

### Fix: `INITIAL_LOGIN_STATE` in `"use server"` module
- Extracted `LoginState` type and `INITIAL_LOGIN_STATE` constant to `app/login/types.ts` — Next.js server actions loader requires `"use server"` files to export only async functions

### Tests
- All 398 tests passing across 41 test files (≥90% coverage on all modified/new files)
- New test files: `app/auth/callback/__tests__/route.test.ts`, `app/update-password/__tests__/actions.test.ts`, `app/update-password/__tests__/page.test.ts`, `app/update-password/_components/__tests__/UpdatePasswordForm.test.tsx`
- Updated: `lib/__tests__/auth-validation.test.ts`, `lib/__tests__/email.test.ts`, `app/forgot-password/__tests__/actions.test.ts`

Closes #139

🤖 Generated with [Claude Code](https://claude.ai/code)