### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/nzmksk/my-chess-tour/security/code-scanning/1](https://github.com/nzmksk/my-chess-tour/security/code-scanning/1)

In general, to fix this issue you add an explicit `permissions` block either at the workflow root (applies to all jobs) or within the specific job. The block should grant only the minimal scopes required. For a simple test workflow that only checks out code and runs tests, `contents: read` is typically sufficient, as it allows reading the repository contents without write access.

The best targeted fix here is to add a `permissions` block under the `test` job so that `GITHUB_TOKEN` is explicitly limited. We will not change any existing steps or behavior. Specifically, in `.github/workflows/tests.yml`, under `jobs: test: name: Run tests`, we’ll insert:

```yaml
permissions:
  contents: read
```

at the same indentation level as `runs-on`. No additional imports or methods are needed; this is purely a configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
