### PR TITLE
feat: add payment return pages (pending, success, failure)

### DIFF
--- a/src/app/tournaments/[id]/register/_components/RegisterForm.tsx
+++ b/src/app/tournaments/[id]/register/_components/RegisterForm.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { TournamentDetail } from "../../types";
 import { formatRm, toTitleCase, formatDeadline, calculateAge } from "@/app/tournaments/utils";
 import type { RegistrationRow, PlayerProfile } from "../types";
+import RegistrationPending from "./RegistrationPending";
 
 const PROCESSING_FEE_CENTS = 150;
 
@@ -179,42 +180,10 @@ export default function RegisterForm({ tournament, playerProfile }: Props) {
 
   if (status === "success" && registration) {
     return (
-      <div className="max-w-lg mx-auto">
-        <div className="card card--featured p-8 flex flex-col text-center">
-          <div className="confirm-icon">♟</div>
-          <h2 className="confirm-title">Registration Submitted</h2>
-          <p className="confirm-body">
-            Your spot is reserved. Your registration is pending payment
-            confirmation.
-          </p>
-          <div className="session-info text-left mt-2">
-            <div className="session-row">
-              <span className="session-key">Reference</span>
-              <span className="session-val font-mono text-xs">
-                {registration.id}
-              </span>
-            </div>
-            <div className="session-row">
-              <span className="session-key">Fee Tier</span>
-              <span className="session-val">
-                {toTitleCase(registration.fee_tier)}
-              </span>
-            </div>
-            <div className="session-row">
-              <span className="session-key">Status</span>
-              <span className="session-val text-amber-400">
-                Pending Payment
-              </span>
-            </div>
-          </div>
-          <Link
-            href={`/tournaments/${tournament.id}`}
-            className="btn-secondary rounded-md text-center mt-2"
-          >
-            Back to Tournament
-          </Link>
-        </div>
-      </div>
+      <RegistrationPending
+        registration={registration}
+        tournamentId={tournament.id}
+      />
     );
   }
 

--- a/src/app/tournaments/[id]/register/_components/RegistrationPending.tsx
+++ b/src/app/tournaments/[id]/register/_components/RegistrationPending.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import type { RegistrationRow } from "../types";
+import { toTitleCase } from "@/app/tournaments/utils";
+
+interface Props {
+  registration: RegistrationRow;
+  tournamentId: string;
+}
+
+export default function RegistrationPending({ registration, tournamentId }: Props) {
+  return (
+    <div className="max-w-lg mx-auto">
+      <div className="card card--featured p-8 flex flex-col text-center">
+        <div className="confirm-icon">♟</div>
+        <h2 className="confirm-title">Registration Submitted</h2>
+        <p className="confirm-body">
+          Your spot is reserved. Your registration is pending payment
+          confirmation.
+        </p>
+        <div className="session-info text-left mt-2">
+          <div className="session-row">
+            <span className="session-key">Reference</span>
+            <span className="session-val font-mono text-xs">
+              {registration.id}
+            </span>
+          </div>
+          <div className="session-row">
+            <span className="session-key">Fee Tier</span>
+            <span className="session-val">
+              {toTitleCase(registration.fee_tier)}
+            </span>
+          </div>
+          <div className="session-row">
+            <span className="session-key">Status</span>
+            <span className="session-val text-amber-400">Pending Payment</span>
+          </div>
+        </div>
+        <Link
+          href={`/tournaments/${tournamentId}`}
+          className="btn-secondary rounded-md text-center mt-2"
+        >
+          Back to Tournament
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/tournaments/[id]/register/failure/page.tsx
+++ b/src/app/tournaments/[id]/register/failure/page.tsx
@@ -25,6 +25,7 @@ export default async function PaymentFailurePage({
               Your payment could not be processed. Please try again or contact
               support if the problem persists.
             </p>
+            {/* TODO: This link is temporary and will be replaced once the payment gateway is integrated */}
             <Link
               href={`/tournaments/${id}/register`}
               className="btn-primary rounded-md text-center mt-2"

--- a/src/app/tournaments/[id]/register/failure/page.tsx
+++ b/src/app/tournaments/[id]/register/failure/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+
+export const metadata: Metadata = {
+  title: "Payment Failed | MY Chess Tour",
+};
+
+export default async function PaymentFailurePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <main className="max-w-2xl mx-auto px-6 md:px-10 py-10">
+        <div className="max-w-lg mx-auto">
+          <div className="card card--featured p-8 flex flex-col text-center">
+            <div className="confirm-icon confirm-icon--danger">✗</div>
+            <h2 className="confirm-title">Payment Failed</h2>
+            <p className="confirm-body">
+              Your payment could not be processed. Please try again or contact
+              support if the problem persists.
+            </p>
+            <Link
+              href={`/tournaments/${id}/register`}
+              className="btn-primary rounded-md text-center mt-2"
+            >
+              Try Again
+            </Link>
+            <Link
+              href={`/tournaments/${id}`}
+              className="btn-secondary rounded-md text-center mt-4"
+            >
+              Back to Tournament
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/tournaments/[id]/register/success/page.tsx
+++ b/src/app/tournaments/[id]/register/success/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+
+export const metadata: Metadata = {
+  title: "Payment Successful | MY Chess Tour",
+};
+
+export default async function PaymentSuccessPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <main className="max-w-2xl mx-auto px-6 md:px-10 py-10">
+        <div className="max-w-lg mx-auto">
+          <div className="card card--featured p-8 flex flex-col text-center">
+            <div className="confirm-icon">✓</div>
+            <h2 className="confirm-title">Payment Successful</h2>
+            <p className="confirm-body">
+              Your payment has been confirmed. Your registration is now active.
+              We look forward to seeing you at the tournament.
+            </p>
+            <Link
+              href={`/tournaments/${id}`}
+              className="btn-secondary rounded-md text-center mt-2"
+            >
+              Back to Tournament
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
Extract the pending registration screen from RegisterForm into a standalone RegistrationPending component, and add success/failure return pages for payment gateway redirects.

Closes #45

Generated with [Claude Code](https://claude.ai/code)