### PR TITLE
fix: remove cursor-pointer from tournament card

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -134,7 +134,7 @@
   }
 
   .tournament-card {
-    @apply transition duration-200 cursor-pointer;
+    @apply transition duration-200;
   }
 
   .tournament-card:hover {


### PR DESCRIPTION
Removes the `cursor-pointer` utility from the `.tournament-card` CSS class so the cursor remains the default arrow when hovering the card. The `View →` button retains its own `cursor-pointer` via `.card-btn-view`.

Closes #159

Generated with [Claude Code](https://claude.ai/code)