### PR TITLE
feat: server-side eligibility checks for tournament registration (#41)

### DIFF
--- a/src/app/api/v1/tournaments/[id]/register/__tests__/route.test.ts
+++ b/src/app/api/v1/tournaments/[id]/register/__tests__/route.test.ts
@@ -1,0 +1,604 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockTournamentBuilder,
+  mockProfileBuilder,
+  mockCapacityBuilder,
+  mockExistingBuilder,
+  mockInsertBuilder,
+  mockFrom,
+  mockGetUser,
+  resetRegCallCount,
+} = vi.hoisted(() => {
+  function makeBuilder(finalResult: {
+    data?: unknown;
+    count?: unknown;
+    error?: unknown;
+  }) {
+    const b: Record<string, unknown> = {};
+    for (const m of ["select", "eq", "in", "single", "maybeSingle", "insert"]) {
+      b[m] = vi.fn(() => b);
+    }
+    b.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return b;
+  }
+
+  const mockTournamentBuilder = makeBuilder({ data: null, error: null });
+  const mockProfileBuilder = makeBuilder({ data: null, error: null });
+  const mockCapacityBuilder = makeBuilder({ count: 0, error: null });
+  const mockExistingBuilder = makeBuilder({ data: null, error: null });
+  const mockInsertBuilder = makeBuilder({ data: null, error: null });
+
+  let regCallCount = 0;
+  const resetRegCallCount = () => {
+    regCallCount = 0;
+  };
+  const mockFrom = vi.fn((table: string) => {
+    if (table === "tournaments") return mockTournamentBuilder;
+    if (table === "player_profiles") return mockProfileBuilder;
+    if (table === "registrations") {
+      const builders = [mockCapacityBuilder, mockExistingBuilder, mockInsertBuilder];
+      return builders[regCallCount++] ?? mockInsertBuilder;
+    }
+    return makeBuilder({ data: null, error: null });
+  });
+
+  const mockGetUser = vi.fn();
+  return {
+    mockTournamentBuilder,
+    mockProfileBuilder,
+    mockCapacityBuilder,
+    mockExistingBuilder,
+    mockInsertBuilder,
+    mockFrom,
+    mockGetUser,
+    resetRegCallCount,
+  };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+import { POST } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_UUID = "00000000-0000-0000-0000-000000000001";
+const USER_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const FUTURE_DEADLINE = "2099-12-31T23:59:59Z";
+const PAST_DEADLINE = "2020-01-01T00:00:00Z";
+
+function makeTournament(overrides: Record<string, unknown> = {}) {
+  return {
+    id: VALID_UUID,
+    entry_fees: { standard: { amount_cents: 5000 }, additional: [] },
+    max_participants: 100,
+    registration_deadline: FUTURE_DEADLINE,
+    restrictions: null,
+    format: { type: "rapid", system: "swiss", rounds: 7 },
+    ...overrides,
+  };
+}
+
+function makeRegistration(status = "pending_payment") {
+  return {
+    id: "reg-uuid",
+    user_id: USER_ID,
+    tournament_id: VALID_UUID,
+    fee_tier: "standard",
+    status,
+    registered_at: "2026-01-01T00:00:00Z",
+    confirmed_at: null,
+    cancelled_at: null,
+    cancellation_reason: null,
+  };
+}
+
+function makeRequest(
+  id: string,
+  body: unknown = { fee_tier: "standard" },
+): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/tournaments/${id}/register`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers to configure mock return values
+// ---------------------------------------------------------------------------
+
+function setTournamentResult(data: unknown, error: unknown = null) {
+  (mockTournamentBuilder as Record<string, unknown>).then = (
+    r: (v: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(r);
+}
+
+function setCapacityResult(count: number | null, error: unknown = null) {
+  (mockCapacityBuilder as Record<string, unknown>).then = (
+    r: (v: unknown) => unknown,
+  ) => Promise.resolve({ count, error }).then(r);
+}
+
+function setProfileResult(data: unknown, error: unknown = null) {
+  (mockProfileBuilder as Record<string, unknown>).then = (
+    r: (v: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(r);
+}
+
+function setExistingResult(data: unknown, error: unknown = null) {
+  (mockExistingBuilder as Record<string, unknown>).then = (
+    r: (v: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(r);
+}
+
+function setInsertResult(data: unknown, error: unknown = null) {
+  (mockInsertBuilder as Record<string, unknown>).then = (
+    r: (v: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(r);
+}
+
+function setUser(id = USER_ID) {
+  mockGetUser.mockResolvedValue({ data: { user: { id } }, error: null });
+}
+
+function setNoUser() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/tournaments/:id/register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRegCallCount();
+    setUser();
+    setTournamentResult(makeTournament());
+    setCapacityResult(0);
+    setProfileResult(null);
+    setExistingResult(null);
+    setInsertResult(makeRegistration());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Input validation
+  // -------------------------------------------------------------------------
+
+  describe("input validation", () => {
+    it("returns 400 for a non-UUID tournament id", async () => {
+      const res = await POST(makeRequest("not-a-uuid"), {
+        params: Promise.resolve({ id: "not-a-uuid" }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.message).toMatch(/invalid tournament id/i);
+    });
+
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 400 when the request body is not valid JSON", async () => {
+      const req = new NextRequest(
+        `http://localhost/api/v1/tournaments/${VALID_UUID}/register`,
+        { method: "POST", body: "not json" },
+      );
+      const res = await POST(req, {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 when fee_tier is missing", async () => {
+      const res = await POST(makeRequest(VALID_UUID, {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.message).toMatch(/fee_tier/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tournament lookup
+  // -------------------------------------------------------------------------
+
+  describe("tournament lookup", () => {
+    it("returns 404 when tournament is not found", async () => {
+      setTournamentResult(null, { code: "PGRST116", message: "Not found" });
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 500 on a non-404 database error", async () => {
+      setTournamentResult(null, { code: "500", message: "DB error" });
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Deadline check
+  // -------------------------------------------------------------------------
+
+  describe("deadline check", () => {
+    it("returns 422 when registration deadline has passed", async () => {
+      setTournamentResult(
+        makeTournament({ registration_deadline: PAST_DEADLINE }),
+      );
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(422);
+      const json = await res.json();
+      expect(json.error.code).toBe("REGISTRATION_CLOSED");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Capacity check
+  // -------------------------------------------------------------------------
+
+  describe("capacity check", () => {
+    it("returns 422 when tournament is already at capacity", async () => {
+      setTournamentResult(makeTournament({ max_participants: 10 }));
+      setCapacityResult(10);
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(422);
+      const json = await res.json();
+      expect(json.error.code).toBe("CAPACITY_FULL");
+    });
+
+    it("allows registration when under capacity", async () => {
+      setTournamentResult(makeTournament({ max_participants: 10 }));
+      setCapacityResult(9);
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(201);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Fee tier validation
+  // -------------------------------------------------------------------------
+
+  describe("fee tier validation", () => {
+    it("returns 400 when fee_tier does not match any available tier", async () => {
+      const res = await POST(
+        makeRequest(VALID_UUID, { fee_tier: "nonexistent" }),
+        { params: Promise.resolve({ id: VALID_UUID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+    });
+
+    it("returns 400 when the selected tier has expired", async () => {
+      setTournamentResult(
+        makeTournament({
+          entry_fees: {
+            standard: { amount_cents: 5000 },
+            additional: [
+              {
+                type: "early_bird",
+                amount_cents: 3500,
+                valid_until: "2020-01-01T00:00:00Z",
+              },
+            ],
+          },
+        }),
+      );
+      const res = await POST(
+        makeRequest(VALID_UUID, { fee_tier: "early_bird" }),
+        { params: Promise.resolve({ id: VALID_UUID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+      expect(json.error.message).toMatch(/expired/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tournament-level restriction checks
+  // -------------------------------------------------------------------------
+
+  describe("tournament restrictions", () => {
+    const baseProfile = {
+      date_of_birth: null,
+      gender: "male",
+      is_oku: false,
+      title: null,
+      fide_rating: null,
+      national_rating: null,
+    };
+
+    describe("title restriction", () => {
+      it("returns 422 when tournament requires titled players and player has no title", async () => {
+        setTournamentResult(
+          makeTournament({ restrictions: { titles: ["GM", "IM"] } }),
+        );
+        setProfileResult({ ...baseProfile, title: null });
+        const res = await POST(makeRequest(VALID_UUID), {
+          params: Promise.resolve({ id: VALID_UUID }),
+        });
+        expect(res.status).toBe(422);
+        const json = await res.json();
+        expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+      });
+
+      it("allows registration when player has a required title", async () => {
+        setTournamentResult(
+          makeTournament({ restrictions: { titles: ["GM", "IM"] } }),
+        );
+        setProfileResult({ ...baseProfile, title: "GM" });
+        const res = await POST(makeRequest(VALID_UUID), {
+          params: Promise.resolve({ id: VALID_UUID }),
+        });
+        expect(res.status).toBe(201);
+      });
+    });
+
+    describe("rating restriction", () => {
+      it("returns 422 when player rating is below the tournament minimum", async () => {
+        setTournamentResult(
+          makeTournament({ restrictions: { min_rating: 2000 } }),
+        );
+        setProfileResult({ ...baseProfile, fide_rating: { rapid: 1800 } });
+        const res = await POST(makeRequest(VALID_UUID), {
+          params: Promise.resolve({ id: VALID_UUID }),
+        });
+        expect(res.status).toBe(422);
+        const json = await res.json();
+        expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+        expect(json.error.message).toContain("2000");
+      });
+
+      it("returns 422 when player rating exceeds the tournament maximum", async () => {
+        setTournamentResult(
+          makeTournament({ restrictions: { max_rating: 1500 } }),
+        );
+        setProfileResult({ ...baseProfile, fide_rating: { rapid: 1800 } });
+        const res = await POST(makeRequest(VALID_UUID), {
+          params: Promise.resolve({ id: VALID_UUID }),
+        });
+        expect(res.status).toBe(422);
+        const json = await res.json();
+        expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+        expect(json.error.message).toContain("1500");
+      });
+
+      it("allows registration when player rating is within range", async () => {
+        setTournamentResult(
+          makeTournament({ restrictions: { min_rating: 1000, max_rating: 2000 } }),
+        );
+        setProfileResult({ ...baseProfile, fide_rating: { rapid: 1500 } });
+        const res = await POST(makeRequest(VALID_UUID), {
+          params: Promise.resolve({ id: VALID_UUID }),
+        });
+        expect(res.status).toBe(201);
+      });
+    });
+
+    describe("age restriction", () => {
+      it("returns 422 when player has no DOB and tournament has an age restriction", async () => {
+        setTournamentResult(
+          makeTournament({ restrictions: { max_age: 18 } }),
+        );
+        setProfileResult({ ...baseProfile, date_of_birth: null });
+        const res = await POST(makeRequest(VALID_UUID), {
+          params: Promise.resolve({ id: VALID_UUID }),
+        });
+        expect(res.status).toBe(422);
+        const json = await res.json();
+        expect(json.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 422 when player exceeds the tournament max_age", async () => {
+        setTournamentResult(
+          makeTournament({ restrictions: { max_age: 17 } }),
+        );
+        // Born 2008-05-12 → age 18 at 2026-05-12
+        setProfileResult({ ...baseProfile, date_of_birth: "2008-05-12" });
+        const res = await POST(makeRequest(VALID_UUID), {
+          params: Promise.resolve({ id: VALID_UUID }),
+        });
+        expect(res.status).toBe(422);
+        const json = await res.json();
+        expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+      });
+
+      it("returns 422 when player is below the tournament min_age", async () => {
+        setTournamentResult(
+          makeTournament({ restrictions: { min_age: 19 } }),
+        );
+        // Born 2008-05-12 → age 18 at 2026-05-12
+        setProfileResult({ ...baseProfile, date_of_birth: "2008-05-12" });
+        const res = await POST(makeRequest(VALID_UUID), {
+          params: Promise.resolve({ id: VALID_UUID }),
+        });
+        expect(res.status).toBe(422);
+        const json = await res.json();
+        expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Fee-tier eligibility
+  // -------------------------------------------------------------------------
+
+  describe("fee-tier eligibility", () => {
+    it("returns 400 when a female-only tier is selected by a male player", async () => {
+      setTournamentResult(
+        makeTournament({
+          entry_fees: {
+            standard: { amount_cents: 5000 },
+            additional: [
+              { type: "female", amount_cents: 3000, gender: "female" },
+            ],
+          },
+        }),
+      );
+      setProfileResult({
+        date_of_birth: null,
+        gender: "male",
+        is_oku: false,
+        title: null,
+        fide_rating: null,
+        national_rating: null,
+      });
+      const res = await POST(
+        makeRequest(VALID_UUID, { fee_tier: "female" }),
+        { params: Promise.resolve({ id: VALID_UUID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+    });
+
+    it("returns 400 when an OKU tier is selected by a non-OKU player", async () => {
+      setTournamentResult(
+        makeTournament({
+          entry_fees: {
+            standard: { amount_cents: 5000 },
+            additional: [{ type: "oku", amount_cents: 2000, oku: true }],
+          },
+        }),
+      );
+      setProfileResult({
+        date_of_birth: null,
+        gender: "male",
+        is_oku: false,
+        title: null,
+        fide_rating: null,
+        national_rating: null,
+      });
+      const res = await POST(
+        makeRequest(VALID_UUID, { fee_tier: "oku" }),
+        { params: Promise.resolve({ id: VALID_UUID }) },
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Duplicate registration
+  // -------------------------------------------------------------------------
+
+  describe("duplicate registration", () => {
+    it("returns 200 with existing registration when status is confirmed", async () => {
+      setExistingResult(makeRegistration("confirmed"));
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.data.status).toBe("confirmed");
+    });
+
+    it("returns 200 with existing registration when status is pending_payment", async () => {
+      setExistingResult(makeRegistration("pending_payment"));
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 409 when existing registration has a non-active status", async () => {
+      setExistingResult(makeRegistration("cancelled_payment"));
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(409);
+      const json = await res.json();
+      expect(json.error.code).toBe("ALREADY_REGISTERED");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Insert
+  // -------------------------------------------------------------------------
+
+  describe("insert", () => {
+    it("returns 201 with registration data on success", async () => {
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json.data.fee_tier).toBe("standard");
+      expect(json.data.status).toBe("pending_payment");
+    });
+
+    it("returns 422 when insert fails due to tournament capacity trigger", async () => {
+      setInsertResult(null, {
+        code: "P0001",
+        message: "Tournament is full (100 / 100 participants)",
+      });
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(422);
+      const json = await res.json();
+      expect(json.error.code).toBe("CAPACITY_FULL");
+    });
+
+    it("returns 500 on an unexpected insert error", async () => {
+      setInsertResult(null, { code: "23505", message: "Unexpected DB error" });
+      const res = await POST(makeRequest(VALID_UUID), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+  });
+});

--- a/src/app/api/v1/tournaments/[id]/register/__tests__/validators.test.ts
+++ b/src/app/api/v1/tournaments/[id]/register/__tests__/validators.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from "vitest";
+import { checkRestrictions, checkFeeTierEligibility } from "../validators";
+import type { EligibilityProfile, FeeTier } from "../validators";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NOW = new Date("2026-05-12T00:00:00Z");
+
+// At NOW, DOB_18 yields age 18, DOB_17 yields age 17, DOB_19 yields age 19
+const DOB_18 = "2008-05-12";
+const DOB_17 = "2008-05-13";
+const DOB_19 = "2007-05-12";
+
+function makeProfile(overrides: Partial<EligibilityProfile> = {}): EligibilityProfile {
+  return {
+    date_of_birth: null,
+    gender: "male",
+    is_oku: false,
+    title: null,
+    fide_rating: null,
+    national_rating: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// checkRestrictions
+// ---------------------------------------------------------------------------
+
+describe("checkRestrictions", () => {
+  describe("no active restrictions", () => {
+    it("returns null when all restriction fields are null", () => {
+      const result = checkRestrictions(
+        { min_rating: null, max_rating: null, min_age: null, max_age: null },
+        makeProfile(),
+        "rapid",
+        NOW,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null for empty restrictions object", () => {
+      expect(checkRestrictions({}, makeProfile(), "rapid", NOW)).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Title
+  // -------------------------------------------------------------------------
+
+  describe("title restriction", () => {
+    it("returns null when player has a matching title", () => {
+      const result = checkRestrictions(
+        { titles: ["GM", "IM"] },
+        makeProfile({ title: "GM" }),
+        "rapid",
+        NOW,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns 422 when player has no title and tournament requires titles", async () => {
+      const result = checkRestrictions(
+        { titles: ["GM", "IM"] },
+        makeProfile({ title: null }),
+        "rapid",
+        NOW,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(422);
+      const json = await result!.json();
+      expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+    });
+
+    it("returns 422 when player's title is not in the allowed list", async () => {
+      const result = checkRestrictions(
+        { titles: ["GM", "IM"] },
+        makeProfile({ title: "FM" }),
+        "rapid",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+      const json = await result!.json();
+      expect(json.error.message).toContain("GM, IM");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rating
+  // -------------------------------------------------------------------------
+
+  describe("rating restriction", () => {
+    it("returns null when player rating is within min/max range", () => {
+      const result = checkRestrictions(
+        { min_rating: 1000, max_rating: 1800 },
+        makeProfile({ fide_rating: { rapid: 1500 } }),
+        "rapid",
+        NOW,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns 422 when player FIDE rapid rating is below min_rating", async () => {
+      const result = checkRestrictions(
+        { min_rating: 1800 },
+        makeProfile({ fide_rating: { rapid: 1600 } }),
+        "rapid",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+      const json = await result!.json();
+      expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+      expect(json.error.message).toContain("1800");
+    });
+
+    it("returns 422 when player has no rating and min_rating is set", async () => {
+      const result = checkRestrictions(
+        { min_rating: 1800 },
+        makeProfile({ fide_rating: null, national_rating: null }),
+        "rapid",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+    });
+
+    it("returns 422 when player FIDE rating exceeds max_rating", async () => {
+      const result = checkRestrictions(
+        { max_rating: 1500 },
+        makeProfile({ fide_rating: { rapid: 1800 } }),
+        "rapid",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+      const json = await result!.json();
+      expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+      expect(json.error.message).toContain("1500");
+    });
+
+    it("returns null when player has no rating and only max_rating is set", () => {
+      const result = checkRestrictions(
+        { max_rating: 1500 },
+        makeProfile({ fide_rating: null, national_rating: null }),
+        "rapid",
+        NOW,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("falls back to national_rating when no FIDE rating for the format", () => {
+      const result = checkRestrictions(
+        { min_rating: 1800 },
+        makeProfile({ fide_rating: null, national_rating: 1900 }),
+        "rapid",
+        NOW,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("uses the blitz key for blitz format tournaments", async () => {
+      const result = checkRestrictions(
+        { min_rating: 1800 },
+        makeProfile({ fide_rating: { standard: 2000, rapid: 2000, blitz: 1600 } }),
+        "blitz",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+    });
+
+    it("uses the standard key for classical format tournaments", () => {
+      const result = checkRestrictions(
+        { min_rating: 1800 },
+        makeProfile({ fide_rating: { standard: 2000, rapid: 1600 } }),
+        "classical",
+        NOW,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Age
+  // -------------------------------------------------------------------------
+
+  describe("age restriction", () => {
+    it("returns null when player age is within min/max range", () => {
+      const result = checkRestrictions(
+        { min_age: 16, max_age: 20 },
+        makeProfile({ date_of_birth: DOB_18 }),
+        "rapid",
+        NOW,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns 422 when date_of_birth is missing and age restriction is set", async () => {
+      const result = checkRestrictions(
+        { min_age: 18 },
+        makeProfile({ date_of_birth: null }),
+        "rapid",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+      const json = await result!.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 422 when player is below min_age", async () => {
+      const result = checkRestrictions(
+        { min_age: 18 },
+        makeProfile({ date_of_birth: DOB_17 }),
+        "rapid",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+      const json = await result!.json();
+      expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+      expect(json.error.message).toContain("18");
+    });
+
+    it("returns 422 when player exceeds max_age", async () => {
+      const result = checkRestrictions(
+        { max_age: 17 },
+        makeProfile({ date_of_birth: DOB_18 }),
+        "rapid",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+      const json = await result!.json();
+      expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+      expect(json.error.message).toContain("17");
+    });
+
+    it("returns null when player is exactly at the age boundary", () => {
+      expect(
+        checkRestrictions(
+          { min_age: 18 },
+          makeProfile({ date_of_birth: DOB_18 }),
+          "rapid",
+          NOW,
+        ),
+      ).toBeNull();
+
+      expect(
+        checkRestrictions(
+          { max_age: 18 },
+          makeProfile({ date_of_birth: DOB_18 }),
+          "rapid",
+          NOW,
+        ),
+      ).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkFeeTierEligibility
+// ---------------------------------------------------------------------------
+
+describe("checkFeeTierEligibility", () => {
+  describe("no tier restrictions", () => {
+    it("returns null for a standard tier with no restrictions", () => {
+      const tier: FeeTier = {};
+      expect(checkFeeTierEligibility(tier, makeProfile(), NOW)).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Gender
+  // -------------------------------------------------------------------------
+
+  describe("gender restriction", () => {
+    it("returns 400 when tier is female-only and player is male", async () => {
+      const tier: FeeTier = { gender: "female" };
+      const result = checkFeeTierEligibility(tier, makeProfile({ gender: "male" }), NOW);
+      expect(result!.status).toBe(400);
+      const json = await result!.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+      expect(json.error.message).toContain("female");
+    });
+
+    it("returns null when tier is female-only and player is female", () => {
+      const tier: FeeTier = { gender: "female" };
+      const result = checkFeeTierEligibility(tier, makeProfile({ gender: "female" }), NOW);
+      expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // OKU
+  // -------------------------------------------------------------------------
+
+  describe("OKU restriction", () => {
+    it("returns 400 when tier is OKU-only and player is not OKU", async () => {
+      const tier: FeeTier = { oku: true };
+      const result = checkFeeTierEligibility(tier, makeProfile({ is_oku: false }), NOW);
+      expect(result!.status).toBe(400);
+      const json = await result!.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+    });
+
+    it("returns null when tier is OKU-only and player is OKU", () => {
+      const tier: FeeTier = { oku: true };
+      const result = checkFeeTierEligibility(tier, makeProfile({ is_oku: true }), NOW);
+      expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Title
+  // -------------------------------------------------------------------------
+
+  describe("title restriction", () => {
+    it("returns 400 when tier requires titles and player has no title", async () => {
+      const tier: FeeTier = { titles: ["GM", "IM"] };
+      const result = checkFeeTierEligibility(tier, makeProfile({ title: null }), NOW);
+      expect(result!.status).toBe(400);
+      const json = await result!.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+    });
+
+    it("returns 400 when tier requires titles and player has wrong title", async () => {
+      const tier: FeeTier = { titles: ["GM", "IM"] };
+      const result = checkFeeTierEligibility(tier, makeProfile({ title: "FM" }), NOW);
+      expect(result!.status).toBe(400);
+    });
+
+    it("returns null when player has a title matching the tier", () => {
+      const tier: FeeTier = { titles: ["GM", "IM", "FM"] };
+      const result = checkFeeTierEligibility(tier, makeProfile({ title: "FM" }), NOW);
+      expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Age
+  // -------------------------------------------------------------------------
+
+  describe("age restriction", () => {
+    it("returns 422 when date_of_birth is missing for age-restricted tier", async () => {
+      const tier: FeeTier = { age_max: 18 };
+      const result = checkFeeTierEligibility(tier, makeProfile({ date_of_birth: null }), NOW);
+      expect(result!.status).toBe(422);
+      const json = await result!.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 when player is below the tier's min_age", async () => {
+      const tier: FeeTier = { age_min: 18 };
+      const result = checkFeeTierEligibility(tier, makeProfile({ date_of_birth: DOB_17 }), NOW);
+      expect(result!.status).toBe(400);
+      const json = await result!.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+    });
+
+    it("returns 400 when player exceeds the tier's max_age", async () => {
+      const tier: FeeTier = { age_max: 17 };
+      const result = checkFeeTierEligibility(tier, makeProfile({ date_of_birth: DOB_18 }), NOW);
+      expect(result!.status).toBe(400);
+      const json = await result!.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+    });
+
+    it("returns null when player is exactly at the tier age boundary", () => {
+      expect(
+        checkFeeTierEligibility(
+          { age_min: 18 },
+          makeProfile({ date_of_birth: DOB_18 }),
+          NOW,
+        ),
+      ).toBeNull();
+
+      expect(
+        checkFeeTierEligibility(
+          { age_max: 18 },
+          makeProfile({ date_of_birth: DOB_18 }),
+          NOW,
+        ),
+      ).toBeNull();
+    });
+
+    it("returns null for an under-19 tier when player is 18 (within range)", () => {
+      const tier: FeeTier = { age_min: 0, age_max: 19 };
+      const result = checkFeeTierEligibility(tier, makeProfile({ date_of_birth: DOB_18 }), NOW);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/app/api/v1/tournaments/[id]/register/__tests__/validators.test.ts
+++ b/src/app/api/v1/tournaments/[id]/register/__tests__/validators.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { checkRestrictions, checkFeeTierEligibility } from "../validators";
+import { checkRestrictions, checkFeeTierEligibility, normalizeRestrictions } from "../validators";
 import type { EligibilityProfile, FeeTier } from "../validators";
 
 // ---------------------------------------------------------------------------
@@ -26,10 +26,108 @@ function makeProfile(overrides: Partial<EligibilityProfile> = {}): EligibilityPr
 }
 
 // ---------------------------------------------------------------------------
+// normalizeRestrictions
+// ---------------------------------------------------------------------------
+
+describe("normalizeRestrictions", () => {
+  it("returns null for null input", () => {
+    expect(normalizeRestrictions(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(normalizeRestrictions(undefined)).toBeNull();
+  });
+
+  it("passes through a flat object unchanged", () => {
+    const flat = { min_rating: 1000, max_rating: 1800 };
+    expect(normalizeRestrictions(flat)).toEqual(flat);
+  });
+
+  it("converts array rating restriction to flat format", () => {
+    const raw = [{ type: "rating", max: 1799 }];
+    expect(normalizeRestrictions(raw)).toEqual({ max_rating: 1799 });
+  });
+
+  it("converts array age restriction to flat format", () => {
+    const raw = [{ type: "age", max: 18 }];
+    expect(normalizeRestrictions(raw)).toEqual({ max_age: 18 });
+  });
+
+  it("converts array gender restriction to flat format", () => {
+    const raw = [{ type: "gender", value: "female" }];
+    expect(normalizeRestrictions(raw)).toEqual({ gender: "female" });
+  });
+
+  it("merges multiple restriction types from an array", () => {
+    const raw = [{ type: "rating", max: 1799 }, { type: "age", max: 20 }];
+    expect(normalizeRestrictions(raw)).toEqual({ max_rating: 1799, max_age: 20 });
+  });
+
+  it("maps both min and max for rating and age", () => {
+    const raw = [{ type: "rating", min: 1000, max: 1799 }, { type: "age", min: 16, max: 20 }];
+    expect(normalizeRestrictions(raw)).toEqual({
+      min_rating: 1000,
+      max_rating: 1799,
+      min_age: 16,
+      max_age: 20,
+    });
+  });
+
+  it("ignores unknown restriction types (e.g. nationality)", () => {
+    const raw = [{ type: "nationality", value: "Malaysian" }];
+    expect(normalizeRestrictions(raw)).toBeNull();
+  });
+
+  it("returns null for an empty array", () => {
+    expect(normalizeRestrictions([])).toBeNull();
+  });
+
+  it("handles combined seed-style restrictions", () => {
+    const raw = [{ type: "nationality", value: "Malaysian" }, { type: "age", max: 20 }];
+    expect(normalizeRestrictions(raw)).toEqual({ max_age: 20 });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // checkRestrictions
 // ---------------------------------------------------------------------------
 
 describe("checkRestrictions", () => {
+  describe("gender restriction", () => {
+    it("returns 422 when tournament is female-only and player is male", async () => {
+      const result = checkRestrictions(
+        { gender: "female" },
+        makeProfile({ gender: "male" }),
+        "rapid",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+      const json = await result!.json();
+      expect(json.error.code).toBe("ELIGIBILITY_ERROR");
+      expect(json.error.message).toContain("female");
+    });
+
+    it("returns null when tournament is female-only and player is female", () => {
+      const result = checkRestrictions(
+        { gender: "female" },
+        makeProfile({ gender: "female" }),
+        "rapid",
+        NOW,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns 422 when profile is null and gender restriction is set", async () => {
+      const result = checkRestrictions(
+        { gender: "female" },
+        null,
+        "rapid",
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+    });
+  });
+
   describe("no active restrictions", () => {
     it("returns null when all restriction fields are null", () => {
       const result = checkRestrictions(

--- a/src/app/api/v1/tournaments/[id]/register/route.ts
+++ b/src/app/api/v1/tournaments/[id]/register/route.ts
@@ -2,10 +2,10 @@ import { supabaseAdmin } from "@/services/supabase/admin";
 import { createClient } from "@/services/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import type { EntryFees } from "@/app/tournaments/types";
-import type { Restrictions } from "@/app/tournaments/[id]/types";
 import {
   checkRestrictions,
   checkFeeTierEligibility,
+  normalizeRestrictions,
 } from "@/app/api/v1/tournaments/[id]/register/validators";
 import type {
   RegistrationRequest,
@@ -159,7 +159,7 @@ export async function POST(
     );
   }
 
-  const restrictions = tournament.restrictions as Restrictions | null;
+  const restrictions = normalizeRestrictions(tournament.restrictions);
 
   const needsTierProfile =
     matchedTier.age_min != null ||
@@ -173,7 +173,8 @@ export async function POST(
     restrictions?.min_rating != null ||
     restrictions?.max_rating != null ||
     restrictions?.min_age != null ||
-    restrictions?.max_age != null
+    restrictions?.max_age != null ||
+    restrictions?.gender != null
   );
 
   if (needsTierProfile || needsRestrictionProfile) {

--- a/src/app/api/v1/tournaments/[id]/register/route.ts
+++ b/src/app/api/v1/tournaments/[id]/register/route.ts
@@ -1,8 +1,12 @@
 import { supabaseAdmin } from "@/services/supabase/admin";
 import { createClient } from "@/services/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
-import type { EntryFees, ChessTitle } from "@/app/tournaments/types";
-import { calculateAge } from "@/app/tournaments/utils";
+import type { EntryFees } from "@/app/tournaments/types";
+import type { Restrictions } from "@/app/tournaments/[id]/types";
+import {
+  checkRestrictions,
+  checkFeeTierEligibility,
+} from "@/app/api/v1/tournaments/[id]/register/validators";
 import type {
   RegistrationRequest,
   RegistrationRow,
@@ -56,7 +60,9 @@ export async function POST(
 
   const { data: tournament, error: tErr } = await supabaseAdmin
     .from("tournaments")
-    .select("id, entry_fees, max_participants, registration_deadline")
+    .select(
+      "id, entry_fees, max_participants, registration_deadline, restrictions, format",
+    )
     .eq("id", id)
     .eq("status", "published")
     .single();
@@ -84,6 +90,19 @@ export async function POST(
           message: "Registration deadline has passed",
         },
       },
+      { status: 422 },
+    );
+  }
+
+  const { count: currentCount } = await supabaseAdmin
+    .from("registrations")
+    .select("*", { count: "exact", head: true })
+    .eq("tournament_id", id)
+    .in("status", ["pending_payment", "confirmed"]);
+
+  if (currentCount !== null && currentCount >= tournament.max_participants) {
+    return NextResponse.json(
+      { error: { code: "CAPACITY_FULL", message: "Tournament is full" } },
       { status: 422 },
     );
   }
@@ -140,100 +159,44 @@ export async function POST(
     );
   }
 
-  const needsProfile =
+  const restrictions = tournament.restrictions as Restrictions | null;
+
+  const needsTierProfile =
     matchedTier.age_min != null ||
     matchedTier.age_max != null ||
     matchedTier.gender != null ||
     matchedTier.oku === true ||
     (matchedTier.titles?.length ?? 0) > 0;
 
-  if (needsProfile) {
+  const needsRestrictionProfile = !!(
+    (restrictions?.titles?.length ?? 0) > 0 ||
+    restrictions?.min_rating != null ||
+    restrictions?.max_rating != null ||
+    restrictions?.min_age != null ||
+    restrictions?.max_age != null
+  );
+
+  if (needsTierProfile || needsRestrictionProfile) {
     const { data: profile } = await supabaseAdmin
       .from("player_profiles")
-      .select("date_of_birth, gender, is_oku, title")
+      .select(
+        "date_of_birth, gender, is_oku, title, fide_rating, national_rating",
+      )
       .eq("user_id", user.id)
       .single();
 
-    if (matchedTier.gender === "female" && profile?.gender !== "female") {
-      return NextResponse.json(
-        {
-          error: {
-            code: "INVALID_FEE_TIER",
-            message: "This fee tier is for female players only",
-          },
-        },
-        { status: 400 },
+    if (needsRestrictionProfile && restrictions) {
+      const restrictionError = checkRestrictions(
+        restrictions,
+        profile,
+        (tournament.format as { type: string }).type,
+        now,
       );
+      if (restrictionError) return restrictionError;
     }
 
-    if (matchedTier.oku && !profile?.is_oku) {
-      return NextResponse.json(
-        {
-          error: {
-            code: "INVALID_FEE_TIER",
-            message: "This fee tier is for OKU players only",
-          },
-        },
-        { status: 400 },
-      );
-    }
-
-    if (
-      matchedTier.titles?.length &&
-      (!profile?.title ||
-        !matchedTier.titles.includes(profile.title as ChessTitle))
-    ) {
-      return NextResponse.json(
-        {
-          error: {
-            code: "INVALID_FEE_TIER",
-            message: `This fee tier is for titled players only (${matchedTier.titles.join(", ")})`,
-          },
-        },
-        { status: 400 },
-      );
-    }
-
-    if (matchedTier.age_min != null || matchedTier.age_max != null) {
-      if (!profile?.date_of_birth) {
-        return NextResponse.json(
-          {
-            error: {
-              code: "VALIDATION_ERROR",
-              message:
-                "Your player profile is missing a date of birth required for this fee tier",
-            },
-          },
-          { status: 422 },
-        );
-      }
-
-      const dob = new Date(profile.date_of_birth);
-      const age = calculateAge(dob, now);
-
-      if (matchedTier.age_min != null && age < matchedTier.age_min) {
-        return NextResponse.json(
-          {
-            error: {
-              code: "INVALID_FEE_TIER",
-              message: `You must be at least ${matchedTier.age_min} years old for this tier`,
-            },
-          },
-          { status: 400 },
-        );
-      }
-      if (matchedTier.age_max != null && age > matchedTier.age_max) {
-        return NextResponse.json(
-          {
-            error: {
-              code: "INVALID_FEE_TIER",
-              message: `You must be ${matchedTier.age_max} years old or younger for this tier`,
-            },
-          },
-          { status: 400 },
-        );
-      }
-    }
+    const tierError = checkFeeTierEligibility(matchedTier, profile, now);
+    if (tierError) return tierError;
   }
 
   const { data: existing } = await supabaseAdmin

--- a/src/app/api/v1/tournaments/[id]/register/validators.ts
+++ b/src/app/api/v1/tournaments/[id]/register/validators.ts
@@ -20,12 +20,54 @@ export interface FeeTier {
   titles?: ChessTitle[] | null;
 }
 
+type RawRestrictionItem = {
+  type: string;
+  min?: number;
+  max?: number;
+  value?: string;
+};
+
+export function normalizeRestrictions(raw: unknown): Restrictions | null {
+  if (!raw) return null;
+  if (!Array.isArray(raw)) return raw as Restrictions;
+
+  const result: Restrictions = {};
+  for (const item of raw as RawRestrictionItem[]) {
+    switch (item.type) {
+      case "rating":
+        if (item.min != null) result.min_rating = item.min;
+        if (item.max != null) result.max_rating = item.max;
+        break;
+      case "age":
+        if (item.min != null) result.min_age = item.min;
+        if (item.max != null) result.max_age = item.max;
+        break;
+      case "gender":
+        if (item.value != null) result.gender = item.value;
+        break;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
 export function checkRestrictions(
   restrictions: Restrictions,
   profile: EligibilityProfile | null,
   formatType: string,
   now: Date,
 ): NextResponse | null {
+  if (restrictions.gender != null && profile?.gender !== restrictions.gender) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "ELIGIBILITY_ERROR",
+          message: `This tournament is for ${restrictions.gender} players only`,
+        },
+      },
+      { status: 422 },
+    );
+  }
+
   if ((restrictions.titles?.length ?? 0) > 0) {
     if (
       !profile?.title ||

--- a/src/app/api/v1/tournaments/[id]/register/validators.ts
+++ b/src/app/api/v1/tournaments/[id]/register/validators.ts
@@ -1,0 +1,219 @@
+import { NextResponse } from "next/server";
+import type { ChessTitle } from "@/app/tournaments/types";
+import type { Restrictions } from "@/app/tournaments/[id]/types";
+import { calculateAge } from "@/app/tournaments/utils";
+
+export interface EligibilityProfile {
+  date_of_birth: string | null;
+  gender: string | null;
+  is_oku: boolean;
+  title: string | null;
+  fide_rating: Record<string, number> | null;
+  national_rating: number | null;
+}
+
+export interface FeeTier {
+  age_min?: number | null;
+  age_max?: number | null;
+  gender?: string | null;
+  oku?: boolean | null;
+  titles?: ChessTitle[] | null;
+}
+
+export function checkRestrictions(
+  restrictions: Restrictions,
+  profile: EligibilityProfile | null,
+  formatType: string,
+  now: Date,
+): NextResponse | null {
+  if ((restrictions.titles?.length ?? 0) > 0) {
+    if (
+      !profile?.title ||
+      !restrictions.titles!.includes(profile.title as ChessTitle)
+    ) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "ELIGIBILITY_ERROR",
+            message: `This tournament is for titled players only (${restrictions.titles!.join(", ")})`,
+          },
+        },
+        { status: 422 },
+      );
+    }
+  }
+
+  if (restrictions.min_rating != null || restrictions.max_rating != null) {
+    const ratingKey =
+      formatType === "blitz"
+        ? "blitz"
+        : formatType === "rapid"
+          ? "rapid"
+          : "standard";
+    const playerRating =
+      profile?.fide_rating?.[ratingKey] ?? profile?.national_rating ?? null;
+
+    if (
+      restrictions.min_rating != null &&
+      (playerRating == null || playerRating < restrictions.min_rating)
+    ) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "ELIGIBILITY_ERROR",
+            message: `A minimum rating of ${restrictions.min_rating} is required`,
+          },
+        },
+        { status: 422 },
+      );
+    }
+
+    if (
+      restrictions.max_rating != null &&
+      playerRating != null &&
+      playerRating > restrictions.max_rating
+    ) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "ELIGIBILITY_ERROR",
+            message: `Your rating exceeds the maximum allowed (${restrictions.max_rating})`,
+          },
+        },
+        { status: 422 },
+      );
+    }
+  }
+
+  if (restrictions.min_age != null || restrictions.max_age != null) {
+    if (!profile?.date_of_birth) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message:
+              "Your player profile is missing a date of birth required for this tournament",
+          },
+        },
+        { status: 422 },
+      );
+    }
+
+    const age = calculateAge(new Date(profile.date_of_birth), now);
+
+    if (restrictions.min_age != null && age < restrictions.min_age) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "ELIGIBILITY_ERROR",
+            message: `You must be at least ${restrictions.min_age} years old to enter`,
+          },
+        },
+        { status: 422 },
+      );
+    }
+
+    if (restrictions.max_age != null && age > restrictions.max_age) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "ELIGIBILITY_ERROR",
+            message: `You must be ${restrictions.max_age} years old or younger to enter`,
+          },
+        },
+        { status: 422 },
+      );
+    }
+  }
+
+  return null;
+}
+
+export function checkFeeTierEligibility(
+  tier: FeeTier,
+  profile: EligibilityProfile | null,
+  now: Date,
+): NextResponse | null {
+  if (tier.gender === "female" && profile?.gender !== "female") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INVALID_FEE_TIER",
+          message: "This fee tier is for female players only",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  if (tier.oku && !profile?.is_oku) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INVALID_FEE_TIER",
+          message: "This fee tier is for OKU players only",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  if (
+    tier.titles?.length &&
+    (!profile?.title ||
+      !tier.titles.includes(profile.title as ChessTitle))
+  ) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "INVALID_FEE_TIER",
+          message: `This fee tier is for titled players only (${tier.titles.join(", ")})`,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  if (tier.age_min != null || tier.age_max != null) {
+    if (!profile?.date_of_birth) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message:
+              "Your player profile is missing a date of birth required for this fee tier",
+          },
+        },
+        { status: 422 },
+      );
+    }
+
+    const age = calculateAge(new Date(profile.date_of_birth), now);
+
+    if (tier.age_min != null && age < tier.age_min) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "INVALID_FEE_TIER",
+            message: `You must be at least ${tier.age_min} years old for this tier`,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    if (tier.age_max != null && age > tier.age_max) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "INVALID_FEE_TIER",
+            message: `You must be ${tier.age_max} years old or younger for this tier`,
+          },
+        },
+        { status: 400 },
+      );
+    }
+  }
+
+  return null;
+}

--- a/src/app/tournaments/[id]/register/page.tsx
+++ b/src/app/tournaments/[id]/register/page.tsx
@@ -58,7 +58,7 @@ async function RegisterPageContent({ id }: { id: string }) {
 
   const { data: playerProfile } = await supabase
     .from("player_profiles")
-    .select("gender, is_oku, date_of_birth, title")
+    .select("gender, is_oku, date_of_birth, title, fide_rating, national_rating")
     .eq("user_id", user.id)
     .single();
 

--- a/src/app/tournaments/[id]/register/types.ts
+++ b/src/app/tournaments/[id]/register/types.ts
@@ -5,6 +5,8 @@ export interface PlayerProfile {
   is_oku: boolean;
   date_of_birth: string | null;
   title: ChessTitle | null;
+  fide_rating: Record<string, number> | null;
+  national_rating: number | null;
 }
 
 export interface RegistrationRequest {

--- a/src/app/tournaments/[id]/types.ts
+++ b/src/app/tournaments/[id]/types.ts
@@ -33,6 +33,7 @@ export interface Restrictions {
   min_age?: number | null;
   max_age?: number | null;
   titles?: ChessTitle[] | null;
+  gender?: string | null;
 }
 
 interface OrganizerDetail {

--- a/src/app/tournaments/[id]/types.ts
+++ b/src/app/tournaments/[id]/types.ts
@@ -1,4 +1,4 @@
-import type { EntryFees, TournamentFormat, TimeControl } from "../types";
+import type { EntryFees, TournamentFormat, TimeControl, ChessTitle } from "../types";
 
 const enum NonMonetaryPrize {
   Trophy = "Trophy",
@@ -32,6 +32,7 @@ export interface Restrictions {
   max_rating?: number | null;
   min_age?: number | null;
   max_age?: number | null;
+  titles?: ChessTitle[] | null;
 }
 
 interface OrganizerDetail {


### PR DESCRIPTION
Closes #41

## Summary

Adds server-side eligibility validation to the tournament registration endpoint:

- Proactive capacity check before insert
- Tournament-level title, rating, and age restriction checks from the `restrictions` JSONB field
- Refactored eligibility logic into `validators.ts` to keep `route.ts` under 400 lines
- 27 new route tests + 30 new validator unit tests

Generated with [Claude Code](https://claude.ai/code)