### PR TITLE
feat: update register button states for deadline and existing registration

### DIFF
--- a/src/app/tournaments/[id]/__tests__/page.test.ts
+++ b/src/app/tournaments/[id]/__tests__/page.test.ts
@@ -36,6 +36,21 @@ vi.mock("@/services/supabase/server", () => ({
   }),
 }));
 
+const mockRegistrationSelect = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockResolvedValue({ count: 0 }),
+  }),
+);
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: {
+    from: vi.fn().mockReturnValue({
+      select: mockRegistrationSelect,
+    }),
+  },
+}));
+
 // ── Helpers ───────────────────────────────────────────────────
 
 const mockFetch = vi.fn();

--- a/src/app/tournaments/[id]/_components/TournamentDetail.tsx
+++ b/src/app/tournaments/[id]/_components/TournamentDetail.tsx
@@ -82,16 +82,19 @@ function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
 interface Props {
   tournament: TournamentDetailType;
   isAuthenticated: boolean;
+  isRegistered?: boolean;
 }
 
 export default function TournamentDetail({
   tournament: t,
   isAuthenticated,
+  isRegistered = false,
 }: Props) {
   const spotsLeft = t.max_participants - t.current_participants;
   const spotsRatio =
     t.max_participants > 0 ? spotsLeft / t.max_participants : 0;
   const minFee = getMinFeeCents(t.entry_fees);
+  const isDeadlinePassed = new Date(t.registration_deadline) < new Date();
   const lowestFeeEntry =
     t.entry_fees.additional?.find((f) => f.amount_cents === minFee) ?? null;
 
@@ -385,6 +388,20 @@ export default function TournamentDetail({
                   disabled
                 >
                   Full
+                </button>
+              ) : isDeadlinePassed ? (
+                <button
+                  className="btn-primary rounded-md w-full opacity-50"
+                  disabled
+                >
+                  Registration Closed
+                </button>
+              ) : isRegistered ? (
+                <button
+                  className="btn-primary rounded-md w-full opacity-50"
+                  disabled
+                >
+                  Registered
                 </button>
               ) : isAuthenticated ? (
                 <Link

--- a/src/app/tournaments/[id]/_components/TournamentDetail.tsx
+++ b/src/app/tournaments/[id]/_components/TournamentDetail.tsx
@@ -382,19 +382,12 @@ export default function TournamentDetail({
               </div>
 
               {/* CTA */}
-              {spotsLeft === 0 ? (
-                <button
-                  className="btn-primary rounded-md not-first:w-full opacity-50"
-                  disabled
-                >
-                  Full
-                </button>
-              ) : isDeadlinePassed ? (
+              {!isAuthenticated ? (
                 <button
                   className="btn-primary rounded-md w-full opacity-50"
                   disabled
                 >
-                  Registration Closed
+                  Sign In to Register
                 </button>
               ) : isRegistered ? (
                 <button
@@ -403,20 +396,27 @@ export default function TournamentDetail({
                 >
                   Registered
                 </button>
-              ) : isAuthenticated ? (
+              ) : isDeadlinePassed ? (
+                <button
+                  className="btn-primary rounded-md w-full opacity-50"
+                  disabled
+                >
+                  Registration Closed
+                </button>
+              ) : spotsLeft === 0 ? (
+                <button
+                  className="btn-primary rounded-md w-full opacity-50"
+                  disabled
+                >
+                  Full Capacity
+                </button>
+              ) : (
                 <Link
                   href={`/tournaments/${t.id}/register`}
                   className="btn-primary rounded-md w-full text-center block"
                 >
                   Register Now
                 </Link>
-              ) : (
-                <button
-                  className="btn-primary rounded-md w-full opacity-50"
-                  disabled
-                >
-                  Sign In to Register
-                </button>
               )}
 
               {/* Spots */}

--- a/src/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
+++ b/src/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
@@ -61,11 +61,13 @@ const base: TournamentDetailType = {
 function render(
   overrides: Partial<TournamentDetailType> = {},
   isAuthenticated = false,
+  isRegistered = false,
 ): string {
   return renderToStaticMarkup(
     <TournamentDetail
       tournament={{ ...base, ...overrides }}
       isAuthenticated={isAuthenticated}
+      isRegistered={isRegistered}
     />,
   );
 }
@@ -392,5 +394,35 @@ describe("CTA button auth states", () => {
     expect(htmlAuth).toContain("disabled");
     expect(htmlNoAuth).toContain("Full");
     expect(htmlNoAuth).toContain("disabled");
+  });
+
+  it("shows 'Registration Closed' when deadline has passed", () => {
+    const pastDeadline = new Date(Date.now() - 1000).toISOString();
+    const html = render({ registration_deadline: pastDeadline }, true);
+    expect(html).toContain("Registration Closed");
+    expect(html).toContain("disabled");
+  });
+
+  it("shows 'Registration Closed' for unauthenticated users when deadline has passed", () => {
+    const pastDeadline = new Date(Date.now() - 1000).toISOString();
+    const html = render({ registration_deadline: pastDeadline }, false);
+    expect(html).toContain("Registration Closed");
+    expect(html).toContain("disabled");
+  });
+
+  it("shows 'Registered' when authenticated user has already registered", () => {
+    const html = render({}, true, true);
+    expect(html).toContain("Registered");
+    expect(html).toContain("disabled");
+  });
+
+  it("shows 'Full' over 'Registration Closed' when tournament is full and deadline passed", () => {
+    const pastDeadline = new Date(Date.now() - 1000).toISOString();
+    const html = render(
+      { max_participants: 100, current_participants: 100, registration_deadline: pastDeadline },
+      true,
+    );
+    expect(html).toContain("Full");
+    expect(html).not.toContain("Registration Closed");
   });
 });

--- a/src/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
+++ b/src/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
@@ -347,8 +347,8 @@ describe("register card", () => {
   });
 
   it("shows full status when no spots remain", () => {
-    const html = render({ max_participants: 100, current_participants: 100 });
-    expect(html).toContain("Full");
+    const html = render({ max_participants: 100, current_participants: 100 }, true);
+    expect(html).toContain("Full Capacity");
   });
 
   it("applies low-spots colour class when spots ratio is at or below 20%", () => {
@@ -381,18 +381,21 @@ describe("CTA button auth states", () => {
     expect(html).toContain("disabled");
   });
 
-  it("shows 'Full' and disables button when no spots remain, regardless of auth", () => {
+  it("shows 'Full Capacity' and disables button for authenticated when no spots remain", () => {
     const htmlAuth = render(
       { max_participants: 100, current_participants: 100 },
       true,
     );
+    expect(htmlAuth).toContain("Full Capacity");
+    expect(htmlAuth).toContain("disabled");
+  });
+
+  it("shows 'Sign In to Register' for unauthenticated users even when no spots remain", () => {
     const htmlNoAuth = render(
       { max_participants: 100, current_participants: 100 },
       false,
     );
-    expect(htmlAuth).toContain("Full");
-    expect(htmlAuth).toContain("disabled");
-    expect(htmlNoAuth).toContain("Full");
+    expect(htmlNoAuth).toContain("Sign In to Register");
     expect(htmlNoAuth).toContain("disabled");
   });
 
@@ -403,10 +406,10 @@ describe("CTA button auth states", () => {
     expect(html).toContain("disabled");
   });
 
-  it("shows 'Registration Closed' for unauthenticated users when deadline has passed", () => {
+  it("shows 'Sign In to Register' for unauthenticated users even when deadline has passed", () => {
     const pastDeadline = new Date(Date.now() - 1000).toISOString();
     const html = render({ registration_deadline: pastDeadline }, false);
-    expect(html).toContain("Registration Closed");
+    expect(html).toContain("Sign In to Register");
     expect(html).toContain("disabled");
   });
 
@@ -416,13 +419,30 @@ describe("CTA button auth states", () => {
     expect(html).toContain("disabled");
   });
 
-  it("shows 'Full' over 'Registration Closed' when tournament is full and deadline passed", () => {
+  it("shows 'Full Capacity' over 'Registration Closed' when tournament is full and deadline passed", () => {
     const pastDeadline = new Date(Date.now() - 1000).toISOString();
     const html = render(
       { max_participants: 100, current_participants: 100, registration_deadline: pastDeadline },
       true,
     );
-    expect(html).toContain("Full");
+    expect(html).toContain("Full Capacity");
     expect(html).not.toContain("Registration Closed");
+  });
+
+  it("shows 'Registered' over 'Registration Closed' when user is registered and deadline passed", () => {
+    const pastDeadline = new Date(Date.now() - 1000).toISOString();
+    const html = render({ registration_deadline: pastDeadline }, true, true);
+    expect(html).toContain("Registered");
+    expect(html).not.toContain("Registration Closed");
+  });
+
+  it("shows 'Registered' over 'Full Capacity' when user is registered and tournament is full", () => {
+    const html = render(
+      { max_participants: 100, current_participants: 100 },
+      true,
+      true,
+    );
+    expect(html).toContain("Registered");
+    expect(html).not.toContain("Full Capacity");
   });
 });

--- a/src/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
+++ b/src/app/tournaments/[id]/_components/__tests__/TournamentDetail.test.tsx
@@ -419,14 +419,14 @@ describe("CTA button auth states", () => {
     expect(html).toContain("disabled");
   });
 
-  it("shows 'Full Capacity' over 'Registration Closed' when tournament is full and deadline passed", () => {
+  it("shows 'Registration Closed' over 'Full Capacity' when deadline passed and tournament is full", () => {
     const pastDeadline = new Date(Date.now() - 1000).toISOString();
     const html = render(
       { max_participants: 100, current_participants: 100, registration_deadline: pastDeadline },
       true,
     );
-    expect(html).toContain("Full Capacity");
-    expect(html).not.toContain("Registration Closed");
+    expect(html).toContain("Registration Closed");
+    expect(html).not.toContain("Full Capacity");
   });
 
   it("shows 'Registered' over 'Registration Closed' when user is registered and deadline passed", () => {

--- a/src/app/tournaments/[id]/page.tsx
+++ b/src/app/tournaments/[id]/page.tsx
@@ -7,6 +7,7 @@ import TournamentDetail from "./_components/TournamentDetail";
 import DetailSkeleton from "./_components/DetailSkeleton";
 import type { TournamentDetail as TournamentDetailType } from "./types";
 import { createClient } from "@/services/supabase/server";
+import { supabaseAdmin } from "@/services/supabase/admin";
 
 export const revalidate = 60;
 
@@ -91,7 +92,24 @@ export async function TournamentDetailData({ id }: { id: string }) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  return <TournamentDetail tournament={tournament} isAuthenticated={!!user} />;
+  let isRegistered = false;
+  if (user) {
+    const { count } = await supabaseAdmin
+      .from("registrations")
+      .select("*", { count: "exact", head: true })
+      .eq("user_id", user.id)
+      .eq("tournament_id", id)
+      .in("status", ["pending_payment", "confirmed"]);
+    isRegistered = (count ?? 0) > 0;
+  }
+
+  return (
+    <TournamentDetail
+      tournament={tournament}
+      isAuthenticated={!!user}
+      isRegistered={isRegistered}
+    />
+  );
 }
 
 export default async function TournamentDetailPage({


### PR DESCRIPTION
Closes #245

## Changes

- Show "Registration Closed" (disabled) when registration deadline has passed
- Show "Registered" (disabled) when authenticated user has already registered
- Server-side query of registrations table to determine isRegistered status
- New tests for both button states

Generated with [Claude Code](https://claude.ai/code)