### PR TITLE
review and fix all API endpoints for issue #224

### DIFF
--- a/src/app/api/v1/auth/callback/__tests__/route.test.ts
+++ b/src/app/api/v1/auth/callback/__tests__/route.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   redirect: vi.fn(),
 }));
 
-vi.mock("@/lib/supabase/server", () => ({
+vi.mock("@/services/supabase/server", () => ({
   createClient: vi.fn(() =>
     Promise.resolve({ auth: { exchangeCodeForSession: mocks.exchangeCodeForSession } })
   ),

--- a/src/app/api/v1/auth/login/__tests__/route.test.ts
+++ b/src/app/api/v1/auth/login/__tests__/route.test.ts
@@ -9,7 +9,7 @@ vi.mock("next/headers", () => ({
 
 const mockSignInWithPassword = vi.fn();
 
-vi.mock("@/lib/supabase/server", () => ({
+vi.mock("@/services/supabase/server", () => ({
   createClient: vi.fn(() =>
     Promise.resolve({ auth: { signInWithPassword: mockSignInWithPassword } })
   ),
@@ -86,7 +86,7 @@ describe("POST /api/auth/login", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/invalid json/i);
+    expect(json.error.message).toMatch(/invalid json/i);
   });
 
   it("returns 400 listing all missing required fields", async () => {
@@ -94,8 +94,8 @@ describe("POST /api/auth/login", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/email/);
-    expect(json.error).toMatch(/password/);
+    expect(json.error.message).toMatch(/email/);
+    expect(json.error.message).toMatch(/password/);
   });
 
   it("returns 400 listing only the missing fields", async () => {
@@ -103,8 +103,8 @@ describe("POST /api/auth/login", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/password/);
-    expect(json.error).not.toMatch(/email/);
+    expect(json.error.message).toMatch(/password/);
+    expect(json.error.message).not.toMatch(/email/);
   });
 
   it("returns 400 for an invalid email format", async () => {
@@ -112,7 +112,7 @@ describe("POST /api/auth/login", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/invalid email/i);
+    expect(json.error.message).toMatch(/invalid email/i);
   });
 
   // --- Supabase error handling ----------------------------------------------
@@ -127,7 +127,7 @@ describe("POST /api/auth/login", () => {
     const json = await res.json();
 
     expect(res.status).toBe(401);
-    expect(json.error).toMatch(/invalid email or password/i);
+    expect(json.error.message).toMatch(/invalid email or password/i);
   });
 
   it("returns 403 when email is not confirmed", async () => {
@@ -140,7 +140,7 @@ describe("POST /api/auth/login", () => {
     const json = await res.json();
 
     expect(res.status).toBe(403);
-    expect(json.error).toMatch(/email not confirmed/i);
+    expect(json.error.message).toMatch(/email not confirmed/i);
   });
 
   it("returns 400 for other Supabase errors", async () => {
@@ -153,6 +153,6 @@ describe("POST /api/auth/login", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toBe("Something went wrong");
+    expect(json.error.message).toBe("Something went wrong");
   });
 });

--- a/src/app/api/v1/auth/login/route.ts
+++ b/src/app/api/v1/auth/login/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: NextRequest) {
     body = await request.json();
   } catch {
     return NextResponse.json(
-      { error: "Invalid JSON body" },
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body" } },
       { status: 400 }
     );
   }
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
 
   if (missing.length > 0) {
     return NextResponse.json(
-      { error: `Missing required fields: ${missing.join(", ")}` },
+      { error: { code: "VALIDATION_ERROR", message: `Missing required fields: ${missing.join(", ")}` } },
       { status: 400 }
     );
   }
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(email)) {
     return NextResponse.json(
-      { error: "Invalid email format" },
+      { error: { code: "VALIDATION_ERROR", message: "Invalid email format" } },
       { status: 400 }
     );
   }
@@ -51,19 +51,22 @@ export async function POST(request: NextRequest) {
   if (error) {
     if (error.message?.toLowerCase().includes("invalid login credentials")) {
       return NextResponse.json(
-        { error: "Invalid email or password" },
+        { error: { code: "UNAUTHORIZED", message: "Invalid email or password" } },
         { status: 401 }
       );
     }
 
     if (error.message?.toLowerCase().includes("email not confirmed")) {
       return NextResponse.json(
-        { error: "Email not confirmed. Please check your inbox." },
+        { error: { code: "FORBIDDEN", message: "Email not confirmed. Please check your inbox." } },
         { status: 403 }
       );
     }
 
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 400 }
+    );
   }
 
   return NextResponse.json(

--- a/src/app/api/v1/auth/logout/__tests__/route.test.ts
+++ b/src/app/api/v1/auth/logout/__tests__/route.test.ts
@@ -8,7 +8,7 @@ vi.mock("next/headers", () => ({
 
 const mockSignOut = vi.fn();
 
-vi.mock("@/lib/supabase/server", () => ({
+vi.mock("@/services/supabase/server", () => ({
   createClient: vi.fn(() =>
     Promise.resolve({ auth: { signOut: mockSignOut } })
   ),
@@ -45,7 +45,7 @@ describe("POST /api/auth/logout", () => {
 
   // --- Supabase error handling ----------------------------------------------
 
-  it("returns 400 when Supabase signOut fails", async () => {
+  it("returns 500 when Supabase signOut fails", async () => {
     mockSignOut.mockResolvedValue({
       error: { message: "Something went wrong" },
     });
@@ -53,7 +53,7 @@ describe("POST /api/auth/logout", () => {
     const res = await POST();
     const json = await res.json();
 
-    expect(res.status).toBe(400);
-    expect(json.error).toBe("Something went wrong");
+    expect(res.status).toBe(500);
+    expect(json.error.message).toBe("Something went wrong");
   });
 });

--- a/src/app/api/v1/auth/logout/route.ts
+++ b/src/app/api/v1/auth/logout/route.ts
@@ -7,7 +7,10 @@ export async function POST() {
   const { error } = await supabase.auth.signOut();
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 500 }
+    );
   }
 
   return NextResponse.json(

--- a/src/app/api/v1/auth/signup/__tests__/route.test.ts
+++ b/src/app/api/v1/auth/signup/__tests__/route.test.ts
@@ -13,7 +13,7 @@ vi.mock("bcryptjs", () => ({
 
 const mockSignUp = vi.fn();
 
-vi.mock("@/lib/supabase/server", () => ({
+vi.mock("@/services/supabase/server", () => ({
   createClient: vi.fn(() =>
     Promise.resolve({ auth: { signUp: mockSignUp } })
   ),
@@ -99,7 +99,7 @@ describe("POST /api/auth/signup", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/invalid json/i);
+    expect(json.error.message).toMatch(/invalid json/i);
   });
 
   it("returns 400 listing all missing required fields", async () => {
@@ -107,10 +107,10 @@ describe("POST /api/auth/signup", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/email/);
-    expect(json.error).toMatch(/password/);
-    expect(json.error).toMatch(/first_name/);
-    expect(json.error).toMatch(/last_name/);
+    expect(json.error.message).toMatch(/email/);
+    expect(json.error.message).toMatch(/password/);
+    expect(json.error.message).toMatch(/first_name/);
+    expect(json.error.message).toMatch(/last_name/);
   });
 
   it("returns 400 listing only the missing fields", async () => {
@@ -120,10 +120,10 @@ describe("POST /api/auth/signup", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/last_name/);
-    expect(json.error).not.toMatch(/email/);
-    expect(json.error).not.toMatch(/password/);
-    expect(json.error).not.toMatch(/first_name/);
+    expect(json.error.message).toMatch(/last_name/);
+    expect(json.error.message).not.toMatch(/email/);
+    expect(json.error.message).not.toMatch(/password/);
+    expect(json.error.message).not.toMatch(/first_name/);
   });
 
   it("returns 400 for an invalid email format", async () => {
@@ -133,7 +133,7 @@ describe("POST /api/auth/signup", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/invalid email/i);
+    expect(json.error.message).toMatch(/invalid email/i);
   });
 
   it("returns 400 when password is shorter than 8 characters", async () => {
@@ -141,7 +141,7 @@ describe("POST /api/auth/signup", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/8 characters/i);
+    expect(json.error.message).toMatch(/8 characters/i);
   });
 
   // --- Supabase error handling ----------------------------------------------
@@ -156,7 +156,7 @@ describe("POST /api/auth/signup", () => {
     const json = await res.json();
 
     expect(res.status).toBe(409);
-    expect(json.error).toMatch(/already exists/i);
+    expect(json.error.message).toMatch(/already exists/i);
   });
 
   it("returns 409 when Supabase error message contains 'already registered'", async () => {
@@ -169,7 +169,7 @@ describe("POST /api/auth/signup", () => {
     const json = await res.json();
 
     expect(res.status).toBe(409);
-    expect(json.error).toMatch(/already exists/i);
+    expect(json.error.message).toMatch(/already exists/i);
   });
 
   it("returns 400 for other Supabase errors", async () => {
@@ -182,6 +182,6 @@ describe("POST /api/auth/signup", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toBe("Something went wrong");
+    expect(json.error.message).toBe("Something went wrong");
   });
 });

--- a/src/app/api/v1/auth/signup/request-code/__tests__/route.test.ts
+++ b/src/app/api/v1/auth/signup/request-code/__tests__/route.test.ts
@@ -16,15 +16,15 @@ const { mockMaybeSingle, mockEq, mockSelect, mockFrom, mockStoreVerificationCode
     return { mockMaybeSingle, mockEq, mockSelect, mockFrom, mockStoreVerificationCode, mockSendVerificationEmail };
   });
 
-vi.mock("@/lib/supabase/admin", () => ({
+vi.mock("@/services/supabase/admin", () => ({
   supabaseAdmin: { from: mockFrom },
 }));
 
-vi.mock("@/lib/redis", () => ({
+vi.mock("@/services/redis/redis", () => ({
   storeVerificationCode: mockStoreVerificationCode,
 }));
 
-vi.mock("@/lib/email", () => ({
+vi.mock("@/services/email/email", () => ({
   sendVerificationEmail: mockSendVerificationEmail,
 }));
 
@@ -103,7 +103,7 @@ describe("POST /api/v1/auth/signup/request-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/invalid json/i);
+    expect(json.error.message).toMatch(/invalid json/i);
   });
 
   it("returns 400 when email is missing", async () => {
@@ -111,7 +111,7 @@ describe("POST /api/v1/auth/signup/request-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/email is required/i);
+    expect(json.error.message).toMatch(/email is required/i);
   });
 
   it("returns 400 when email is not a string", async () => {
@@ -119,7 +119,15 @@ describe("POST /api/v1/auth/signup/request-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/email is required/i);
+    expect(json.error.message).toMatch(/email is required/i);
+  });
+
+  it("returns 400 for invalid email format", async () => {
+    const res = await POST(makeRequest({ email: "not-an-email" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error.message).toMatch(/invalid email format/i);
   });
 
   // --- Email-exists check ---------------------------------------------------
@@ -131,8 +139,8 @@ describe("POST /api/v1/auth/signup/request-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(409);
-    expect(json.code).toBe("EMAIL_EXISTS");
-    expect(json.error).toMatch(/already exists/i);
+    expect(json.error.code).toBe("EMAIL_EXISTS");
+    expect(json.error.message).toMatch(/already exists/i);
   });
 
   it("does not store or send code when email already exists", async () => {
@@ -159,7 +167,7 @@ describe("POST /api/v1/auth/signup/request-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(500);
-    expect(json.error).toMatch(/failed to validate email/i);
+    expect(json.error.message).toMatch(/failed to validate email/i);
   });
 
   it("returns 500 when Redis store fails", async () => {
@@ -169,7 +177,7 @@ describe("POST /api/v1/auth/signup/request-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(500);
-    expect(json.error).toMatch(/failed to store verification code/i);
+    expect(json.error.message).toMatch(/failed to store verification code/i);
   });
 
   it("returns 500 when sending email fails", async () => {
@@ -179,7 +187,7 @@ describe("POST /api/v1/auth/signup/request-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(500);
-    expect(json.error).toMatch(/failed to send verification email/i);
+    expect(json.error.message).toMatch(/failed to send verification email/i);
   });
 
   it("does not send email when Redis store fails", async () => {

--- a/src/app/api/v1/auth/signup/request-code/route.ts
+++ b/src/app/api/v1/auth/signup/request-code/route.ts
@@ -5,12 +5,12 @@ import { sendVerificationEmail } from "@/services/email/email";
 
 function generateCode(): string {
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  let code = "";
-  for (let i = 0; i < 6; i++) {
-    code += chars[Math.floor(Math.random() * chars.length)];
-  }
-  return code;
+  const bytes = new Uint8Array(6);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => chars[b % chars.length]).join("");
 }
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export async function POST(request: NextRequest) {
   let body: unknown;
@@ -18,32 +18,47 @@ export async function POST(request: NextRequest) {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body" } },
+      { status: 400 }
+    );
   }
 
   const { email } = body as { email?: string };
 
   if (!email || typeof email !== "string") {
-    return NextResponse.json({ error: "Email is required" }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Email is required" } },
+      { status: 400 }
+    );
+  }
+
+  const normalized = email.toLowerCase().trim();
+
+  if (!emailRegex.test(normalized)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid email format" } },
+      { status: 400 }
+    );
   }
 
   // Check if email already exists in public.users
   const { data: existing, error: dbError } = await supabaseAdmin
     .from("users")
     .select("id")
-    .eq("email", email.toLowerCase().trim())
+    .eq("email", normalized)
     .maybeSingle();
 
   if (dbError) {
     return NextResponse.json(
-      { error: "Failed to validate email" },
+      { error: { code: "INTERNAL_ERROR", message: "Failed to validate email" } },
       { status: 500 }
     );
   }
 
   if (existing) {
     return NextResponse.json(
-      { error: "An account with this email already exists", code: "EMAIL_EXISTS" },
+      { error: { code: "EMAIL_EXISTS", message: "An account with this email already exists" } },
       { status: 409 }
     );
   }
@@ -54,7 +69,7 @@ export async function POST(request: NextRequest) {
     await storeVerificationCode(email, code);
   } catch {
     return NextResponse.json(
-      { error: "Failed to store verification code" },
+      { error: { code: "INTERNAL_ERROR", message: "Failed to store verification code" } },
       { status: 500 }
     );
   }
@@ -63,7 +78,7 @@ export async function POST(request: NextRequest) {
     await sendVerificationEmail(email, code);
   } catch {
     return NextResponse.json(
-      { error: "Failed to send verification email" },
+      { error: { code: "INTERNAL_ERROR", message: "Failed to send verification email" } },
       { status: 500 }
     );
   }

--- a/src/app/api/v1/auth/signup/route.ts
+++ b/src/app/api/v1/auth/signup/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
     body = await request.json();
   } catch {
     return NextResponse.json(
-      { error: "Invalid JSON body" },
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body" } },
       { status: 400 }
     );
   }
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest) {
 
   if (missing.length > 0) {
     return NextResponse.json(
-      { error: `Missing required fields: ${missing.join(", ")}` },
+      { error: { code: "VALIDATION_ERROR", message: `Missing required fields: ${missing.join(", ")}` } },
       { status: 400 }
     );
   }
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(email)) {
     return NextResponse.json(
-      { error: "Invalid email format" },
+      { error: { code: "VALIDATION_ERROR", message: "Invalid email format" } },
       { status: 400 }
     );
   }
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
   // Password length validation
   if (password.length < 8) {
     return NextResponse.json(
-      { error: "Password must be at least 8 characters" },
+      { error: { code: "VALIDATION_ERROR", message: "Password must be at least 8 characters" } },
       { status: 400 }
     );
   }
@@ -82,12 +82,15 @@ export async function POST(request: NextRequest) {
       error.message?.toLowerCase().includes("already registered")
     ) {
       return NextResponse.json(
-        { error: "An account with this email already exists" },
+        { error: { code: "CONFLICT", message: "An account with this email already exists" } },
         { status: 409 }
       );
     }
 
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 400 }
+    );
   }
 
   // When email confirmation is enabled, identities is an empty array for

--- a/src/app/api/v1/auth/signup/verify-code/__tests__/route.test.ts
+++ b/src/app/api/v1/auth/signup/verify-code/__tests__/route.test.ts
@@ -215,7 +215,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/invalid json/i);
+    expect(json.error.message).toMatch(/invalid json/i);
   });
 
   it("returns 400 when email is missing", async () => {
@@ -224,7 +224,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/email is required/i);
+    expect(json.error.message).toMatch(/email is required/i);
   });
 
   it("returns 400 when code is missing", async () => {
@@ -233,7 +233,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/code is required/i);
+    expect(json.error.message).toMatch(/code is required/i);
   });
 
   it("returns 400 when password is missing", async () => {
@@ -242,7 +242,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/missing required registration fields/i);
+    expect(json.error.message).toMatch(/missing required registration fields/i);
   });
 
   it("returns 400 when firstName is missing", async () => {
@@ -251,7 +251,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/missing required registration fields/i);
+    expect(json.error.message).toMatch(/missing required registration fields/i);
   });
 
   it("returns 400 when lastName is missing", async () => {
@@ -260,7 +260,15 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toMatch(/missing required registration fields/i);
+    expect(json.error.message).toMatch(/missing required registration fields/i);
+  });
+
+  it("returns 400 when password is shorter than 8 characters", async () => {
+    const res = await POST(makeRequest({ ...validBody, password: "short" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error.message).toMatch(/8 characters/i);
   });
 
   // --- Code validation ------------------------------------------------------
@@ -272,7 +280,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(410);
-    expect(json.code).toBe("CODE_EXPIRED");
+    expect(json.error.code).toBe("CODE_EXPIRED");
   });
 
   it("returns 422 CODE_INVALID when code does not match", async () => {
@@ -282,7 +290,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(422);
-    expect(json.code).toBe("CODE_INVALID");
+    expect(json.error.code).toBe("CODE_INVALID");
   });
 
   it("does not call createUser when code is expired", async () => {
@@ -309,7 +317,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(409);
-    expect(json.code).toBe("EMAIL_EXISTS");
+    expect(json.error.code).toBe("EMAIL_EXISTS");
   });
 
   it("returns 409 EMAIL_EXISTS when error message contains 'already registered'", async () => {
@@ -322,7 +330,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(409);
-    expect(json.code).toBe("EMAIL_EXISTS");
+    expect(json.error.code).toBe("EMAIL_EXISTS");
   });
 
   it("returns 400 for other auth errors", async () => {
@@ -335,7 +343,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(400);
-    expect(json.error).toBe("Something went wrong");
+    expect(json.error.message).toBe("Something went wrong");
   });
 
   // --- Profile update errors ------------------------------------------------
@@ -347,7 +355,7 @@ describe("POST /api/v1/auth/signup/verify-code", () => {
     const json = await res.json();
 
     expect(res.status).toBe(500);
-    expect(json.error).toMatch(/failed to save profile/i);
+    expect(json.error.message).toMatch(/failed to save profile/i);
   });
 
   it("does not sign in when profile update fails", async () => {

--- a/src/app/api/v1/auth/signup/verify-code/route.ts
+++ b/src/app/api/v1/auth/signup/verify-code/route.ts
@@ -10,7 +10,10 @@ export async function POST(request: NextRequest) {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body" } },
+      { status: 400 }
+    );
   }
 
   const {
@@ -42,14 +45,27 @@ export async function POST(request: NextRequest) {
   };
 
   if (!email || typeof email !== "string") {
-    return NextResponse.json({ error: "Email is required" }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Email is required" } },
+      { status: 400 }
+    );
   }
   if (!code || typeof code !== "string") {
-    return NextResponse.json({ error: "Code is required" }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Code is required" } },
+      { status: 400 }
+    );
   }
   if (!password || !firstName || !lastName) {
     return NextResponse.json(
-      { error: "Missing required registration fields" },
+      { error: { code: "VALIDATION_ERROR", message: "Missing required registration fields" } },
+      { status: 400 }
+    );
+  }
+
+  if (password.length < 8) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Password must be at least 8 characters" } },
       { status: 400 }
     );
   }
@@ -58,14 +74,14 @@ export async function POST(request: NextRequest) {
 
   if (!stored) {
     return NextResponse.json(
-      { error: "Code has expired. Please request a new one.", code: "CODE_EXPIRED" },
+      { error: { code: "CODE_EXPIRED", message: "Code has expired. Please request a new one." } },
       { status: 410 }
     );
   }
 
   if (stored.toUpperCase() !== code.toUpperCase()) {
     return NextResponse.json(
-      { error: "Incorrect code. Please try again.", code: "CODE_INVALID" },
+      { error: { code: "CODE_INVALID", message: "Incorrect code. Please try again." } },
       { status: 422 }
     );
   }
@@ -92,11 +108,14 @@ export async function POST(request: NextRequest) {
       authError.message?.toLowerCase().includes("already registered")
     ) {
       return NextResponse.json(
-        { error: "An account with this email already exists", code: "EMAIL_EXISTS" },
+        { error: { code: "EMAIL_EXISTS", message: "An account with this email already exists" } },
         { status: 409 }
       );
     }
-    return NextResponse.json({ error: authError.message }, { status: 400 });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: authError.message } },
+      { status: 400 }
+    );
   }
 
   const userId = authData.user.id;
@@ -117,7 +136,7 @@ export async function POST(request: NextRequest) {
 
   if (profileError) {
     return NextResponse.json(
-      { error: "Account created but failed to save profile" },
+      { error: { code: "INTERNAL_ERROR", message: "Account created but failed to save profile" } },
       { status: 500 }
     );
   }

--- a/src/app/api/v1/tournaments/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/tournaments/[id]/__tests__/route.test.ts
@@ -29,13 +29,15 @@ const { mockTournamentBuilder, mockRegistrationsBuilder, mockFrom } =
     return { mockTournamentBuilder, mockRegistrationsBuilder, mockFrom };
   });
 
-vi.mock("@/lib/supabase/admin", () => ({
+vi.mock("@/services/supabase/admin", () => ({
   supabaseAdmin: { from: mockFrom },
 }));
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
+
+const VALID_UUID = "00000000-0000-0000-0000-000000000001";
 
 const mockOrganization = {
   id: "org-1",
@@ -49,7 +51,7 @@ const mockOrganization = {
 
 function makeTournament(overrides: Record<string, unknown> = {}) {
   return {
-    id: "tournament-1",
+    id: VALID_UUID,
     name: "KL Open Rapid 2026",
     description: "Annual rapid chess championship",
     venue_name: "Kuala Lumpur Convention Centre",
@@ -126,8 +128,8 @@ describe("GET /api/v1/tournaments/:id", () => {
     it("returns 200 with a data object for a valid published tournament", async () => {
       setTournamentResult(makeTournament());
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
 
@@ -140,13 +142,13 @@ describe("GET /api/v1/tournaments/:id", () => {
     it("shapes the tournament detail correctly", async () => {
       setTournamentResult(makeTournament());
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
       const item = json.data;
 
-      expect(item.id).toBe("tournament-1");
+      expect(item.id).toBe(VALID_UUID);
       expect(item.name).toBe("KL Open Rapid 2026");
       expect(item.description).toBe("Annual rapid chess championship");
       expect(item.venue).toEqual({
@@ -189,8 +191,8 @@ describe("GET /api/v1/tournaments/:id", () => {
     it("includes a nested organization object with full info", async () => {
       setTournamentResult(makeTournament());
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
       const org = json.data.organization;
@@ -206,8 +208,8 @@ describe("GET /api/v1/tournaments/:id", () => {
     it("does not expose raw organizations join or organization_id on the tournament item", async () => {
       setTournamentResult(makeTournament());
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
 
@@ -218,8 +220,8 @@ describe("GET /api/v1/tournaments/:id", () => {
     it("sets organization to null when organizations join is null", async () => {
       setTournamentResult(makeTournament({ organizations: null }));
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
 
@@ -229,8 +231,8 @@ describe("GET /api/v1/tournaments/:id", () => {
     it("sets prizes to null when prizes is null", async () => {
       setTournamentResult(makeTournament({ prizes: null }));
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
 
@@ -240,8 +242,8 @@ describe("GET /api/v1/tournaments/:id", () => {
     it("sets restrictions to null when restrictions is null", async () => {
       setTournamentResult(makeTournament({ restrictions: null }));
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
 
@@ -258,8 +260,8 @@ describe("GET /api/v1/tournaments/:id", () => {
       setTournamentResult(makeTournament());
       setRegistrationsCount(3);
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
 
@@ -270,8 +272,8 @@ describe("GET /api/v1/tournaments/:id", () => {
       setTournamentResult(makeTournament());
       setRegistrationsCount(null);
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
 
@@ -282,12 +284,12 @@ describe("GET /api/v1/tournaments/:id", () => {
       setTournamentResult(makeTournament());
       setRegistrationsCount(0);
 
-      await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
 
       const eqMock = mockRegistrationsBuilder.eq as ReturnType<typeof vi.fn>;
-      expect(eqMock).toHaveBeenCalledWith("tournament_id", "tournament-1");
+      expect(eqMock).toHaveBeenCalledWith("tournament_id", VALID_UUID);
       expect(eqMock).toHaveBeenCalledWith("status", "confirmed");
     });
   });
@@ -300,20 +302,20 @@ describe("GET /api/v1/tournaments/:id", () => {
     it("queries by id and status=published", async () => {
       setTournamentResult(makeTournament());
 
-      await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
 
       const eqMock = mockTournamentBuilder.eq as ReturnType<typeof vi.fn>;
-      expect(eqMock).toHaveBeenCalledWith("id", "tournament-1");
+      expect(eqMock).toHaveBeenCalledWith("id", VALID_UUID);
       expect(eqMock).toHaveBeenCalledWith("status", "published");
     });
 
     it("calls .single() on the tournament query", async () => {
       setTournamentResult(makeTournament());
 
-      await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
 
       const singleMock = mockTournamentBuilder.single as ReturnType<
@@ -328,16 +330,26 @@ describe("GET /api/v1/tournaments/:id", () => {
   // -------------------------------------------------------------------------
 
   describe("error handling", () => {
+    it("returns 400 for a non-UUID id", async () => {
+      const res = await GET(makeRequest("not-a-uuid"), {
+        params: Promise.resolve({ id: "not-a-uuid" }),
+      });
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error.message).toMatch(/invalid tournament id/i);
+    });
+
     it("returns 404 when tournament is not found", async () => {
       setTournamentResult(null, { code: "PGRST116", message: "No rows found" });
 
-      const res = await GET(makeRequest("nonexistent-id"), {
-        params: Promise.resolve({ id: "nonexistent-id" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
 
       expect(res.status).toBe(404);
-      expect(json.error).toBe("Tournament not found");
+      expect(json.error.message).toBe("Tournament not found");
     });
 
     it("returns 500 when Supabase returns a non-404 error", async () => {
@@ -346,13 +358,13 @@ describe("GET /api/v1/tournaments/:id", () => {
         message: "DB connection failed",
       });
 
-      const res = await GET(makeRequest("tournament-1"), {
-        params: Promise.resolve({ id: "tournament-1" }),
+      const res = await GET(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
       });
       const json = await res.json();
 
       expect(res.status).toBe(500);
-      expect(json.error).toBe("DB connection failed");
+      expect(json.error.message).toBe("DB connection failed");
     });
   });
 });

--- a/src/app/api/v1/tournaments/[id]/route.ts
+++ b/src/app/api/v1/tournaments/[id]/route.ts
@@ -35,11 +35,20 @@ interface TournamentRow {
   organizations: Organization[] | Organization;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid tournament ID" } },
+      { status: 400 },
+    );
+  }
 
   const [{ data: row, error }, { count: currentParticipants }] =
     await Promise.all([
@@ -66,11 +75,14 @@ export async function GET(
   if (error) {
     if (error.code === "PGRST116") {
       return NextResponse.json(
-        { error: "Tournament not found" },
+        { error: { code: "NOT_FOUND", message: "Tournament not found" } },
         { status: 404 },
       );
     }
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 500 },
+    );
   }
 
   const t = row as TournamentRow;

--- a/src/app/api/v1/tournaments/__tests__/route.test.ts
+++ b/src/app/api/v1/tournaments/__tests__/route.test.ts
@@ -22,7 +22,7 @@ const { mockTournamentsBuilder, mockRpc, mockFrom } = vi.hoisted(() => {
   return { mockTournamentsBuilder, mockRpc, mockFrom };
 });
 
-vi.mock("@/lib/supabase/admin", () => ({
+vi.mock("@/services/supabase/admin", () => ({
   supabaseAdmin: { from: mockFrom, rpc: mockRpc },
 }));
 
@@ -191,7 +191,7 @@ describe("GET /api/v1/tournaments", () => {
       const json = await res.json();
 
       expect(res.status).toBe(500);
-      expect(json.error).toBe("DB connection failed");
+      expect(json.error.message).toBe("DB connection failed");
     });
   });
 });

--- a/src/app/api/v1/tournaments/route.ts
+++ b/src/app/api/v1/tournaments/route.ts
@@ -36,7 +36,10 @@ export async function GET() {
     .order("start_date", { ascending: true });
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 500 }
+    );
   }
 
   const participantCounts: Record<string, number> = {};


### PR DESCRIPTION
- fix broken mock import paths in 7 of 8 test files (@/lib/ → @/services/)
- standardize error response format to { error: { code, message } } across all routes
- replace Math.random() with crypto.getRandomValues() for secure code generation
- add email format validation to request-code endpoint
- add password minimum-length validation to verify-code endpoint
- add UUID format validation to tournaments/:id endpoint
- fix logout error status from 400 to 500 (server-side failure)
- update all test assertions to match new error shape
- add new test for non-UUID tournament id (400), password too short (verify-code)