### PR TITLE
feat: tournament detail page (#26)

### DIFF
--- a/app/tournaments/[id]/__tests__/page.test.ts
+++ b/app/tournaments/[id]/__tests__/page.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ─────────────────────────────────────────────────────
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Map([["host", "localhost:3000"]])),
+}));
+
+const mockNotFound = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  notFound: mockNotFound,
+}));
+
+vi.mock(
+  "@/app/tournaments/[id]/_components/TournamentDetail",
+  () => ({
+    default: vi.fn().mockReturnValue(null),
+  }),
+);
+
+vi.mock(
+  "@/app/tournaments/[id]/_components/DetailSkeleton",
+  () => ({
+    default: vi.fn().mockReturnValue(null),
+  }),
+);
+
+vi.mock("@/app/_components/NavBar", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+
+function makeTournamentPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    data: {
+      id: "t1",
+      name: "KL Open Rapid Championship 2026",
+      description: "Annual rapid chess championship.",
+      venue_name: "Dewan Bandaraya KL",
+      state: "W.P. Kuala Lumpur",
+      venue_address: "Jalan Raja Laut, 50350 Kuala Lumpur",
+      start_date: "2026-06-01",
+      end_date: "2026-06-02",
+      registration_deadline: "2026-05-28T23:59:59Z",
+      format: { type: "rapid", system: "swiss", rounds: 7 },
+      time_control: { base_minutes: 15, increment_seconds: 10, delay_seconds: 0 },
+      is_fide_rated: true,
+      is_mcf_rated: false,
+      entry_fees: { standard: { amount_cents: 5000 } },
+      prizes: null,
+      restrictions: null,
+      max_participants: 120,
+      current_participants: 78,
+      status: "published",
+      organizer: null,
+      ...overrides,
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("TournamentDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = mockFetch;
+  });
+
+  it("renders a non-null React element", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeTournamentPayload(),
+    });
+
+    const { default: TournamentDetailPage } = await import("../page");
+    const result = await TournamentDetailPage({
+      params: Promise.resolve({ id: "t1" }),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+});
+
+describe("TournamentDetailData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = mockFetch;
+  });
+
+  it("returns a React element when tournament is found", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeTournamentPayload(),
+    });
+
+    const { TournamentDetailData } = await import("../page");
+    const result = await TournamentDetailData({ id: "t1" });
+
+    expect(result).toBeDefined();
+  });
+
+  it("calls notFound() when fetch returns non-ok status", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404 });
+
+    const { TournamentDetailData } = await import("../page");
+    await TournamentDetailData({ id: "nonexistent" });
+
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it("calls notFound() when fetch throws a network error", async () => {
+    mockFetch.mockRejectedValue(new Error("Network failure"));
+
+    const { TournamentDetailData } = await import("../page");
+    await TournamentDetailData({ id: "t1" });
+
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it("calls notFound() when API returns null data", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: null }),
+    });
+
+    const { TournamentDetailData } = await import("../page");
+    await TournamentDetailData({ id: "t1" });
+
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+});

