### PR TITLE
feat: remove poster from tournaments page and database schema

### DIFF
--- a/app/api/v1/tournaments/__tests__/route.test.ts
+++ b/app/api/v1/tournaments/__tests__/route.test.ts
@@ -54,7 +54,6 @@ function makeTournament(overrides: Record<string, unknown> = {}) {
     is_mcf_rated: false,
     entry_fees: { standard: { amount_cents: 5000 }, additional: [] },
     max_participants: 120,
-    poster_url: null,
     status: "published",
     organizer_profiles: mockOrganizer,
     ...overrides,
@@ -131,7 +130,6 @@ describe("GET /api/v1/tournaments", () => {
       expect(item.is_fide_rated).toBe(true);
       expect(item.is_mcf_rated).toBe(false);
       expect(item.max_participants).toBe(120);
-      expect(item.poster_url).toBeNull();
       expect(item.status).toBe("published");
     });
 

--- a/app/api/v1/tournaments/route.ts
+++ b/app/api/v1/tournaments/route.ts
@@ -6,7 +6,7 @@ export async function GET() {
     .from("tournaments")
     .select(
       `id, name, venue_name, venue_state, start_date, end_date, registration_deadline,
-       format, time_control, is_fide_rated, is_mcf_rated, entry_fees, max_participants, poster_url, status,
+       format, time_control, is_fide_rated, is_mcf_rated, entry_fees, max_participants, status,
        organizer_profiles(id, organization_name, links)`
     )
     .eq("status", "published")
@@ -53,7 +53,6 @@ export async function GET() {
     is_mcf_rated: boolean;
     entry_fees: unknown;
     max_participants: number;
-    poster_url: string | null;
     status: string;
     organizer_profiles: OrganizerProfile | OrganizerProfile[] | null;
   }
@@ -77,7 +76,6 @@ export async function GET() {
       entry_fees: t.entry_fees,
       max_participants: t.max_participants,
       current_participants: participantCounts[t.id] ?? 0,
-      poster_url: t.poster_url,
       status: t.status,
       organizer: org
         ? { id: org.id, organization_name: org.organization_name, links: org.links }

--- a/app/tournaments/_components/TournamentCard.tsx
+++ b/app/tournaments/_components/TournamentCard.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import type { Tournament } from "../types";
 
 function formatDateRange(start: string, end: string): string {
@@ -63,29 +62,10 @@ export default function TournamentCard({ tournament: t }: Props) {
   }
 
   return (
-    <article className="tournament-card grid-cols-1 sm:grid-cols-[10rem_1fr]">
-      {/* Poster */}
-      <div className="hidden sm:flex items-center justify-center min-h-50 relative shrink-0 bg-(--color-bg-raised)">
-        {t.poster_url ? (
-          <Image
-            src={t.poster_url}
-            alt={`${t.name} poster`}
-            className="w-full h-full object-cover"
-          />
-        ) : (
-          <span className="text-[2rem] text-(--color-gold-dim)">♟</span>
-        )}
-
-        <span
-          className={`absolute top-2.5 right-2.5 text-[0.6875rem] [font-family:var(--font-lato)] font-semibold py-0.75 px-2 rounded-xs ${spotsClass}`}
-        >
-          {spotsLabel}
-        </span>
-      </div>
-
+    <article className="tournament-card">
       {/* Body */}
       <div className="p-4 flex flex-col justify-center">
-        {/* Format + rating badges */}
+        {/* Format + rating + spots badges */}
         <div className="flex flex-wrap gap-1.5 mb-2">
           <span className="badge-format">{capitalise(formatType) || "—"}</span>
           {t.is_fide_rated && <span className="badge-fide">FIDE</span>}
@@ -93,6 +73,11 @@ export default function TournamentCard({ tournament: t }: Props) {
           {!t.is_fide_rated && !t.is_mcf_rated && (
             <span className="badge-unrated">Unrated</span>
           )}
+          <span
+            className={`text-[0.6875rem] [font-family:var(--font-lato)] font-semibold py-0.75 px-2 rounded-xs ${spotsClass}`}
+          >
+            {spotsLabel}
+          </span>
         </div>
 
         {/* Title */}

--- a/app/tournaments/_components/TournamentCardSkeleton.tsx
+++ b/app/tournaments/_components/TournamentCardSkeleton.tsx
@@ -1,18 +1,16 @@
 export default function TournamentCardSkeleton() {
   return (
     <article
-      className="tournament-card grid-cols-1 sm:grid-cols-[10rem_1fr]"
+      className="tournament-card"
       aria-hidden="true"
     >
-      {/* Poster placeholder */}
-      <div className="skeleton-shimmer hidden sm:block min-h-50 shrink-0" />
-
       {/* Body */}
       <div className="p-4 flex flex-col justify-center">
         {/* Badge row */}
         <div className="flex gap-1.5 mb-3">
           <div className="skeleton-shimmer w-15.5 h-4.5 rounded-xs" />
           <div className="skeleton-shimmer w-11 h-4.5 rounded-xs" />
+          <div className="skeleton-shimmer w-16 h-4.5 rounded-xs" />
         </div>
 
         {/* Title */}

--- a/app/tournaments/_components/TournamentsClient.tsx
+++ b/app/tournaments/_components/TournamentsClient.tsx
@@ -121,7 +121,7 @@ export default function TournamentsClient({ tournaments }: Props) {
             </p>
           </div>
         ) : (
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(min(25rem,100%),1fr))] gap-4">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(min(300px,100%),1fr))] gap-4">
             {filtered.map((t) => (
               <TournamentCard key={t.id} tournament={t} />
             ))}

--- a/app/tournaments/_components/TournamentsGridSkeleton.tsx
+++ b/app/tournaments/_components/TournamentsGridSkeleton.tsx
@@ -25,7 +25,7 @@ export default function TournamentsGridSkeleton() {
 
       {/* Card grid */}
       <div className="max-w-300 mx-auto px-10 py-6">
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(min(25rem,100%),1fr))] gap-4">
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(min(300px,100%),1fr))] gap-4">
           {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
             <TournamentCardSkeleton key={i} />
           ))}

--- a/app/tournaments/_components/__tests__/TournamentCard.test.tsx
+++ b/app/tournaments/_components/__tests__/TournamentCard.test.tsx
@@ -1,20 +1,7 @@
-/* eslint-disable @next/next/no-img-element */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import TournamentCard from "../TournamentCard";
 import type { Tournament } from "../../types";
-
-vi.mock("next/image", () => ({
-  default: ({
-    src,
-    alt,
-    className,
-  }: {
-    src: string;
-    alt: string;
-    className?: string;
-  }) => <img src={src} alt={alt} className={className} />,
-}));
 
 const base: Tournament = {
   id: "1",
@@ -31,7 +18,6 @@ const base: Tournament = {
   entry_fees: { standard: { amount_cents: 5000 } },
   max_participants: 100,
   current_participants: 50,
-  poster_url: null,
   status: "published",
   organizer: null,
 };
@@ -132,22 +118,6 @@ describe("rating badges", () => {
   it("shows unrated badge when neither FIDE nor MCF", () => {
     const html = render({ is_fide_rated: false, is_mcf_rated: false });
     expect(html).toContain("badge-unrated");
-  });
-});
-
-// ── Poster ───────────────────────────────────────────────────
-
-describe("poster", () => {
-  it("renders chess piece fallback when no poster URL", () => {
-    const html = render({ poster_url: null });
-    expect(html).toContain("♟");
-    expect(html).not.toContain("<img");
-  });
-
-  it("renders image when poster URL is provided", () => {
-    const html = render({ poster_url: "https://example.com/poster.jpg" });
-    expect(html).toContain("<img");
-    expect(html).not.toContain("text-[2rem]");
   });
 });
 

--- a/app/tournaments/_components/__tests__/TournamentCardSkeleton.test.tsx
+++ b/app/tournaments/_components/__tests__/TournamentCardSkeleton.test.tsx
@@ -1,21 +1,8 @@
-/* eslint-disable @next/next/no-img-element */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import TournamentCardSkeleton from "../TournamentCardSkeleton";
 import TournamentCard from "../TournamentCard";
 import type { Tournament } from "../../types";
-
-vi.mock("next/image", () => ({
-  default: ({
-    src,
-    alt,
-    className,
-  }: {
-    src: string;
-    alt: string;
-    className?: string;
-  }) => <img src={src} alt={alt} className={className} />,
-}));
 
 const mockTournament: Tournament = {
   id: "1",
@@ -32,7 +19,6 @@ const mockTournament: Tournament = {
   entry_fees: { standard: { amount_cents: 5000 } },
   max_participants: 100,
   current_participants: 50,
-  poster_url: null,
   status: "published",
   organizer: null,
 };
@@ -52,27 +38,6 @@ describe("TournamentCardSkeleton mirrors TournamentCard layout", () => {
   it("article uses tournament-card class", () => {
     expect(getClasses(cardHtml, "article")).toContain("tournament-card");
     expect(getClasses(skeletonHtml, "article")).toContain("tournament-card");
-  });
-
-  it("article has matching responsive grid columns", () => {
-    const cardClasses = getClasses(cardHtml, "article");
-    const skeletonClasses = getClasses(skeletonHtml, "article");
-
-    expect(cardClasses).toContain("grid-cols-1");
-    expect(cardClasses).toContain("sm:grid-cols-[10rem_1fr]");
-    expect(skeletonClasses).toContain("grid-cols-1");
-    expect(skeletonClasses).toContain("sm:grid-cols-[10rem_1fr]");
-  });
-
-  it("poster column is hidden below sm on both", () => {
-    // Real card uses hidden sm:flex, skeleton uses hidden sm:block
-    const cardPosterClasses = getClasses(cardHtml, "div", 0);
-    const skeletonPosterClasses = getClasses(skeletonHtml, "div", 0);
-
-    expect(cardPosterClasses).toContain("hidden");
-    expect(cardPosterClasses.some((c) => c.startsWith("sm:"))).toBe(true);
-    expect(skeletonPosterClasses).toContain("hidden");
-    expect(skeletonPosterClasses.some((c) => c.startsWith("sm:"))).toBe(true);
   });
 
   it("body column has matching layout", () => {

--- a/app/tournaments/types.ts
+++ b/app/tournaments/types.ts
@@ -36,7 +36,6 @@ export interface Tournament {
   entry_fees: EntryFees;
   max_participants: number;
   current_participants: number;
-  poster_url: string | null;
   status: string;
   organizer: {
     id: string;

--- a/supabase/migrations/001_tables.sql
+++ b/supabase/migrations/001_tables.sql
@@ -95,7 +95,6 @@ CREATE TABLE tournaments (
   prizes                  jsonb,
   restrictions            jsonb,
   max_participants        integer NOT NULL,
-  poster_url              text,
   status                  varchar(20) NOT NULL DEFAULT 'draft',
   created_at              timestamptz NOT NULL DEFAULT now(),
   updated_at              timestamptz NOT NULL DEFAULT now()

--- a/supabase/migrations/010_drop_poster_url.sql
+++ b/supabase/migrations/010_drop_poster_url.sql
@@ -1,0 +1,3 @@
+-- Remove poster_url column from tournaments table.
+-- The posters Supabase bucket has already been deleted.
+ALTER TABLE tournaments DROP COLUMN IF EXISTS poster_url;

--- a/supabase/migrations/production/001_tables.sql
+++ b/supabase/migrations/production/001_tables.sql
@@ -97,7 +97,6 @@ CREATE TABLE tournaments (
   prizes                  jsonb,
   restrictions            jsonb,
   max_participants        integer NOT NULL,
-  poster_url              text,
   status                  tournament_status NOT NULL DEFAULT 'draft',
   created_at              timestamptz NOT NULL DEFAULT now(),
   updated_at              timestamptz NOT NULL DEFAULT now()


### PR DESCRIPTION
Removes poster from the `/tournaments` page and database schema as the Supabase bucket has already been deleted.

Changes:
- New migration `010_drop_poster_url.sql` to drop the column from production
- Removed `poster_url` from schema definitions, API route, and TypeScript types
- Removed poster section from `TournamentCard`; spots indicator moved to badge row
- All tests updated and passing (415 tests)

Closes #186

Generated with [Claude Code](https://claude.ai/code)