### PR TITLE
feat: Registration CTA button (#28)

### DIFF
--- a/app/tournaments/[id]/__tests__/page.test.ts
+++ b/app/tournaments/[id]/__tests__/page.test.ts
@@ -30,6 +30,14 @@ vi.mock("@/app/_components/NavBar", () => ({
   default: vi.fn().mockReturnValue(null),
 }));
 
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+    },
+  }),
+}));
+
 // ── Helpers ───────────────────────────────────────────────────
 
 const mockFetch = vi.fn();

--- a/app/tournaments/[id]/_components/TournamentDetail.tsx
+++ b/app/tournaments/[id]/_components/TournamentDetail.tsx
@@ -89,9 +89,10 @@ function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
 
 interface Props {
   tournament: TournamentDetailType;
+  isAuthenticated: boolean;
 }
 
-export default function TournamentDetail({ tournament: t }: Props) {
+export default function TournamentDetail({ tournament: t, isAuthenticated }: Props) {
   const spotsLeft = t.max_participants - t.current_participants;
   const spotsRatio = t.max_participants > 0 ? spotsLeft / t.max_participants : 0;
   const minFee = getMinFeeCents(t.entry_fees);
@@ -389,11 +390,15 @@ export default function TournamentDetail({ tournament: t }: Props) {
               </div>
 
               {/* CTA */}
-              {spotsLeft > 0 ? (
+              {spotsLeft === 0 ? (
+                <button className="btn-primary w-full opacity-50" disabled>
+                  Full
+                </button>
+              ) : isAuthenticated ? (
                 <button className="btn-primary w-full">Register Now</button>
               ) : (
                 <button className="btn-primary w-full opacity-50" disabled>
-                  Full
+                  Log In / Sign Up to Register
                 </button>
               )}
 

--- a/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
+++ b/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
@@ -56,9 +56,9 @@ const base: TournamentDetailType = {
   },
 };
 
-function render(overrides: Partial<TournamentDetailType> = {}): string {
+function render(overrides: Partial<TournamentDetailType> = {}, isAuthenticated = false): string {
   return renderToStaticMarkup(
-    <TournamentDetail tournament={{ ...base, ...overrides }} />,
+    <TournamentDetail tournament={{ ...base, ...overrides }} isAuthenticated={isAuthenticated} />,
   );
 }
 
@@ -335,5 +335,33 @@ describe("register card", () => {
   it("shows registration deadline", () => {
     const html = render();
     expect(html).toContain("28 May");
+  });
+});
+
+// ── CTA button auth states ────────────────────────────────────
+
+describe("CTA button auth states", () => {
+  it("shows 'Register Now' when authenticated and spots available", () => {
+    const html = render({}, true);
+    expect(html).toContain("Register Now");
+  });
+
+  it("shows 'Log In / Sign Up to Register' when not authenticated and spots available", () => {
+    const html = render({}, false);
+    expect(html).toContain("Log In / Sign Up to Register");
+  });
+
+  it("disables CTA button when not authenticated", () => {
+    const html = render({}, false);
+    expect(html).toContain("disabled");
+  });
+
+  it("shows 'Full' and disables button when no spots remain, regardless of auth", () => {
+    const htmlAuth = render({ max_participants: 100, current_participants: 100 }, true);
+    const htmlNoAuth = render({ max_participants: 100, current_participants: 100 }, false);
+    expect(htmlAuth).toContain("Full");
+    expect(htmlAuth).toContain("disabled");
+    expect(htmlNoAuth).toContain("Full");
+    expect(htmlNoAuth).toContain("disabled");
   });
 });

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -5,6 +5,7 @@ import NavBar from "@/app/_components/NavBar";
 import TournamentDetail from "./_components/TournamentDetail";
 import DetailSkeleton from "./_components/DetailSkeleton";
 import type { TournamentDetail as TournamentDetailType } from "./types";
+import { createClient } from "@/lib/supabase/server";
 
 export const revalidate = 60;
 
@@ -41,7 +42,10 @@ export async function TournamentDetailData({ id }: { id: string }) {
     return null;
   }
 
-  return <TournamentDetail tournament={tournament} />;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  return <TournamentDetail tournament={tournament} isAuthenticated={!!user} />;
 }
 
 export default async function TournamentDetailPage({


### PR DESCRIPTION
Add auth-aware registration CTA button to tournament detail page.

- "Register Now" when user is authenticated and spots are available
- "Log In / Sign Up to Register" (disabled) when not authenticated
- "Full" (disabled) when no spots remain

Closes #28

Generated with [Claude Code](https://claude.ai/code)