--- a/app/tournaments/[id]/_components/DetailSkeleton.tsx
+++ b/app/tournaments/[id]/_components/DetailSkeleton.tsx
@@ -1,0 +1,68 @@
+export default function DetailSkeleton() {
+  return (
+    <div className="min-h-screen bg-(--color-bg-base)">
+      <main className="max-w-[75rem] mx-auto px-6 md:px-10 py-8">
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_340px] gap-8 items-start animate-pulse">
+
+          {/* Left column skeleton */}
+          <div className="flex flex-col gap-6">
+            {/* Title */}
+            <div className="flex flex-col gap-2">
+              <div className="h-8 bg-(--color-bg-raised) rounded w-3/4" />
+              <div className="h-4 bg-(--color-bg-raised) rounded w-1/3" />
+            </div>
+
+            {/* Badges */}
+            <div className="flex gap-2">
+              <div className="h-6 w-16 bg-(--color-bg-raised) rounded" />
+              <div className="h-6 w-20 bg-(--color-bg-raised) rounded" />
+            </div>
+
+            {/* Details section */}
+            <div className="pt-6 border-t border-(--color-border) flex flex-col gap-4">
+              <div className="h-5 bg-(--color-bg-raised) rounded w-1/4" />
+              <div className="grid grid-cols-2 gap-4">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="flex flex-col gap-1">
+                    <div className="h-3 bg-(--color-bg-raised) rounded w-1/3" />
+                    <div className="h-4 bg-(--color-bg-raised) rounded w-2/3" />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Entry fees section */}
+            <div className="pt-6 border-t border-(--color-border) flex flex-col gap-4">
+              <div className="h-5 bg-(--color-bg-raised) rounded w-1/4" />
+              <div className="flex flex-col gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="flex justify-between">
+                    <div className="h-4 bg-(--color-bg-raised) rounded w-1/3" />
+                    <div className="h-4 bg-(--color-bg-raised) rounded w-16" />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Description section */}
+            <div className="pt-6 border-t border-(--color-border) flex flex-col gap-3">
+              <div className="h-5 bg-(--color-bg-raised) rounded w-1/4" />
+              <div className="h-4 bg-(--color-bg-raised) rounded w-full" />
+              <div className="h-4 bg-(--color-bg-raised) rounded w-5/6" />
+              <div className="h-4 bg-(--color-bg-raised) rounded w-4/6" />
+            </div>
+          </div>
+
+          {/* Right column skeleton (register card) */}
+          <div className="card card--featured p-6 flex flex-col gap-4">
+            <div className="h-5 bg-(--color-bg-raised) rounded w-3/4" />
+            <div className="h-10 bg-(--color-bg-raised) rounded w-1/2" />
+            <div className="h-10 bg-(--color-bg-raised) rounded w-full" />
+            <div className="h-4 bg-(--color-bg-raised) rounded w-2/3" />
+            <div className="h-4 bg-(--color-bg-raised) rounded w-1/2" />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/tournaments/[id]/_components/TournamentDetail.tsx
+++ b/app/tournaments/[id]/_components/TournamentDetail.tsx
@@ -1,0 +1,418 @@
+import type { TournamentDetail as TournamentDetailType, Restrictions } from "../types";
+
+// ── Formatting helpers ────────────────────────────────────────
+
+function formatDateRange(start: string, end: string): string {
+  const s = new Date(start + "T00:00:00");
+  const e = new Date(end + "T00:00:00");
+  const opts: Intl.DateTimeFormatOptions = {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  };
+  if (s.toDateString() === e.toDateString()) {
+    return s.toLocaleDateString("en-MY", opts);
+  }
+  const sStr = s.toLocaleDateString("en-MY", { day: "numeric", month: "short" });
+  const eStr = e.toLocaleDateString("en-MY", opts);
+  return `${sStr} – ${eStr}`;
+}
+
+function formatDeadline(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-MY", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function formatRm(cents: number): string {
+  if (cents === 0) return "Free";
+  return `RM${(cents / 100).toLocaleString("en-MY", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+}
+
+function capitalise(s: string): string {
+  if (!s) return "";
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+function getMinFeeCents(fees: TournamentDetailType["entry_fees"]): number {
+  if (!fees) return 0;
+  const standard = fees.standard?.amount_cents ?? 0;
+  const additional = fees.additional?.map((f) => f.amount_cents) ?? [];
+  return Math.min(standard, ...additional);
+}
+
+function hasRestrictions(r: Restrictions): boolean {
+  return (
+    r.min_rating != null ||
+    r.max_rating != null ||
+    r.min_age != null ||
+    r.max_age != null
+  );
+}
+
+// ── Sub-sections ──────────────────────────────────────────────
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="pt-6 border-t border-(--color-border)">
+      <h2 className="[font-family:var(--font-cinzel)] text-[1.125rem] font-semibold text-(--color-text-primary) tracking-[0.04em] mb-4">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="[font-family:var(--font-cinzel)] text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-(--color-text-muted)">
+        {label}
+      </dt>
+      <dd className="[font-family:var(--font-lato)] text-[0.9375rem] text-(--color-text-body)">
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────
+
+interface Props {
+  tournament: TournamentDetailType;
+}
+
+export default function TournamentDetail({ tournament: t }: Props) {
+  const spotsLeft = t.max_participants - t.current_participants;
+  const spotsRatio = t.max_participants > 0 ? spotsLeft / t.max_participants : 0;
+  const minFee = getMinFeeCents(t.entry_fees);
+  const lowestFeeEntry =
+    t.entry_fees.additional?.find((f) => f.amount_cents === minFee) ?? null;
+
+  let spotsClass = "text-(--color-gold-bright)";
+  if (spotsLeft === 0) spotsClass = "text-red-500";
+  else if (spotsRatio <= 0.2) spotsClass = "text-amber-400";
+
+  const orgLinks =
+    t.organizer?.links && Array.isArray(t.organizer.links)
+      ? (t.organizer.links as Array<{ url: string; label: string }>)
+      : [];
+
+  return (
+    <div className="min-h-screen bg-(--color-bg-base)">
+      <main className="max-w-[75rem] mx-auto px-6 md:px-10 py-8">
+        {/* Two-column layout */}
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_340px] gap-8 items-start">
+
+          {/* ── Left: scrollable detail ── */}
+          <div className="flex flex-col gap-6">
+
+            {/* Header */}
+            <div>
+              <h1 className="[font-family:var(--font-cinzel)] text-[1.75rem] font-semibold text-(--color-text-primary) tracking-[0.05em] leading-[1.2] mb-2">
+                {t.name}
+              </h1>
+              {t.organizer && (
+                <p className="[font-family:var(--font-lato)] text-[0.875rem] text-(--color-text-secondary)">
+                  Organized by{" "}
+                  <span className="text-(--color-gold-bright)">
+                    {t.organizer.organization_name}
+                  </span>
+                </p>
+              )}
+            </div>
+
+            {/* Badges */}
+            <div className="flex flex-wrap gap-2">
+              <span className="badge badge--neutral">
+                {capitalise(t.format?.type ?? "") || "—"}
+              </span>
+              {t.is_fide_rated && (
+                <span className="badge badge--gold">FIDE Rated</span>
+              )}
+              {t.is_mcf_rated && (
+                <span className="badge badge--gold">MCF Rated</span>
+              )}
+              {!t.is_fide_rated && !t.is_mcf_rated && (
+                <span className="badge badge--neutral">Unrated</span>
+              )}
+              {(!t.restrictions || !hasRestrictions(t.restrictions)) && (
+                <span className="badge badge--neutral">Open to All</span>
+              )}
+            </div>
+
+            {/* Tournament Details */}
+            <Section title="Tournament Details">
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <InfoRow
+                  label="Date"
+                  value={formatDateRange(t.start_date, t.end_date)}
+                />
+                <InfoRow
+                  label="Venue"
+                  value={
+                    <>
+                      {t.venue_name}, {t.state}
+                      {t.venue_address && (
+                        <span className="block text-[0.8125rem] text-(--color-text-muted) mt-0.5">
+                          {t.venue_address}
+                        </span>
+                      )}
+                    </>
+                  }
+                />
+                <InfoRow
+                  label="Format"
+                  value={`${capitalise(t.format?.type ?? "")} — ${capitalise(t.format?.system ?? "")} System, ${t.format?.rounds} rounds`}
+                />
+                <InfoRow
+                  label="Time Control"
+                  value={
+                    t.time_control
+                      ? `${t.time_control.base_minutes} min${t.time_control.increment_seconds > 0 ? ` + ${t.time_control.increment_seconds} sec` : ""}`
+                      : "—"
+                  }
+                />
+                <InfoRow
+                  label="Registration Deadline"
+                  value={formatDeadline(t.registration_deadline)}
+                />
+                <InfoRow
+                  label="Capacity"
+                  value={
+                    <>
+                      {t.max_participants} players{" "}
+                      <span className={spotsClass}>
+                        ({spotsLeft > 0 ? `${spotsLeft} spots left` : "Full"})
+                      </span>
+                    </>
+                  }
+                />
+              </dl>
+            </Section>
+
+            {/* Entry Fees */}
+            <Section title="Entry Fees">
+              <table className="table w-full">
+                <thead>
+                  <tr>
+                    <th className="text-left">Category</th>
+                    <th className="text-right">Fee</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {t.entry_fees.additional?.map((fee, i) => (
+                    <tr key={i}>
+                      <td>
+                        {fee.type}
+                        {fee.valid_until && (
+                          <span className="block text-[0.75rem] text-(--color-text-muted)">
+                            before {formatDeadline(fee.valid_until)}
+                          </span>
+                        )}
+                        {(fee.age_min != null || fee.age_max != null) && (
+                          <span className="block text-[0.75rem] text-(--color-text-muted)">
+                            {fee.age_min != null && fee.age_max != null
+                              ? `Age ${fee.age_min}–${fee.age_max}`
+                              : fee.age_min != null
+                                ? `Age ${fee.age_min}+`
+                                : `Age up to ${fee.age_max}`}
+                          </span>
+                        )}
+                      </td>
+                      <td className="text-right [font-family:var(--font-cinzel)] font-semibold text-(--color-text-primary)">
+                        {formatRm(fee.amount_cents)}
+                      </td>
+                    </tr>
+                  ))}
+                  <tr>
+                    <td>Standard</td>
+                    <td className="text-right [font-family:var(--font-cinzel)] font-semibold text-(--color-text-primary)">
+                      {formatRm(t.entry_fees.standard.amount_cents)}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </Section>
+
+            {/* Prizes */}
+            {t.prizes && t.prizes.categories.length > 0 && (
+              <Section title="Prizes">
+                <ul className="flex flex-col gap-3">
+                  {t.prizes.categories.map((cat, ci) => (
+                    <li key={ci}>
+                      <p className="[font-family:var(--font-cinzel)] text-[0.75rem] font-semibold uppercase tracking-[0.1em] text-(--color-gold-muted) mb-2">
+                        {cat.name}
+                      </p>
+                      <ul className="flex flex-col gap-1">
+                        {cat.entries.map((entry, ei) => (
+                          <li
+                            key={ei}
+                            className="flex justify-between [font-family:var(--font-lato)] text-[0.9375rem] text-(--color-text-body)"
+                          >
+                            <span>{entry.place}</span>
+                            <span className="[font-family:var(--font-cinzel)] font-semibold text-(--color-text-primary)">
+                              {formatRm(entry.amount_cents)}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  ))}
+                </ul>
+              </Section>
+            )}
+
+            {/* Restrictions */}
+            {t.restrictions && (
+              <Section title="Restrictions">
+                {hasRestrictions(t.restrictions) ? (
+                  <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    {(t.restrictions.min_rating != null ||
+                      t.restrictions.max_rating != null) && (
+                      <InfoRow
+                        label="Rating"
+                        value={
+                          t.restrictions.min_rating != null &&
+                          t.restrictions.max_rating != null
+                            ? `${t.restrictions.min_rating} – ${t.restrictions.max_rating}`
+                            : t.restrictions.min_rating != null
+                              ? `${t.restrictions.min_rating}+`
+                              : `Up to ${t.restrictions.max_rating}`
+                        }
+                      />
+                    )}
+                    {(t.restrictions.min_age != null ||
+                      t.restrictions.max_age != null) && (
+                      <InfoRow
+                        label="Age"
+                        value={
+                          t.restrictions.min_age != null &&
+                          t.restrictions.max_age != null
+                            ? `${t.restrictions.min_age} – ${t.restrictions.max_age} years`
+                            : t.restrictions.min_age != null
+                              ? `${t.restrictions.min_age}+ years`
+                              : `Up to ${t.restrictions.max_age} years`
+                        }
+                      />
+                    )}
+                  </dl>
+                ) : (
+                  <p className="[font-family:var(--font-lato)] text-[0.9375rem] text-(--color-text-body)">
+                    Open to all players — no rating or age restrictions apply.
+                  </p>
+                )}
+              </Section>
+            )}
+
+            {/* Description */}
+            {t.description && (
+              <Section title="Description">
+                <p className="[font-family:var(--font-lato)] text-[0.9375rem] text-(--color-text-body) leading-[1.75]">
+                  {t.description}
+                </p>
+              </Section>
+            )}
+
+            {/* Organizer */}
+            {t.organizer && (
+              <Section title="Organizer">
+                <div className="flex flex-col gap-3">
+                  <h3 className="[font-family:var(--font-cinzel)] text-[1rem] font-semibold text-(--color-text-primary)">
+                    {t.organizer.organization_name}
+                  </h3>
+                  {t.organizer.description && (
+                    <p className="[font-family:var(--font-lato)] text-[0.9375rem] text-(--color-text-body) leading-[1.7]">
+                      {t.organizer.description}
+                    </p>
+                  )}
+                  <div className="flex flex-col gap-1 [font-family:var(--font-lato)] text-[0.875rem] text-(--color-text-secondary)">
+                    <a
+                      href={`mailto:${t.organizer.email}`}
+                      className="hover:text-(--color-gold-bright) transition-colors"
+                    >
+                      ✉ {t.organizer.email}
+                    </a>
+                    {t.organizer.phone && (
+                      <a
+                        href={`tel:${t.organizer.phone}`}
+                        className="hover:text-(--color-gold-bright) transition-colors"
+                      >
+                        ☎ {t.organizer.phone}
+                      </a>
+                    )}
+                    {orgLinks.map((link, i) => (
+                      <a
+                        key={i}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-(--color-gold-bright) transition-colors"
+                      >
+                        ↗ {link.label}
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              </Section>
+            )}
+          </div>
+
+          {/* ── Right: sticky register card ── */}
+          <aside className="md:sticky md:top-6">
+            <div className="card card--featured p-6 flex flex-col gap-4">
+              <h3 className="[font-family:var(--font-cinzel)] text-[1rem] font-semibold text-(--color-text-primary) tracking-[0.05em]">
+                Register for this tournament
+              </h3>
+
+              {/* Price */}
+              <div>
+                <div className="[font-family:var(--font-cinzel)] text-[2rem] font-bold text-(--color-text-primary)">
+                  {minFee > 0 ? formatRm(minFee) : "Free"}
+                </div>
+                {lowestFeeEntry && (
+                  <p className="[font-family:var(--font-lato)] text-[0.8125rem] text-(--color-text-muted) mt-0.5">
+                    {lowestFeeEntry.type} price
+                    {lowestFeeEntry.valid_until &&
+                      ` (ends ${formatDeadline(lowestFeeEntry.valid_until)})`}
+                  </p>
+                )}
+              </div>
+
+              {/* CTA */}
+              {spotsLeft > 0 ? (
+                <button className="btn-primary w-full">Register Now</button>
+              ) : (
+                <button className="btn-primary w-full opacity-50" disabled>
+                  Full
+                </button>
+              )}
+
+              {/* Spots */}
+              <div className="[font-family:var(--font-lato)] text-[0.875rem] text-(--color-text-secondary)">
+                <span className={`font-semibold ${spotsClass}`}>
+                  {spotsLeft}
+                </span>{" "}
+                of {t.max_participants} spots remaining
+              </div>
+
+              {/* Deadline */}
+              <p className="[font-family:var(--font-lato)] text-[0.8125rem] text-(--color-text-muted)">
+                ⏰ Registration closes {formatDeadline(t.registration_deadline)}
+              </p>
+            </div>
+          </aside>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/tournaments/[id]/_components/TournamentDetail.tsx
+++ b/app/tournaments/[id]/_components/TournamentDetail.tsx
@@ -368,7 +368,7 @@ export default function TournamentDetail({ tournament: t }: Props) {
           </div>
 
           {/* ── Right: sticky register card ── */}
-          <aside className="md:sticky md:top-6">
+          <aside className="md:sticky md:top-24">
             <div className="card card--featured p-6 flex flex-col gap-4">
               <h3 className="[font-family:var(--font-cinzel)] text-[1rem] font-semibold text-(--color-text-primary) tracking-[0.05em]">
                 Register for this tournament

--- a/app/tournaments/[id]/_components/__tests__/DetailSkeleton.test.ts
+++ b/app/tournaments/[id]/_components/__tests__/DetailSkeleton.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import DetailSkeleton from "../DetailSkeleton";
+
+describe("DetailSkeleton", () => {
+  it("renders without crashing", () => {
+    const html = renderToStaticMarkup(DetailSkeleton());
+    expect(html).toBeTruthy();
+  });
+
+  it("renders skeleton pulse elements", () => {
+    const html = renderToStaticMarkup(DetailSkeleton());
+    expect(html).toContain("animate-pulse");
+  });
+});

--- a/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
+++ b/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
@@ -1,0 +1,339 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import TournamentDetail from "../TournamentDetail";
+import type { TournamentDetail as TournamentDetailType } from "../../types";
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+const base: TournamentDetailType = {
+  id: "t1",
+  name: "KL Open Rapid Championship 2026",
+  description: "Annual rapid chess championship in Kuala Lumpur.",
+  venue_name: "Dewan Bandaraya KL",
+  state: "W.P. Kuala Lumpur",
+  venue_address: "Jalan Raja Laut, 50350 Kuala Lumpur",
+  start_date: "2026-06-01",
+  end_date: "2026-06-02",
+  registration_deadline: "2026-05-28T23:59:59Z",
+  format: { type: "rapid", system: "swiss", rounds: 7 },
+  time_control: { base_minutes: 15, increment_seconds: 10, delay_seconds: 0 },
+  is_fide_rated: true,
+  is_mcf_rated: false,
+  entry_fees: {
+    standard: { amount_cents: 5000 },
+    additional: [
+      { type: "Early Bird", amount_cents: 3500, valid_until: "2026-05-01" },
+    ],
+  },
+  prizes: {
+    categories: [
+      {
+        name: "Open",
+        entries: [
+          { place: "1st Place", amount_cents: 300000 },
+          { place: "2nd Place", amount_cents: 200000 },
+          { place: "3rd Place", amount_cents: 100000 },
+        ],
+      },
+    ],
+  },
+  restrictions: {
+    min_rating: null,
+    max_rating: 2200,
+    min_age: null,
+    max_age: null,
+  },
+  max_participants: 120,
+  current_participants: 78,
+  status: "published",
+  organizer: {
+    id: "org-1",
+    organization_name: "KL Chess Association",
+    description: "Premier chess organization in KL.",
+    links: [{ url: "https://klchess.org", label: "Website" }],
+    email: "info@klchess.org",
+    phone: "+60123456789",
+  },
+};
+
+function render(overrides: Partial<TournamentDetailType> = {}): string {
+  return renderToStaticMarkup(
+    <TournamentDetail tournament={{ ...base, ...overrides }} />,
+  );
+}
+
+// ── Tournament header ─────────────────────────────────────────
+
+describe("tournament header", () => {
+  it("renders the tournament name", () => {
+    const html = render();
+    expect(html).toContain("KL Open Rapid Championship 2026");
+  });
+
+  it("renders the organizer name when organizer is present", () => {
+    const html = render();
+    expect(html).toContain("KL Chess Association");
+  });
+
+  it("does not render organizer line when organizer is null", () => {
+    const html = render({ organizer: null });
+    expect(html).not.toContain("Organized by");
+  });
+});
+
+// ── Rating badges ─────────────────────────────────────────────
+
+describe("rating badges", () => {
+  it("shows FIDE badge when FIDE rated", () => {
+    const html = render({ is_fide_rated: true, is_mcf_rated: false });
+    expect(html).toContain("FIDE");
+  });
+
+  it("shows MCF badge when MCF rated", () => {
+    const html = render({ is_fide_rated: false, is_mcf_rated: true });
+    expect(html).toContain("MCF");
+  });
+
+  it("shows Unrated badge when neither FIDE nor MCF rated", () => {
+    const html = render({ is_fide_rated: false, is_mcf_rated: false });
+    expect(html).toContain("Unrated");
+  });
+});
+
+// ── Tournament details section ────────────────────────────────
+
+describe("tournament details section", () => {
+  it("renders the venue name and state", () => {
+    const html = render();
+    expect(html).toContain("Dewan Bandaraya KL");
+    expect(html).toContain("W.P. Kuala Lumpur");
+  });
+
+  it("renders the format type and rounds", () => {
+    const html = render();
+    expect(html).toContain("Rapid");
+    expect(html).toContain("7");
+  });
+
+  it("renders the time control with increment", () => {
+    const html = render();
+    expect(html).toContain("15 min");
+    expect(html).toContain("10 sec");
+  });
+
+  it("renders time control without increment when increment is 0", () => {
+    const html = render({
+      time_control: { base_minutes: 90, increment_seconds: 0, delay_seconds: 0 },
+    });
+    expect(html).toContain("90 min");
+    expect(html).not.toContain("+ 0 sec");
+  });
+
+  it("renders capacity with spots remaining", () => {
+    const html = render({ max_participants: 120, current_participants: 78 });
+    expect(html).toContain("120");
+    expect(html).toContain("42");
+  });
+
+  it("renders date range when start and end differ", () => {
+    const html = render({ start_date: "2026-06-01", end_date: "2026-06-02" });
+    expect(html).toContain("–");
+  });
+
+  it("renders single date when start and end are the same", () => {
+    const html = render({ start_date: "2026-06-01", end_date: "2026-06-01" });
+    expect(html).not.toContain("–");
+  });
+
+  it("renders the venue address when present", () => {
+    const html = render();
+    expect(html).toContain("Jalan Raja Laut");
+  });
+
+  it("omits venue address when not present", () => {
+    const html = render({ venue_address: null });
+    expect(html).not.toContain("Jalan Raja Laut");
+  });
+});
+
+// ── Entry fees section ────────────────────────────────────────
+
+describe("entry fees section", () => {
+  it("renders the standard fee", () => {
+    const html = render({ entry_fees: { standard: { amount_cents: 5000 } } });
+    expect(html).toContain("RM50");
+  });
+
+  it("renders 'Free' for zero standard fee", () => {
+    const html = render({ entry_fees: { standard: { amount_cents: 0 } } });
+    expect(html).toContain("Free");
+  });
+
+  it("renders additional fee tiers when present", () => {
+    const html = render();
+    expect(html).toContain("Early Bird");
+    expect(html).toContain("RM35");
+  });
+
+  it("omits additional fees section when not present", () => {
+    const html = render({ entry_fees: { standard: { amount_cents: 5000 } } });
+    expect(html).not.toContain("Early Bird");
+  });
+});
+
+// ── Prizes section ────────────────────────────────────────────
+
+describe("prizes section", () => {
+  it("renders prizes section when prizes are present", () => {
+    const html = render();
+    expect(html).toContain("Prizes");
+    expect(html).toContain("1st Place");
+    expect(html).toContain("RM3,000");
+  });
+
+  it("renders prize category headers", () => {
+    const html = render();
+    expect(html).toContain("Open");
+  });
+
+  it("hides prizes section when prizes are null", () => {
+    const html = render({ prizes: null });
+    expect(html).not.toContain("1st Place");
+  });
+
+  it("renders multiple categories when provided", () => {
+    const html = render({
+      prizes: {
+        categories: [
+          {
+            name: "Open",
+            entries: [{ place: "1st Place", amount_cents: 300000 }],
+          },
+          {
+            name: "Under-12",
+            entries: [{ place: "1st Place", amount_cents: 50000 }],
+          },
+        ],
+      },
+    });
+    expect(html).toContain("Open");
+    expect(html).toContain("Under-12");
+  });
+});
+
+// ── Restrictions section ──────────────────────────────────────
+
+describe("restrictions section", () => {
+  it("renders restrictions section when restrictions are present", () => {
+    const html = render({ restrictions: { max_rating: 2200 } });
+    expect(html).toContain("2200");
+  });
+
+  it("hides restrictions section when restrictions are null", () => {
+    const html = render({ restrictions: null });
+    // Section header should not appear when no restrictions
+    expect(html).not.toContain("Restrictions");
+  });
+
+  it("shows 'Open to all' when all restriction fields are null/absent", () => {
+    const html = render({
+      restrictions: {
+        min_rating: null,
+        max_rating: null,
+        min_age: null,
+        max_age: null,
+      },
+    });
+    expect(html).toContain("Open to all");
+  });
+
+  it("renders min and max rating when both are set", () => {
+    const html = render({
+      restrictions: { min_rating: 1200, max_rating: 2200 },
+    });
+    expect(html).toContain("1200");
+    expect(html).toContain("2200");
+  });
+
+  it("renders max age restriction when set", () => {
+    const html = render({
+      restrictions: { min_rating: null, max_rating: null, min_age: null, max_age: 18 },
+    });
+    expect(html).toContain("18");
+  });
+});
+
+// ── Description section ───────────────────────────────────────
+
+describe("description section", () => {
+  it("renders description when present", () => {
+    const html = render();
+    expect(html).toContain("Annual rapid chess championship in Kuala Lumpur.");
+  });
+
+  it("hides description section when description is null", () => {
+    const html = render({ description: null });
+    expect(html).not.toContain("Annual rapid chess championship");
+  });
+});
+
+// ── Organizer section ─────────────────────────────────────────
+
+describe("organizer section", () => {
+  it("renders organizer description when present", () => {
+    const html = render();
+    expect(html).toContain("Premier chess organization in KL.");
+  });
+
+  it("renders organizer email", () => {
+    const html = render();
+    expect(html).toContain("info@klchess.org");
+  });
+
+  it("renders organizer phone when present", () => {
+    const html = render();
+    expect(html).toContain("+60123456789");
+  });
+
+  it("omits phone when not present", () => {
+    const html = render({
+      organizer: { ...base.organizer!, phone: null },
+    });
+    expect(html).not.toContain("+60123456789");
+  });
+
+  it("hides organizer section when organizer is null", () => {
+    const html = render({ organizer: null });
+    expect(html).not.toContain("info@klchess.org");
+  });
+
+  it("renders organizer links when present as array", () => {
+    const html = render();
+    expect(html).toContain("Website");
+  });
+});
+
+// ── Register card (sidebar) ───────────────────────────────────
+
+describe("register card", () => {
+  it("shows the lowest applicable fee in the register card", () => {
+    const html = render();
+    // Early Bird at RM35 is lower than standard RM50
+    expect(html).toContain("RM35");
+  });
+
+  it("shows spots remaining", () => {
+    const html = render({ max_participants: 120, current_participants: 78 });
+    expect(html).toContain("42");
+  });
+
+  it("shows full status when no spots remain", () => {
+    const html = render({ max_participants: 100, current_participants: 100 });
+    expect(html).toContain("Full");
+  });
+
+  it("shows registration deadline", () => {
+    const html = render();
+    expect(html).toContain("28 May");
+  });
+});

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -1,0 +1,61 @@
+import { Suspense } from "react";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import NavBar from "@/app/_components/NavBar";
+import TournamentDetail from "./_components/TournamentDetail";
+import DetailSkeleton from "./_components/DetailSkeleton";
+import type { TournamentDetail as TournamentDetailType } from "./types";
+
+export const revalidate = 60;
+
+export async function TournamentDetailData({ id }: { id: string }) {
+  const headersList = await headers();
+  const host = headersList.get("host") ?? "localhost:3000";
+  const protocol =
+    host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https";
+
+  let tournament: TournamentDetailType | null = null;
+
+  try {
+    const res = await fetch(`${protocol}://${host}/api/v1/tournaments/${id}`, {
+      next: { revalidate: 60 },
+    });
+
+    if (!res.ok) {
+      notFound();
+      return null;
+    }
+
+    const json = await res.json();
+    tournament = json.data ?? null;
+  } catch {
+    notFound();
+    return null;
+  }
+
+  if (!tournament) {
+    notFound();
+    return null;
+  }
+
+  return <TournamentDetail tournament={tournament} />;
+}
+
+export default async function TournamentDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return (
+    <div className="min-h-screen bg-(--color-bg-base)">
+      <NavBar />
+      <Suspense fallback={<DetailSkeleton />}>
+        <TournamentDetailData id={id} />
+      </Suspense>
+    </div>
+  );
+}

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -29,6 +29,7 @@ export async function TournamentDetailData({ id }: { id: string }) {
     }
 
     const json = await res.json();
