### PR TITLE
feat: GET /player/registrations API + My Tournaments dashboard

### DIFF
--- a/src/app/api/v1/player/registrations/__tests__/route.test.ts
+++ b/src/app/api/v1/player/registrations/__tests__/route.test.ts
@@ -1,0 +1,340 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+// ---------------------------------------------------------------------------
+// Mock Supabase server client (user auth)
+// ---------------------------------------------------------------------------
+
+const { mockGetUser } = vi.hoisted(() => {
+  const mockGetUser = vi.fn();
+  return { mockGetUser };
+});
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock Supabase admin client (data queries)
+// ---------------------------------------------------------------------------
+
+const { mockRegistrationsBuilder, mockFrom } = vi.hoisted(() => {
+  function makeBuilder(finalResult: { data: unknown; error: unknown }) {
+    const chain: Record<string, unknown> = {};
+    const methods = ["select", "eq", "in", "order"];
+    for (const m of methods) {
+      chain[m] = vi.fn(() => chain);
+    }
+    chain.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return chain;
+  }
+
+  const mockRegistrationsBuilder = makeBuilder({ data: [], error: null });
+  const mockFrom = vi.fn(() => mockRegistrationsBuilder);
+  return { mockRegistrationsBuilder, mockFrom };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const AUTHENTICATED_USER = { id: "user-123" };
+
+function makeRegistration(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "reg-1",
+    fee_tier: "standard",
+    status: "confirmed",
+    registered_at: "2026-02-22T12:00:00Z",
+    confirmed_at: "2026-02-22T12:01:30Z",
+    tournaments: {
+      id: "tournament-1",
+      name: "KL Open Rapid 2026",
+      start_date: "2026-03-15",
+      venue_name: "Kuala Lumpur Convention Centre",
+      venue_state: "Kuala Lumpur",
+      format: { type: "rapid", system: "swiss", rounds: 7 },
+      time_control: { base_minutes: 10, increment_seconds: 5, delay_seconds: 0 },
+      entry_fees: { standard: { amount_cents: 5000 }, additional: [] },
+      status: "published",
+    },
+    ...overrides,
+  };
+}
+
+function makeRequest(url = "http://localhost/api/v1/player/registrations") {
+  return new NextRequest(url);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setQueryResult(data: unknown, error: unknown = null) {
+  const result = { data, error };
+  (mockRegistrationsBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve(result).then(onfulfilled, onrejected);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/player/registrations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: AUTHENTICATED_USER } });
+    setQueryResult([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+
+      const res = await GET(makeRequest());
+      const json = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(json.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("queries registrations for the authenticated user only", async () => {
+      setQueryResult([]);
+
+      await GET(makeRequest());
+
+      const eqMock = mockRegistrationsBuilder.eq as ReturnType<typeof vi.fn>;
+      expect(eqMock).toHaveBeenCalledWith("user_id", AUTHENTICATED_USER.id);
+    });
+  });
+
+  describe("response shape", () => {
+    it("returns 200 with data, next_cursor, and has_more", async () => {
+      setQueryResult([makeRegistration()]);
+
+      const res = await GET(makeRequest());
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json).toHaveProperty("data");
+      expect(json).toHaveProperty("next_cursor", null);
+      expect(json).toHaveProperty("has_more", false);
+      expect(Array.isArray(json.data)).toBe(true);
+    });
+
+    it("shapes each registration item correctly", async () => {
+      setQueryResult([makeRegistration()]);
+
+      const res = await GET(makeRequest());
+      const json = await res.json();
+      const item = json.data[0];
+
+      expect(item.id).toBe("reg-1");
+      expect(item.fee_tier).toBe("standard");
+      expect(item.status).toBe("confirmed");
+      expect(item.registered_at).toBe("2026-02-22T12:00:00Z");
+      expect(item.confirmed_at).toBe("2026-02-22T12:01:30Z");
+      expect(item.tournament).toEqual({
+        id: "tournament-1",
+        name: "KL Open Rapid 2026",
+        start_date: "2026-03-15",
+        venue_name: "Kuala Lumpur Convention Centre",
+        venue_state: "Kuala Lumpur",
+        format: { type: "rapid", system: "swiss", rounds: 7 },
+        time_control: { base_minutes: 10, increment_seconds: 5, delay_seconds: 0 },
+        status: "published",
+      });
+    });
+
+    it("computes entry_fee_cents from standard fee tier", async () => {
+      setQueryResult([makeRegistration({ fee_tier: "standard" })]);
+
+      const res = await GET(makeRequest());
+      const json = await res.json();
+
+      expect(json.data[0].entry_fee_cents).toBe(5000);
+    });
+
+    it("computes entry_fee_cents from additional fee tier", async () => {
+      setQueryResult([
+        makeRegistration({
+          fee_tier: "early_bird",
+          tournaments: {
+            id: "tournament-1",
+            name: "KL Open Rapid 2026",
+            start_date: "2026-03-15",
+            venue_name: "KLCC",
+            venue_state: "Kuala Lumpur",
+            format: { type: "rapid", system: "swiss", rounds: 7 },
+            time_control: { base_minutes: 10, increment_seconds: 5, delay_seconds: 0 },
+            entry_fees: {
+              standard: { amount_cents: 5000 },
+              additional: [
+                { type: "early_bird", amount_cents: 3500, valid_until: "2026-03-01" },
+              ],
+            },
+            status: "published",
+          },
+        }),
+      ]);
+
+      const res = await GET(makeRequest());
+      const json = await res.json();
+
+      expect(json.data[0].entry_fee_cents).toBe(3500);
+    });
+
+    it("sets entry_fee_cents to null for unknown fee tier", async () => {
+      setQueryResult([makeRegistration({ fee_tier: "unknown_tier" })]);
+
+      const res = await GET(makeRequest());
+      const json = await res.json();
+
+      expect(json.data[0].entry_fee_cents).toBeNull();
+    });
+
+    it("returns empty data array when there are no registrations", async () => {
+      setQueryResult([]);
+
+      const res = await GET(makeRequest());
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.data).toEqual([]);
+    });
+  });
+
+  describe("status filter", () => {
+    it("applies status filter when provided", async () => {
+      setQueryResult([]);
+      const req = makeRequest(
+        "http://localhost/api/v1/player/registrations?status=confirmed",
+      );
+
+      await GET(req);
+
+      const inMock = mockRegistrationsBuilder.in as ReturnType<typeof vi.fn>;
+      expect(inMock).toHaveBeenCalledWith("status", ["confirmed"]);
+    });
+
+    it("accepts comma-separated status values", async () => {
+      setQueryResult([]);
+      const req = makeRequest(
+        "http://localhost/api/v1/player/registrations?status=confirmed,pending_payment",
+      );
+
+      await GET(req);
+
+      const inMock = mockRegistrationsBuilder.in as ReturnType<typeof vi.fn>;
+      expect(inMock).toHaveBeenCalledWith("status", [
+        "confirmed",
+        "pending_payment",
+      ]);
+    });
+
+    it("returns 400 for invalid status value", async () => {
+      const req = makeRequest(
+        "http://localhost/api/v1/player/registrations?status=invalid_status",
+      );
+
+      const res = await GET(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("does not apply status filter when not provided", async () => {
+      setQueryResult([]);
+
+      await GET(makeRequest());
+
+      const inMock = mockRegistrationsBuilder.in as ReturnType<typeof vi.fn>;
+      expect(inMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sorting", () => {
+    it("defaults to sorting by registered_at descending", async () => {
+      setQueryResult([]);
+
+      await GET(makeRequest());
+
+      const orderMock = mockRegistrationsBuilder.order as ReturnType<
+        typeof vi.fn
+      >;
+      expect(orderMock).toHaveBeenCalledWith("registered_at", {
+        ascending: false,
+      });
+    });
+
+    it("sorts ascending when order=asc", async () => {
+      setQueryResult([]);
+      const req = makeRequest(
+        "http://localhost/api/v1/player/registrations?sort=registered_at&order=asc",
+      );
+
+      await GET(req);
+
+      const orderMock = mockRegistrationsBuilder.order as ReturnType<
+        typeof vi.fn
+      >;
+      expect(orderMock).toHaveBeenCalledWith("registered_at", {
+        ascending: true,
+      });
+    });
+
+    it("returns 400 for invalid sort field", async () => {
+      const req = makeRequest(
+        "http://localhost/api/v1/player/registrations?sort=invalid_field",
+      );
+
+      const res = await GET(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 for invalid order value", async () => {
+      const req = makeRequest(
+        "http://localhost/api/v1/player/registrations?order=sideways",
+      );
+
+      const res = await GET(req);
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns 500 when Supabase returns an error", async () => {
+      setQueryResult(null, { message: "DB connection failed" });
+
+      const res = await GET(makeRequest());
+      const json = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+      expect(json.error.message).toBe("DB connection failed");
+    });
+  });
+});

--- a/src/app/api/v1/player/registrations/route.ts
+++ b/src/app/api/v1/player/registrations/route.ts
@@ -118,7 +118,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const rows = (data ?? []) as RegistrationRow[];
+  const rows = (data ?? []) as unknown as RegistrationRow[];
 
   const formatted = rows.map((row) => {
     const fees = row.tournaments.entry_fees;

--- a/src/app/api/v1/player/registrations/route.ts
+++ b/src/app/api/v1/player/registrations/route.ts
@@ -1,0 +1,159 @@
+import { createClient } from "@/services/supabase/server";
+import { supabaseAdmin } from "@/services/supabase/admin";
+import { NextRequest, NextResponse } from "next/server";
+import type { EntryFees } from "@/app/tournaments/types";
+
+const VALID_STATUSES = new Set([
+  "pending_payment",
+  "failed_payment",
+  "cancelled_payment",
+  "confirmed",
+  "forfeited",
+]);
+const VALID_SORT = new Set(["registered_at", "confirmed_at"]);
+const VALID_ORDER = new Set(["asc", "desc"]);
+
+type TournamentRow = {
+  id: string;
+  name: string;
+  start_date: string;
+  venue_name: string;
+  venue_state: string;
+  format: unknown;
+  time_control: unknown;
+  entry_fees: EntryFees;
+  status: string;
+};
+
+type RegistrationRow = {
+  id: string;
+  fee_tier: string;
+  status: string;
+  registered_at: string;
+  confirmed_at: string | null;
+  tournaments: TournamentRow;
+};
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  const { searchParams } = request.nextUrl;
+
+  const statusParam = searchParams.get("status");
+  let statuses: string[] | null = null;
+  if (statusParam) {
+    const requested = statusParam.split(",").map((s) => s.trim());
+    const invalid = requested.filter((s) => !VALID_STATUSES.has(s));
+    if (invalid.length > 0) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: `Invalid status value(s): ${invalid.join(", ")}`,
+          },
+        },
+        { status: 400 },
+      );
+    }
+    statuses = requested;
+  }
+
+  const sort = searchParams.get("sort") ?? "registered_at";
+  if (!VALID_SORT.has(sort)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: `Invalid sort field: ${sort}`,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const order = searchParams.get("order") ?? "desc";
+  if (!VALID_ORDER.has(order)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: `Invalid order: ${order}`,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  let query = supabaseAdmin
+    .from("registrations")
+    .select(
+      `id, fee_tier, status, registered_at, confirmed_at,
+      tournaments!inner (
+        id, name, start_date, venue_name, venue_state, format, time_control, entry_fees, status
+      )`,
+    )
+    .eq("user_id", user.id)
+    .order(sort, { ascending: order === "asc" });
+
+  if (statuses) {
+    query = query.in("status", statuses);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 500 },
+    );
+  }
+
+  const rows = (data ?? []) as RegistrationRow[];
+
+  const formatted = rows.map((row) => {
+    const fees = row.tournaments.entry_fees;
+    let entry_fee_cents: number | null = null;
+    if (fees) {
+      if (row.fee_tier === "standard") {
+        entry_fee_cents = fees.standard?.amount_cents ?? null;
+      } else {
+        const tier = fees.additional?.find((t) => t.type === row.fee_tier);
+        entry_fee_cents = tier?.amount_cents ?? null;
+      }
+    }
+
+    return {
+      id: row.id,
+      tournament: {
+        id: row.tournaments.id,
+        name: row.tournaments.name,
+        start_date: row.tournaments.start_date,
+        venue_name: row.tournaments.venue_name,
+        venue_state: row.tournaments.venue_state,
+        format: row.tournaments.format,
+        time_control: row.tournaments.time_control,
+        status: row.tournaments.status,
+      },
+      fee_tier: row.fee_tier,
+      entry_fee_cents,
+      status: row.status,
+      registered_at: row.registered_at,
+      confirmed_at: row.confirmed_at,
+    };
+  });
+
+  return NextResponse.json(
+    { data: formatted, next_cursor: null, has_more: false },
+    { status: 200 },
+  );
+}

--- a/src/app/player/registrations/_components/RegistrationsClient.tsx
+++ b/src/app/player/registrations/_components/RegistrationsClient.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import type { PlayerRegistration, RegistrationStatus } from "../types";
+import type { TournamentFormat, TimeControl } from "@/app/tournaments/types";
+
+type Tab = "upcoming" | "past" | "cancelled";
+
+interface Props {
+  registrations: PlayerRegistration[];
+}
+
+function classifyRegistration(
+  reg: PlayerRegistration,
+  today: Date,
+): Tab | null {
+  const startDate = new Date(reg.tournament.start_date + "T00:00:00");
+  const isActive =
+    reg.status === "confirmed" || reg.status === "pending_payment";
+  const isCancelled =
+    reg.status === "cancelled_payment" ||
+    reg.status === "failed_payment";
+  const isCompleted =
+    reg.status === "confirmed" || reg.status === "forfeited";
+
+  if (isCancelled) return "cancelled";
+  if (isActive && startDate >= today) return "upcoming";
+  if (isCompleted && startDate < today) return "past";
+  // pending_payment for past tournament — treat as past
+  if (startDate < today) return "past";
+  return "upcoming";
+}
+
+function formatTimeControl(tc: TimeControl): string {
+  return `${tc.base_minutes}+${tc.increment_seconds}`;
+}
+
+function formatTournamentType(format: TournamentFormat): string {
+  return format.type.charAt(0).toUpperCase() + format.type.slice(1);
+}
+
+function StatusBadge({ status }: { status: RegistrationStatus }) {
+  const config: Record<
+    RegistrationStatus,
+    { label: string; className: string }
+  > = {
+    confirmed: {
+      label: "Confirmed",
+      className:
+        "bg-success/10 text-success border border-success/20",
+    },
+    pending_payment: {
+      label: "Pending Payment",
+      className:
+        "bg-warning/15 text-warning border border-warning/20",
+    },
+    failed_payment: {
+      label: "Payment Failed",
+      className:
+        "bg-danger/15 text-danger border border-danger/20",
+    },
+    cancelled_payment: {
+      label: "Cancelled",
+      className:
+        "bg-bg-raised text-text-muted border border-border",
+    },
+    forfeited: {
+      label: "Forfeited",
+      className:
+        "bg-bg-raised text-text-muted border border-border",
+    },
+  };
+
+  const { label, className } = config[status] ?? config.cancelled_payment;
+
+  return (
+    <span
+      className={`font-cinzel text-2xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${className}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+interface RegistrationCardProps {
+  registration: PlayerRegistration;
+  dimmed?: boolean;
+}
+
+function RegistrationCard({ registration, dimmed }: RegistrationCardProps) {
+  const { tournament, status } = registration;
+  const startDate = new Date(tournament.start_date + "T00:00:00");
+  const month = startDate.toLocaleString("en-MY", { month: "short" }).toUpperCase();
+  const day = startDate.getDate();
+  const format = tournament.format as TournamentFormat;
+  const tc = tournament.time_control as TimeControl;
+
+  return (
+    <Link
+      href={`/tournaments/${tournament.id}`}
+      className={`flex items-center gap-4 card px-5 py-4 no-underline transition-shadow duration-150 hover:shadow-[0_4px_20px_var(--color-grandiose-hover)] ${dimmed ? "opacity-60" : ""}`}
+    >
+      {/* Date block */}
+      <div className="text-center min-w-12 shrink-0">
+        <div className="font-cinzel text-2xs font-bold tracking-widest text-gold-bright">
+          {month}
+        </div>
+        <div className="font-cinzel text-2xl font-bold text-text-primary leading-tight">
+          {day}
+        </div>
+      </div>
+
+      {/* Tournament info */}
+      <div className="flex-1 min-w-0">
+        <h4 className="font-lato text-sm font-semibold text-text-primary truncate">
+          {tournament.name}
+        </h4>
+        <p className="font-lato text-xs text-text-muted mt-0.5">
+          {tournament.venue_name}
+          {format && tc && (
+            <>
+              {" · "}
+              {formatTournamentType(format)}
+              {" · "}
+              {formatTimeControl(tc)}
+            </>
+          )}
+        </p>
+      </div>
+
+      {/* Status badge */}
+      <StatusBadge status={status} />
+    </Link>
+  );
+}
+
+function EmptyState({ tab }: { tab: Tab }) {
+  const messages: Record<Tab, string> = {
+    upcoming: "No upcoming tournaments. Browse available tournaments to register.",
+    past: "No past tournaments yet.",
+    cancelled: "No cancelled registrations.",
+  };
+
+  return (
+    <div className="text-center py-16 px-5">
+      <div className="text-4xl mb-4 opacity-20">♟</div>
+      <p className="font-lato text-sm text-text-muted leading-relaxed">
+        {messages[tab]}
+      </p>
+      {tab === "upcoming" && (
+        <Link
+          href="/tournaments"
+          className="btn-secondary mt-4 inline-block px-5 py-2 text-xs"
+        >
+          Browse Tournaments
+        </Link>
+      )}
+    </div>
+  );
+}
+
+export default function RegistrationsClient({ registrations }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("upcoming");
+  const today = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }, []);
+
+  const categorised = useMemo(() => {
+    const upcoming: PlayerRegistration[] = [];
+    const past: PlayerRegistration[] = [];
+    const cancelled: PlayerRegistration[] = [];
+
+    for (const reg of registrations) {
+      const tab = classifyRegistration(reg, today);
+      if (tab === "upcoming") upcoming.push(reg);
+      else if (tab === "past") past.push(reg);
+      else if (tab === "cancelled") cancelled.push(reg);
+    }
+
+    return { upcoming, past, cancelled };
+  }, [registrations, today]);
+
+  const tabs: Array<{ key: Tab; label: string; count: number }> = [
+    { key: "upcoming", label: "Upcoming", count: categorised.upcoming.length },
+    { key: "past", label: "Past", count: categorised.past.length },
+    { key: "cancelled", label: "Cancelled", count: categorised.cancelled.length },
+  ];
+
+  const items = categorised[activeTab];
+
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8">
+      <h1 className="font-cinzel text-2xl font-bold text-text-primary tracking-wide mb-1">
+        My Tournaments
+      </h1>
+      <p className="font-lato text-sm text-text-muted mb-6">
+        Manage your registrations and view upcoming events.
+      </p>
+
+      {/* Tabs */}
+      <div className="flex border-b border-border mb-5">
+        {tabs.map(({ key, label, count }) => (
+          <button
+            key={key}
+            onClick={() => setActiveTab(key)}
+            className={`font-lato text-sm font-medium px-4 py-2.5 border-b-2 transition-colors duration-150 cursor-pointer bg-transparent ${
+              activeTab === key
+                ? "text-text-primary border-gold-bright"
+                : "text-text-muted border-transparent hover:text-text-secondary"
+            }`}
+          >
+            {label}
+            {count > 0 && (
+              <span
+                className={`ml-1.5 font-cinzel text-2xs font-bold px-1.5 py-0.5 rounded-full ${
+                  activeTab === key
+                    ? "bg-gold-ghost text-gold-bright"
+                    : "bg-bg-raised text-text-muted"
+                }`}
+              >
+                {count}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Registration list */}
+      {items.length === 0 ? (
+        <EmptyState tab={activeTab} />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {items.map((reg) => (
+            <RegistrationCard
+              key={reg.id}
+              registration={reg}
+              dimmed={activeTab === "past"}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/player/registrations/page.tsx
+++ b/src/app/player/registrations/page.tsx
@@ -1,0 +1,53 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import { createClient } from "@/services/supabase/server";
+import RegistrationsClient from "./_components/RegistrationsClient";
+import type { PlayerRegistration } from "./types";
+
+export const metadata: Metadata = {
+  title: "My Tournaments",
+  description: "View and manage your chess tournament registrations.",
+};
+
+async function fetchRegistrations(host: string): Promise<PlayerRegistration[]> {
+  const protocol =
+    host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https";
+
+  try {
+    const res = await fetch(
+      `${protocol}://${host}/api/v1/player/registrations?sort=registered_at&order=desc`,
+      { cache: "no-store" },
+    );
+    if (!res.ok) return [];
+    const json = await res.json();
+    return json.data ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export default async function PlayerRegistrationsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/login");
+  }
+
+  const headersList = await headers();
+  const host = headersList.get("host") ?? "localhost:3000";
+  const registrations = await fetchRegistrations(host);
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <RegistrationsClient registrations={registrations} />
+    </div>
+  );
+}

--- a/src/app/player/registrations/page.tsx
+++ b/src/app/player/registrations/page.tsx
@@ -11,7 +11,10 @@ export const metadata: Metadata = {
   description: "View and manage your chess tournament registrations.",
 };
 
-async function fetchRegistrations(host: string): Promise<PlayerRegistration[]> {
+async function fetchRegistrations(
+  host: string,
+  cookieHeader: string,
+): Promise<PlayerRegistration[]> {
   const protocol =
     host.startsWith("localhost") || host.startsWith("127.0.0.1")
       ? "http"
@@ -20,7 +23,10 @@ async function fetchRegistrations(host: string): Promise<PlayerRegistration[]> {
   try {
     const res = await fetch(
       `${protocol}://${host}/api/v1/player/registrations?sort=registered_at&order=desc`,
-      { cache: "no-store" },
+      {
+        cache: "no-store",
+        headers: { cookie: cookieHeader },
+      },
     );
     if (!res.ok) return [];
     const json = await res.json();
@@ -42,7 +48,8 @@ export default async function PlayerRegistrationsPage() {
 
   const headersList = await headers();
   const host = headersList.get("host") ?? "localhost:3000";
-  const registrations = await fetchRegistrations(host);
+  const cookieHeader = headersList.get("cookie") ?? "";
+  const registrations = await fetchRegistrations(host, cookieHeader);
 
   return (
     <div className="min-h-screen bg-bg-base">

--- a/src/app/player/registrations/types.ts
+++ b/src/app/player/registrations/types.ts
@@ -1,0 +1,27 @@
+import type { TournamentFormat, TimeControl } from "@/app/tournaments/types";
+
+export type RegistrationStatus =
+  | "pending_payment"
+  | "failed_payment"
+  | "cancelled_payment"
+  | "confirmed"
+  | "forfeited";
+
+export interface PlayerRegistration {
+  id: string;
+  tournament: {
+    id: string;
+    name: string;
+    start_date: string;
+    venue_name: string;
+    venue_state: string;
+    format: TournamentFormat;
+    time_control: TimeControl;
+    status: string;
+  };
+  fee_tier: string;
+  entry_fee_cents: number | null;
+  status: RegistrationStatus;
+  registered_at: string;
+  confirmed_at: string | null;
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -131,8 +131,8 @@ export default function NavBar() {
             {authUser ? (
               <>
                 <Link
-                  href="/tournaments"
-                  className={`nav-link${pathname === "/tournaments" ? " nav-link--active" : ""}`}
+                  href="/player/registrations"
+                  className={`nav-link${pathname === "/player/registrations" ? " nav-link--active" : ""}`}
                 >
                   My Tournaments
                 </Link>
@@ -163,7 +163,7 @@ export default function NavBar() {
                           My Profile
                         </Link>
                         <Link
-                          href="/tournaments"
+                          href="/player/registrations"
                           className="nav-dropdown-item"
                           onClick={() => setDropdownOpen(false)}
                         >
@@ -289,11 +289,11 @@ export default function NavBar() {
           {authUser ? (
             <>
               <Link
-                href="/tournaments"
+                href="/player/registrations"
                 onClick={() =>
                   setDrawerState((current) => closeDrawer(current))
                 }
-                className={`nav-drawer-link${pathname === "/tournaments" ? " nav-drawer-link--active" : ""}`}
+                className={`nav-drawer-link${pathname === "/player/registrations" ? " nav-drawer-link--active" : ""}`}
               >
                 My Tournaments
               </Link>


### PR DESCRIPTION
Closes #49, closes #50

## Summary

- Add `GET /api/v1/player/registrations` API route with status/sort/order query params
- Add `/player/registrations` dashboard page with Upcoming/Past/Cancelled tabs and status badges
- Update NavBar "My Tournaments" links to `/player/registrations`

## Test plan

- [x] 17 new unit tests for the API route (auth, response shape, filtering, sorting, errors)
- [ ] Manual: log in and navigate to /player/registrations
- [ ] Manual: verify unauthenticated access redirects to /auth/login
- [ ] Manual: verify registrations appear in correct tabs with correct status badges

Generated with [Claude Code](https://claude.ai/code)