### PR TITLE
feat: SEO meta tags and Open Graph for tournament pages

### DIFF
--- a/app/__tests__/layout.test.ts
+++ b/app/__tests__/layout.test.ts
@@ -45,7 +45,10 @@ describe("generateMetadata", () => {
   it("returns the exact title", async () => {
     mockGet.mockReturnValue("example.com");
     const meta = await generateMetadata();
-    expect(meta.title).toBe("MY Chess Tour — Coming Soon");
+    expect(meta.title).toEqual({
+      default: "MY Chess Tour — Coming Soon",
+      template: "%s | MY Chess Tour",
+    });
   });
 
   it("returns the exact description", async () => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,10 @@ export async function generateMetadata(): Promise<Metadata> {
   const noindex = host.startsWith("admin.") || host.startsWith("staging");
 
   return {
-    title: "MY Chess Tour — Coming Soon",
+    title: {
+      default: "MY Chess Tour — Coming Soon",
+      template: "%s | MY Chess Tour",
+    },
     description:
       "Malaysia's premier competitive chess circuit. Join the waitlist.",
     robots: noindex
@@ -30,6 +33,19 @@ export async function generateMetadata(): Promise<Metadata> {
       : { index: true, follow: true },
     icons: {
       icon: "/mct-logo-square.svg",
+    },
+    openGraph: {
+      title: "MY Chess Tour — Coming Soon",
+      description:
+        "Malaysia's premier competitive chess circuit. Join the waitlist.",
+      type: "website",
+      siteName: "MY Chess Tour",
+    },
+    twitter: {
+      card: "summary",
+      title: "MY Chess Tour — Coming Soon",
+      description:
+        "Malaysia's premier competitive chess circuit. Join the waitlist.",
     },
   };
 }

--- a/app/tournaments/[id]/__tests__/page.test.ts
+++ b/app/tournaments/[id]/__tests__/page.test.ts
@@ -2,8 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mocks ─────────────────────────────────────────────────────
 
+const mockHeadersGet = vi.hoisted(() =>
+  vi.fn().mockReturnValue("localhost:3000"),
+);
+
 vi.mock("next/headers", () => ({
-  headers: vi.fn().mockResolvedValue(new Map([["host", "localhost:3000"]])),
+  headers: vi.fn().mockResolvedValue({ get: mockHeadersGet }),
 }));
 
 const mockNotFound = vi.hoisted(() => vi.fn());
@@ -76,6 +80,7 @@ describe("TournamentDetailPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     globalThis.fetch = mockFetch;
+    mockHeadersGet.mockReturnValue("localhost:3000");
   });
 
   it("renders a non-null React element", async () => {
@@ -98,6 +103,7 @@ describe("TournamentDetailData", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     globalThis.fetch = mockFetch;
+    mockHeadersGet.mockReturnValue("localhost:3000");
   });
 
   it("returns a React element when tournament is found", async () => {
@@ -140,5 +146,147 @@ describe("TournamentDetailData", () => {
     await TournamentDetailData({ id: "t1" });
 
     expect(mockNotFound).toHaveBeenCalled();
+  });
+});
+
+describe("generateMetadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = mockFetch;
+    mockHeadersGet.mockReturnValue("localhost:3000");
+  });
+
+  it("returns Tournament Not Found title when tournament does not exist", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404 });
+
+    const { generateMetadata } = await import("../page");
+    const result = await generateMetadata({
+      params: Promise.resolve({ id: "nonexistent" }),
+    });
+
+    expect(result).toEqual({ title: "Tournament Not Found" });
+  });
+
+  it("uses tournament name as title when tournament exists", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeTournamentPayload(),
+    });
+
+    const { generateMetadata } = await import("../page");
+    const result = await generateMetadata({
+      params: Promise.resolve({ id: "t1" }),
+    });
+
+    expect(result.title).toBe("KL Open Rapid Championship 2026");
+  });
+
+  it("uses existing description when tournament has a non-empty description", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () =>
+        makeTournamentPayload({ description: "Custom tournament description." }),
+    });
+
+    const { generateMetadata } = await import("../page");
+    const result = await generateMetadata({
+      params: Promise.resolve({ id: "t1" }),
+    });
+
+    expect(result.description).toBe("Custom tournament description.");
+  });
+
+  it("builds auto description with FIDE and MCF labels when both are rated", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () =>
+        makeTournamentPayload({
+          description: "",
+          is_fide_rated: true,
+          is_mcf_rated: true,
+        }),
+    });
+
+    const { generateMetadata } = await import("../page");
+    const result = await generateMetadata({
+      params: Promise.resolve({ id: "t1" }),
+    });
+
+    expect(result.description).toContain(" FIDE rated.");
+    expect(result.description).toContain(" MCF rated.");
+  });
+
+  it("builds auto description without rating labels when neither is rated", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () =>
+        makeTournamentPayload({
+          description: "",
+          is_fide_rated: false,
+          is_mcf_rated: false,
+        }),
+    });
+
+    const { generateMetadata } = await import("../page");
+    const result = await generateMetadata({
+      params: Promise.resolve({ id: "t1" }),
+    });
+
+    expect(result.description).not.toContain("FIDE rated");
+    expect(result.description).not.toContain("MCF rated");
+  });
+
+  it("includes openGraph article type and twitter summary card when tournament exists", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeTournamentPayload(),
+    });
+
+    const { generateMetadata } = await import("../page");
+    const result = await generateMetadata({
+      params: Promise.resolve({ id: "t1" }),
+    });
+
+    expect(result.openGraph?.type).toBe("article");
+    expect(result.openGraph?.siteName).toBe("MY Chess Tour");
+    expect(result.twitter?.card).toBe("summary");
+  });
+
+  it("uses https protocol when host is not localhost", async () => {
+    mockHeadersGet.mockReturnValue("mychessour.com");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeTournamentPayload(),
+    });
+
+    const { generateMetadata } = await import("../page");
+    const result = await generateMetadata({
+      params: Promise.resolve({ id: "t1" }),
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("https://mychessour.com"),
+      expect.any(Object),
+    );
+    expect(result.title).toBe("KL Open Rapid Championship 2026");
+  });
+
+  it("falls back to localhost:3000 when host header is absent", async () => {
+    mockHeadersGet.mockReturnValue(null);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeTournamentPayload(),
+    });
+
+    const { generateMetadata } = await import("../page");
+    const result = await generateMetadata({
+      params: Promise.resolve({ id: "t1" }),
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("http://localhost:3000"),
+      expect.any(Object),
+    );
+    expect(result.title).toBe("KL Open Rapid Championship 2026");
   });
 });

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import NavBar from "@/app/_components/NavBar";
 import TournamentDetail from "./_components/TournamentDetail";
 import DetailSkeleton from "./_components/DetailSkeleton";