+    console.log(json);
     tournament = json.data ?? null;
   } catch {
     notFound();

--- a/app/tournaments/[id]/types.ts
+++ b/app/tournaments/[id]/types.ts
@@ -1,8 +1,15 @@
 import type { EntryFees, TournamentFormat, TimeControl } from "../types";
 
+const enum NonMonetaryPrize {
+  Trophy = "Trophy",
+  Medal = "Medal",
+  Certificate = "Certificate",
+}
+
 export interface PrizeEntry {
   place: string;
   amount_cents: number;
+  non_monetary_prize?: NonMonetaryPrize | null;
 }
 
 export interface PrizeCategory {
@@ -10,8 +17,14 @@ export interface PrizeCategory {
   entries: PrizeEntry[];
 }
 
+export interface PrizeSubCategory {
+  name: string;
+  entries: PrizeEntry[];
+  conditions: unknown;
+}
 export interface PrizesData {
   categories: PrizeCategory[];
+  subcategories?: PrizeSubCategory[] | null;
 }
 
 export interface Restrictions {

--- a/app/tournaments/[id]/types.ts
+++ b/app/tournaments/[id]/types.ts
@@ -1,0 +1,54 @@
+import type { EntryFees, TournamentFormat, TimeControl } from "../types";
+
+export interface PrizeEntry {
+  place: string;
+  amount_cents: number;
+}
+
+export interface PrizeCategory {
+  name: string;
+  entries: PrizeEntry[];
+}
+
+export interface PrizesData {
+  categories: PrizeCategory[];
+}
+
+export interface Restrictions {
+  min_rating?: number | null;
+  max_rating?: number | null;
+  min_age?: number | null;
+  max_age?: number | null;
+}
+
+export interface OrganizerDetail {
+  id: string;
+  organization_name: string;
+  description?: string | null;
+  links?: Array<{ url: string; label: string }> | unknown;
+  email: string;
+  phone?: string | null;
+}
+
+export interface TournamentDetail {
+  id: string;
+  name: string;
+  description?: string | null;
+  venue_name: string;
+  state: string;
+  venue_address?: string | null;
+  start_date: string;
+  end_date: string;
+  registration_deadline: string;
+  format: TournamentFormat;
+  time_control?: TimeControl;
+  is_fide_rated: boolean;
+  is_mcf_rated: boolean;
+  entry_fees: EntryFees;
+  prizes?: PrizesData | null;
+  restrictions?: Restrictions | null;
+  max_participants: number;
+  current_participants: number;
+  status: string;
+  organizer: OrganizerDetail | null;
+}

--- a/app/tournaments/_components/TournamentCard.tsx
+++ b/app/tournaments/_components/TournamentCard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { Tournament } from "../types";
 
 function formatDateRange(start: string, end: string): string {
@@ -114,12 +115,15 @@ export default function TournamentCard({ tournament: t }: Props) {
             </span>
           </div>
 
-          <button
-            className={`${spotsLeft === 0 ? "card-btn-full" : "card-btn-view"}`}
-            disabled={spotsLeft === 0}
-          >
-            {spotsLeft === 0 ? "Full" : "View →"}
-          </button>
+          {spotsLeft === 0 ? (
+            <button className="card-btn-full" disabled>
+              Full
+            </button>
+          ) : (
+            <Link href={`/tournaments/${t.id}`} className="card-btn-view">
+              View →
+            </Link>
+          )}
         </div>
       </div>
     </article>

--- a/app/tournaments/_components/__tests__/TournamentCard.test.tsx
+++ b/app/tournaments/_components/__tests__/TournamentCard.test.tsx
@@ -1,5 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+import * as React from "react";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => <a href={href} className={className}>{children}</a>,
+}));
+
 import TournamentCard from "../TournamentCard";
 import type { Tournament } from "../../types";
 

--- a/supabase/migrations/006_seed.sql
+++ b/supabase/migrations/006_seed.sql
@@ -345,13 +345,30 @@ BEGIN
         ),
         json_build_object(
           'categories', json_build_array(
-            json_build_object('place', 1, 'amount_cents', t_fee * 20),
-            json_build_object('place', 2, 'amount_cents', t_fee * 12),
-            json_build_object('place', 3, 'amount_cents', t_fee * 8)
+            json_build_object(
+              'name', 'Open',
+              'entries', json_build_array(
+                json_build_object('place', '1st', 'amount_cents', t_fee * 20),
+                json_build_object('place', '2nd', 'amount_cents', t_fee * 12),
+                json_build_object('place', '3rd', 'amount_cents', t_fee * 8)
+              )
+            )
           ),
-          'special', json_build_array(
-            json_build_object('title', 'Best Under-1500', 'amount_cents', t_fee * 5),
-            json_build_object('title', 'Best Female Player', 'amount_cents', t_fee * 5)
+          'subcategories', json_build_array(
+            json_build_object(
+              'name', 'Best Under-1500',
+              'entries', json_build_array(
+                json_build_object('place', '1st', 'amount_cents', t_fee * 5)
+              ),
+              'conditions', json_build_object('max_rating', 1499)
+            ),
+            json_build_object(
+              'name', 'Best Female Player',
+              'entries', json_build_array(
+                json_build_object('place', '1st', 'amount_cents', t_fee * 5)
+              ),
+              'conditions', json_build_object('gender', 'female')
+            )
           )
         ),
         '[{"type":"nationality","value":"Malaysian"}]'::jsonb,


### PR DESCRIPTION
Implements the tournament detail page at `/tournaments/[id]` per issue #26.

## Changes
- Two-column detail layout (no poster) following wireframes/player.html
- Full tournament info, entry fees with player-pays breakdown, prizes, restrictions, organizer info
- Sticky register card sidebar
- DetailSkeleton loading state
- TDD: 47 new tests (561 total, all passing)
- TournamentCard "View →" now links to detail page

Closes #26

Generated with [Claude Code](https://claude.ai/code)