@@ -8,7 +9,9 @@ import type { TournamentDetail as TournamentDetailType } from "./types";
 
 export const revalidate = 60;
 
-export async function TournamentDetailData({ id }: { id: string }) {
+async function fetchTournament(
+  id: string
+): Promise<TournamentDetailType | null> {
   const headersList = await headers();
   const host = headersList.get("host") ?? "localhost:3000";
   const protocol =
@@ -16,25 +19,67 @@ export async function TournamentDetailData({ id }: { id: string }) {
       ? "http"
       : "https";
 
-  let tournament: TournamentDetailType | null = null;
-
   try {
     const res = await fetch(`${protocol}://${host}/api/v1/tournaments/${id}`, {
       next: { revalidate: 60 },
     });
-
-    if (!res.ok) {
-      notFound();
-      return null;
-    }
-
+    if (!res.ok) return null;
     const json = await res.json();
-    console.log(json);
-    tournament = json.data ?? null;
+    return json.data ?? null;
   } catch {
-    notFound();
     return null;
   }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const tournament = await fetchTournament(id);
+
+  if (!tournament) {
+    return {
+      title: "Tournament Not Found",
+    };
+  }
+
+  const startDate = new Date(tournament.start_date).toLocaleDateString(
+    "en-MY",
+    { day: "numeric", month: "long", year: "numeric" }
+  );
+  const endDate = new Date(tournament.end_date).toLocaleDateString("en-MY", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  const description =
+    tournament.description?.trim() ||
+    `${tournament.name} — a ${tournament.format.type} chess tournament held at ${tournament.venue_name}, ${tournament.state} from ${startDate} to ${endDate}.${tournament.is_fide_rated ? " FIDE rated." : ""}${tournament.is_mcf_rated ? " MCF rated." : ""}`;
+
+  const ogTitle = `${tournament.name} | MY Chess Tour`;
+
+  return {
+    title: tournament.name,
+    description,
+    openGraph: {
+      title: ogTitle,
+      description,
+      type: "article",
+      siteName: "MY Chess Tour",
+    },
+    twitter: {
+      card: "summary",
+      title: ogTitle,
+      description,
+    },
+  };
+}
+
+export async function TournamentDetailData({ id }: { id: string }) {
+  const tournament = await fetchTournament(id);
 
   if (!tournament) {
     notFound();

--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -1,11 +1,31 @@
 import { Suspense } from "react";
 import { headers } from "next/headers";
+import type { Metadata } from "next";
 import NavBar from "@/app/_components/NavBar";
 import TournamentsClient from "./_components/TournamentsClient";
 import TournamentsGridSkeleton from "./_components/TournamentsGridSkeleton";
 import type { Tournament } from "./types";
 
 export const revalidate = 60;
+
+export const metadata: Metadata = {
+  title: "Tournaments",
+  description:
+    "Browse upcoming and ongoing chess tournaments across Malaysia. Find events by date, location, and format.",
+  openGraph: {
+    title: "Tournaments | MY Chess Tour",
+    description:
+      "Browse upcoming and ongoing chess tournaments across Malaysia. Find events by date, location, and format.",
+    type: "website",
+    siteName: "MY Chess Tour",
+  },
+  twitter: {
+    card: "summary",
+    title: "Tournaments | MY Chess Tour",
+    description:
+      "Browse upcoming and ongoing chess tournaments across Malaysia. Find events by date, location, and format.",
+  },
+};
 
 async function TournamentsData() {
   const headersList = await headers();


### PR DESCRIPTION
Implements SEO meta tags and Open Graph support for tournament detail and listing pages.

- Dynamic `generateMetadata` on tournament detail page with title, description, og:title, og:description, og:type, og:siteName, and twitter:card
- Static metadata on tournaments listing page
- Root layout title template and default OG/Twitter Card fallbacks

Closes #30

Generated with [Claude Code](https://claude.ai/code)