### PR TITLE
feat: add T&C and Privacy Policy modals on sign-up page (#179, #180)

### DIFF
--- a/src/app/auth/signup/_components/PrivacyModal.tsx
+++ b/src/app/auth/signup/_components/PrivacyModal.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface PrivacyModalProps {
+  onClose: () => void;
+}
+
+export default function PrivacyModal({ onClose }: PrivacyModalProps) {
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="privacy-modal-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="modal modal--featured">
+        <div className="modal-header">
+          <h2 id="privacy-modal-title" className="modal-title">
+            Privacy Policy
+          </h2>
+          <button
+            type="button"
+            className="modal-close"
+            onClick={onClose}
+            aria-label="Close Privacy Policy"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <p className="modal-paragraph">
+            <strong>Effective Date: 1 June 2025</strong>
+          </p>
+          <p className="modal-paragraph">
+            MY Chess Tour (&quot;MCT&quot;, &quot;we&quot;, &quot;us&quot;, or
+            &quot;our&quot;) is committed to protecting your personal data in
+            accordance with the{" "}
+            <strong>Personal Data Protection Act 2010 (PDPA)</strong> of
+            Malaysia. This Privacy Policy explains what data we collect, how we
+            use it, and your rights.
+          </p>
+
+          <h3 className="modal-section-title">1. Data We Collect</h3>
+          <p className="modal-paragraph">
+            We collect the following categories of personal data:
+          </p>
+
+          <p className="modal-paragraph">
+            <strong>Account Data</strong>
+          </p>
+          <ul className="modal-list">
+            <li>First name, last name</li>
+            <li>Email address</li>
+            <li>Profile avatar</li>
+          </ul>
+
+          <p className="modal-paragraph">
+            <strong>Player Profile Data</strong>
+          </p>
+          <ul className="modal-list">
+            <li>Nationality</li>
+            <li>FIDE ID and MCF ID</li>
+            <li>
+              Date of birth, gender — collected for age-category eligibility and
+              FIDE registration
+            </li>
+            <li>
+              OKU (disability) status — collected solely to facilitate
+              accessibility requirements at events
+            </li>
+          </ul>
+
+          <p className="modal-paragraph">
+            <strong>Financial Data</strong> (collected only for prize payout
+            purposes)
+          </p>
+          <ul className="modal-list">
+            <li>Bank account number</li>
+            <li>Bank account holder name</li>
+            <li>Bank name</li>
+          </ul>
+
+          <p className="modal-paragraph">
+            <strong>Tournament & Registration Data</strong>
+          </p>
+          <ul className="modal-list">
+            <li>Tournament registration records</li>
+            <li>Payment records (amounts, dates, transaction IDs)</li>
+          </ul>
+
+          <h3 className="modal-section-title">
+            2. Sensitive Personal Data
+          </h3>
+          <p className="modal-paragraph">
+            Under the PDPA, certain data requires your explicit consent before
+            collection:
+          </p>
+          <table className="modal-table">
+            <thead>
+              <tr>
+                <th>Data Field</th>
+                <th>Reason for Collection</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>OKU (disability) status</td>
+                <td>Event accessibility and FIDE Special Needs registration</td>
+              </tr>
+              <tr>
+                <td>Date of birth</td>
+                <td>Age-category eligibility; identity verification</td>
+              </tr>
+              <tr>
+                <td>Gender</td>
+                <td>Gender-restricted event categories (e.g. Women&apos;s Open)</td>
+              </tr>
+            </tbody>
+          </table>
+          <p className="modal-paragraph">
+            By providing this data, you give explicit consent for its use as
+            described above.
+          </p>
+
+          <h3 className="modal-section-title">3. How We Use Your Data</h3>
+          <ul className="modal-list">
+            <li>To create and manage your MCT account.</li>
+            <li>To register you for tournaments and verify eligibility.</li>
+            <li>To submit ratings to FIDE and MCF on your behalf.</li>
+            <li>To process prize payouts via bank transfer.</li>
+            <li>
+              To send you tournament updates, results, and important
+              notifications.
+            </li>
+            <li>
+              To comply with legal obligations under Malaysian law.
+            </li>
+          </ul>
+          <p className="modal-paragraph">
+            We do not sell, rent, or trade your personal data to third parties
+            for marketing purposes.
+          </p>
+
+          <h3 className="modal-section-title">4. Data Retention</h3>
+          <p className="modal-paragraph">
+            We retain your data only as long as necessary:
+          </p>
+          <table className="modal-table">
+            <thead>
+              <tr>
+                <th>Data Type</th>
+                <th>Retention Period</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Personal profile data</td>
+                <td>30 days after account deletion request</td>
+              </tr>
+              <tr>
+                <td>Financial / payment records</td>
+                <td>7 years from transaction date (Income Tax Act requirement)</td>
+              </tr>
+              <tr>
+                <td>Tournament results &amp; pairings</td>
+                <td>Kept indefinitely (not personal data)</td>
+              </tr>
+              <tr>
+                <td>Registration records</td>
+                <td>
+                  Personal fields anonymised after account deletion; financial
+                  facts retained for 7 years
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h3 className="modal-section-title">5. Data Security</h3>
+          <p className="modal-paragraph">
+            We implement appropriate technical and organisational measures to
+            protect your data:
+          </p>
+          <ul className="modal-list">
+            <li>
+              Sensitive personal data (OKU status, date of birth, gender) and
+              financial data (bank details) are encrypted at rest.
+            </li>
+            <li>All data is transmitted over encrypted connections (HTTPS/TLS).</li>
+            <li>Access to personal data is restricted to authorised personnel only.</li>
+          </ul>
+
+          <h3 className="modal-section-title">6. Your Rights Under PDPA</h3>
+          <p className="modal-paragraph">
+            As a data subject under the PDPA, you have the right to:
+          </p>
+          <ul className="modal-list">
+            <li>
+              <strong>Access</strong> — request a copy of the personal data we
+              hold about you.
+            </li>
+            <li>
+              <strong>Correction</strong> — request correction of inaccurate or
+              incomplete data.
+            </li>
+            <li>
+              <strong>Withdrawal of consent</strong> — withdraw consent for the
+              processing of sensitive personal data at any time (note: this may
+              affect your ability to participate in certain events).
+            </li>
+            <li>
+              <strong>Data deletion</strong> — request deletion of your account
+              and associated personal data, subject to our retention obligations.
+            </li>
+          </ul>
+          <p className="modal-paragraph">
+            To exercise any of these rights, contact us at{" "}
+            <strong>privacy@mychesstour.com</strong>.
+          </p>
+
+          <h3 className="modal-section-title">7. Sharing of Data</h3>
+          <p className="modal-paragraph">
+            We may share your data with the following third parties only where
+            necessary:
+          </p>
+          <ul className="modal-list">
+            <li>
+              <strong>FIDE</strong> — for rating submission and player
+              registration.
+            </li>
+            <li>
+              <strong>Malaysian Chess Federation (MCF)</strong> — for MCF-rated
+              event registration.
+            </li>
+            <li>
+              <strong>Tournament organisers</strong> — name, FIDE/MCF ID, and
+              rating for pairing and certification purposes.
+            </li>
+            <li>
+              <strong>Payment processors</strong> — for processing entry fees
+              and prize disbursements.
+            </li>
+          </ul>
+
+          <h3 className="modal-section-title">8. Cookies</h3>
+          <p className="modal-paragraph">
+            We use session cookies essential for authentication and platform
+            functionality. We do not use advertising or tracking cookies.
+          </p>
+
+          <h3 className="modal-section-title">9. Changes to This Policy</h3>
+          <p className="modal-paragraph">
+            We may update this Privacy Policy from time to time. We will notify
+            you of significant changes via email or a platform notice at least 14
+            days before they take effect.
+          </p>
+
+          <h3 className="modal-section-title">10. Contact Us</h3>
+          <p className="modal-paragraph">
+            For privacy-related inquiries or to exercise your PDPA rights,
+            contact our Data Protection Officer at{" "}
+            <strong>privacy@mychesstour.com</strong>.
+          </p>
+        </div>
+
+        <div className="modal-footer">
+          <button type="button" className="btn-secondary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/auth/signup/_components/SignUpForm.tsx
+++ b/src/app/auth/signup/_components/SignUpForm.tsx
@@ -13,6 +13,8 @@ import {
 import StepTracker from "./StepTracker";
 import { useSignUpForm } from "./SignUpContext";
 import { SIGNUP_STEP_COOKIE, SIGNUP_STEP_MAX_AGE } from "@/lib/signup-cookie";
+import TermsModal from "./TermsModal";
+import PrivacyModal from "./PrivacyModal";
 
 export default function SignUpForm() {
   const { form, setForm } = useSignUpForm();
@@ -21,6 +23,8 @@ export default function SignUpForm() {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [errors, setErrors] = useState<RegistrationErrors>({});
   const [submitted, setSubmitted] = useState(false);
+  const [showTermsModal, setShowTermsModal] = useState(false);
+  const [showPrivacyModal, setShowPrivacyModal] = useState(false);
 
   const passwordReqs = checkPasswordRequirements(form.password);
   const passwordStrength = getPasswordStrength(form.password);
@@ -333,8 +337,22 @@ export default function SignUpForm() {
                 className={`check-label ${errors.terms ? "" : "mb-2"}`}
                 htmlFor="terms"
               >
-                I agree to the <Link href="/terms">Terms of Service</Link> and{" "}
-                <Link href="/privacy">Privacy Policy</Link>
+                I agree to the{" "}
+                <button
+                  type="button"
+                  className="modal-trigger-link"
+                  onClick={() => setShowTermsModal(true)}
+                >
+                  Terms of Service
+                </button>{" "}
+                and{" "}
+                <button
+                  type="button"
+                  className="modal-trigger-link"
+                  onClick={() => setShowPrivacyModal(true)}
+                >
+                  Privacy Policy
+                </button>
               </label>
             </div>
             {errors.terms && (
@@ -359,6 +377,13 @@ export default function SignUpForm() {
           </p>
         </div>
       </div>
+
+      {showTermsModal && (
+        <TermsModal onClose={() => setShowTermsModal(false)} />
+      )}
+      {showPrivacyModal && (
+        <PrivacyModal onClose={() => setShowPrivacyModal(false)} />
+      )}
     </div>
   );
 }

--- a/src/app/auth/signup/_components/TermsModal.tsx
+++ b/src/app/auth/signup/_components/TermsModal.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface TermsModalProps {
+  onClose: () => void;
+}
+
+export default function TermsModal({ onClose }: TermsModalProps) {
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="terms-modal-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="modal modal--featured">
+        <div className="modal-header">
+          <h2 id="terms-modal-title" className="modal-title">
+            Terms of Service
+          </h2>
+          <button
+            type="button"
+            className="modal-close"
+            onClick={onClose}
+            aria-label="Close Terms of Service"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <p className="modal-paragraph">
+            <strong>Effective Date: 1 June 2025</strong>
+          </p>
+          <p className="modal-paragraph">
+            Welcome to MY Chess Tour (&quot;MCT&quot;, &quot;we&quot;,
+            &quot;us&quot;, or &quot;our&quot;). These Terms of Service govern
+            your use of our platform and services. By creating an account or
+            participating in any tournament, you agree to these terms.
+          </p>
+
+          <h3 className="modal-section-title">1. Acceptance of Terms</h3>
+          <p className="modal-paragraph">
+            By registering for an account or using any MCT service, you confirm
+            that you are at least 13 years of age (or have parental consent) and
+            that you agree to be bound by these Terms and our Privacy Policy. If
+            you do not agree, you may not use our services.
+          </p>
+
+          <h3 className="modal-section-title">2. Account Registration</h3>
+          <p className="modal-paragraph">
+            You must provide accurate, complete, and up-to-date information when
+            creating an account. Your name must match the name on your national
+            identity card (MyKad) or passport, as it is used for official
+            tournament records and FIDE/MCF registration.
+          </p>
+          <ul className="modal-list">
+            <li>You are responsible for maintaining the security of your account.</li>
+            <li>You must not share your credentials with any other person.</li>
+            <li>
+              You must notify us immediately if you suspect unauthorised access
+              to your account.
+            </li>
+            <li>Each individual may only maintain one active account.</li>
+          </ul>
+
+          <h3 className="modal-section-title">3. Tournament Participation</h3>
+          <p className="modal-paragraph">
+            All tournaments hosted on MY Chess Tour are governed by the Laws of
+            Chess as published by FIDE, unless otherwise specified by the
+            tournament arbiter. By registering for a tournament, you agree to:
+          </p>
+          <ul className="modal-list">
+            <li>Abide by all rules and decisions made by the chief arbiter.</li>
+            <li>
+              Compete with integrity and without the use of computer assistance
+              or other prohibited aids during play.
+            </li>
+            <li>
+              Provide accurate FIDE ID and/or MCF ID where required for rated
+              events.
+            </li>
+            <li>
+              Accept that results are final unless a formal appeal is submitted
+              within the time prescribed by the arbiter.
+            </li>
+          </ul>
+
+          <h3 className="modal-section-title">4. Payment & Refund Policy</h3>
+          <p className="modal-paragraph">
+            Tournament entry fees are stated on the event page and are collected
+            by the tournament organiser. Refund eligibility is determined by the
+            organiser&apos;s policy for that event, which will be displayed
+            during registration. MY Chess Tour is not liable for any disputes
+            between players and organisers regarding refunds.
+          </p>
+          <ul className="modal-list">
+            <li>
+              Prize money disbursement is the sole responsibility of the
+              tournament organiser.
+            </li>
+            <li>
+              MY Chess Tour may collect a platform service fee, which will be
+              disclosed at the time of registration.
+            </li>
+            <li>All fees are in Malaysian Ringgit (MYR) unless stated otherwise.</li>
+          </ul>
+
+          <h3 className="modal-section-title">5. Code of Conduct</h3>
+          <p className="modal-paragraph">
+            We are committed to a respectful and inclusive environment. All
+            users must:
+          </p>
+          <ul className="modal-list">
+            <li>Treat fellow players, organisers, and arbiters with respect.</li>
+            <li>
+              Refrain from harassment, discrimination, or abusive language on
+              the platform or at events.
+            </li>
+            <li>Not engage in cheating, sandbagging, or manipulation of ratings.</li>
+            <li>
+              Comply with any anti-doping requirements applicable to the event.
+            </li>
+          </ul>
+          <p className="modal-paragraph">
+            Violations may result in account suspension, disqualification from
+            events, or reporting to the Malaysian Chess Federation (MCF) and
+            FIDE.
+          </p>
+
+          <h3 className="modal-section-title">6. Intellectual Property</h3>
+          <p className="modal-paragraph">
+            All content on the MY Chess Tour platform — including logos,
+            graphics, software, and tournament data — is owned by or licensed to
+            MCT. You may not reproduce, distribute, or create derivative works
+            without our written permission.
+          </p>
+
+          <h3 className="modal-section-title">7. Limitation of Liability</h3>
+          <p className="modal-paragraph">
+            MY Chess Tour provides its platform on an &quot;as is&quot; basis.
+            To the fullest extent permitted by Malaysian law, we are not liable
+            for any indirect, incidental, or consequential damages arising from
+            your use of the platform or participation in any event.
+          </p>
+
+          <h3 className="modal-section-title">8. Amendments</h3>
+          <p className="modal-paragraph">
+            We may update these Terms from time to time. We will notify you of
+            material changes via email or a prominent notice on the platform.
+            Continued use of the platform after changes constitutes acceptance of
+            the revised Terms.
+          </p>
+
+          <h3 className="modal-section-title">9. Governing Law</h3>
+          <p className="modal-paragraph">
+            These Terms are governed by the laws of Malaysia. Any disputes shall
+            be subject to the exclusive jurisdiction of the courts of Kuala
+            Lumpur, Malaysia.
+          </p>
+
+          <h3 className="modal-section-title">10. Contact Us</h3>
+          <p className="modal-paragraph">
+            For questions about these Terms, please contact us at{" "}
+            <strong>support@mychesstour.com</strong>.
+          </p>
+        </div>
+
+        <div className="modal-footer">
+          <button type="button" className="btn-secondary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,335 @@
+import NavBar from "@/components/NavBar";
+
+export const metadata = {
+  title: "Privacy Policy",
+  description:
+    "Privacy Policy for MY Chess Tour — how we collect, use, and protect your personal data under the PDPA Malaysia.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <main className="max-w-3xl mx-auto px-6 py-16">
+        <div className="card card--featured p-8">
+          <div className="text-center mb-8">
+            <span className="auth-logo">MY Chess Tour</span>
+            <h1 className="auth-heading">Privacy Policy</h1>
+            <p className="auth-subheading">Effective Date: 1 June 2025</p>
+            <hr className="divider-gold" />
+          </div>
+
+          <div className="font-lato text-sm text-text-body leading-relaxed space-y-6">
+            <p className="text-text-secondary">
+              MY Chess Tour (&quot;MCT&quot;, &quot;we&quot;, &quot;us&quot;,
+              or &quot;our&quot;) is committed to protecting your personal data
+              in accordance with the{" "}
+              <strong>Personal Data Protection Act 2010 (PDPA)</strong> of
+              Malaysia. This Privacy Policy explains what data we collect, how
+              we use it, and your rights.
+            </p>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                1. Data We Collect
+              </h2>
+              <p className="text-text-secondary mb-2 font-semibold">
+                Account Data
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-4">
+                <li>First name, last name</li>
+                <li>Email address</li>
+                <li>Profile avatar</li>
+              </ul>
+
+              <p className="text-text-secondary mb-2 font-semibold">
+                Player Profile Data
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-4">
+                <li>Nationality</li>
+                <li>FIDE ID and MCF ID</li>
+                <li>
+                  Date of birth, gender — collected for age-category eligibility
+                  and FIDE registration
+                </li>
+                <li>
+                  OKU (disability) status — collected solely to facilitate
+                  accessibility requirements at events
+                </li>
+              </ul>
+
+              <p className="text-text-secondary mb-2 font-semibold">
+                Financial Data (collected only for prize payout purposes)
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-4">
+                <li>Bank account number</li>
+                <li>Bank account holder name</li>
+                <li>Bank name</li>
+              </ul>
+
+              <p className="text-text-secondary mb-2 font-semibold">
+                Tournament &amp; Registration Data
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+                <li>Tournament registration records</li>
+                <li>Payment records (amounts, dates, transaction IDs)</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                2. Sensitive Personal Data
+              </h2>
+              <p className="text-text-secondary mb-3">
+                Under the PDPA, certain data requires your explicit consent
+                before collection:
+              </p>
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-xs">
+                  <thead>
+                    <tr>
+                      <th className="font-cinzel tracking-widest uppercase text-gold-muted text-left px-3 py-2 border-b border-border">
+                        Data Field
+                      </th>
+                      <th className="font-cinzel tracking-widest uppercase text-gold-muted text-left px-3 py-2 border-b border-border">
+                        Reason for Collection
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        OKU (disability) status
+                      </td>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        Event accessibility and FIDE Special Needs registration
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        Date of birth
+                      </td>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        Age-category eligibility; identity verification
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="px-3 py-2 text-text-secondary">Gender</td>
+                      <td className="px-3 py-2 text-text-secondary">
+                        Gender-restricted event categories (e.g. Women&apos;s Open)
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-text-secondary mt-3">
+                By providing this data, you give explicit consent for its use as
+                described above.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                3. How We Use Your Data
+              </h2>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-2">
+                <li>To create and manage your MCT account.</li>
+                <li>
+                  To register you for tournaments and verify eligibility.
+                </li>
+                <li>To submit ratings to FIDE and MCF on your behalf.</li>
+                <li>To process prize payouts via bank transfer.</li>
+                <li>
+                  To send you tournament updates, results, and important
+                  notifications.
+                </li>
+                <li>
+                  To comply with legal obligations under Malaysian law.
+                </li>
+              </ul>
+              <p className="text-text-secondary">
+                We do not sell, rent, or trade your personal data to third
+                parties for marketing purposes.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                4. Data Retention
+              </h2>
+              <p className="text-text-secondary mb-3">
+                We retain your data only as long as necessary:
+              </p>
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-xs">
+                  <thead>
+                    <tr>
+                      <th className="font-cinzel tracking-widest uppercase text-gold-muted text-left px-3 py-2 border-b border-border">
+                        Data Type
+                      </th>
+                      <th className="font-cinzel tracking-widest uppercase text-gold-muted text-left px-3 py-2 border-b border-border">
+                        Retention Period
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        Personal profile data
+                      </td>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        30 days after account deletion request
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        Financial / payment records
+                      </td>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        7 years from transaction date (Income Tax Act requirement)
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        Tournament results &amp; pairings
+                      </td>
+                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                        Kept indefinitely (not personal data)
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="px-3 py-2 text-text-secondary">
+                        Registration records
+                      </td>
+                      <td className="px-3 py-2 text-text-secondary">
+                        Personal fields anonymised after account deletion;
+                        financial facts retained for 7 years
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                5. Data Security
+              </h2>
+              <p className="text-text-secondary mb-2">
+                We implement appropriate technical and organisational measures
+                to protect your data:
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+                <li>
+                  Sensitive personal data (OKU status, date of birth, gender)
+                  and financial data (bank details) are encrypted at rest.
+                </li>
+                <li>
+                  All data is transmitted over encrypted connections
+                  (HTTPS/TLS).
+                </li>
+                <li>
+                  Access to personal data is restricted to authorised personnel
+                  only.
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                6. Your Rights Under PDPA
+              </h2>
+              <p className="text-text-secondary mb-2">
+                As a data subject under the PDPA, you have the right to:
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-2">
+                <li>
+                  <strong>Access</strong> — request a copy of the personal data
+                  we hold about you.
+                </li>
+                <li>
+                  <strong>Correction</strong> — request correction of inaccurate
+                  or incomplete data.
+                </li>
+                <li>
+                  <strong>Withdrawal of consent</strong> — withdraw consent for
+                  the processing of sensitive personal data at any time (note:
+                  this may affect your ability to participate in certain events).
+                </li>
+                <li>
+                  <strong>Data deletion</strong> — request deletion of your
+                  account and associated personal data, subject to our retention
+                  obligations.
+                </li>
+              </ul>
+              <p className="text-text-secondary">
+                To exercise any of these rights, contact us at{" "}
+                <strong>privacy@mychesstour.com</strong>.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                7. Sharing of Data
+              </h2>
+              <p className="text-text-secondary mb-2">
+                We may share your data with the following third parties only
+                where necessary:
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+                <li>
+                  <strong>FIDE</strong> — for rating submission and player
+                  registration.
+                </li>
+                <li>
+                  <strong>Malaysian Chess Federation (MCF)</strong> — for
+                  MCF-rated event registration.
+                </li>
+                <li>
+                  <strong>Tournament organisers</strong> — name, FIDE/MCF ID,
+                  and rating for pairing and certification purposes.
+                </li>
+                <li>
+                  <strong>Payment processors</strong> — for processing entry
+                  fees and prize disbursements.
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                8. Cookies
+              </h2>
+              <p className="text-text-secondary">
+                We use session cookies essential for authentication and platform
+                functionality. We do not use advertising or tracking cookies.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                9. Changes to This Policy
+              </h2>
+              <p className="text-text-secondary">
+                We may update this Privacy Policy from time to time. We will
+                notify you of significant changes via email or a platform notice
+                at least 14 days before they take effect.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                10. Contact Us
+              </h2>
+              <p className="text-text-secondary">
+                For privacy-related inquiries or to exercise your PDPA rights,
+                contact our Data Protection Officer at{" "}
+                <strong>privacy@mychesstour.com</strong>.
+              </p>
+            </section>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,215 @@
+import NavBar from "@/components/NavBar";
+
+export const metadata = {
+  title: "Terms of Service",
+  description:
+    "Terms of Service for MY Chess Tour — Malaysia's premier competitive chess circuit.",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <main className="max-w-3xl mx-auto px-6 py-16">
+        <div className="card card--featured p-8">
+          <div className="text-center mb-8">
+            <span className="auth-logo">MY Chess Tour</span>
+            <h1 className="auth-heading">Terms of Service</h1>
+            <p className="auth-subheading">Effective Date: 1 June 2025</p>
+            <hr className="divider-gold" />
+          </div>
+
+          <div className="font-lato text-sm text-text-body leading-relaxed space-y-6">
+            <p className="text-text-secondary">
+              Welcome to MY Chess Tour (&quot;MCT&quot;, &quot;we&quot;,
+              &quot;us&quot;, or &quot;our&quot;). These Terms of Service govern
+              your use of our platform and services. By creating an account or
+              participating in any tournament, you agree to these terms.
+            </p>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                1. Acceptance of Terms
+              </h2>
+              <p className="text-text-secondary">
+                By registering for an account or using any MCT service, you
+                confirm that you are at least 13 years of age (or have parental
+                consent) and that you agree to be bound by these Terms and our
+                Privacy Policy. If you do not agree, you may not use our
+                services.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                2. Account Registration
+              </h2>
+              <p className="text-text-secondary mb-2">
+                You must provide accurate, complete, and up-to-date information
+                when creating an account. Your name must match the name on your
+                national identity card (MyKad) or passport, as it is used for
+                official tournament records and FIDE/MCF registration.
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+                <li>You are responsible for maintaining the security of your account.</li>
+                <li>You must not share your credentials with any other person.</li>
+                <li>
+                  You must notify us immediately if you suspect unauthorised
+                  access to your account.
+                </li>
+                <li>Each individual may only maintain one active account.</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                3. Tournament Participation
+              </h2>
+              <p className="text-text-secondary mb-2">
+                All tournaments hosted on MY Chess Tour are governed by the Laws
+                of Chess as published by FIDE, unless otherwise specified by the
+                tournament arbiter. By registering for a tournament, you agree
+                to:
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+                <li>
+                  Abide by all rules and decisions made by the chief arbiter.
+                </li>
+                <li>
+                  Compete with integrity and without the use of computer
+                  assistance or other prohibited aids during play.
+                </li>
+                <li>
+                  Provide accurate FIDE ID and/or MCF ID where required for
+                  rated events.
+                </li>
+                <li>
+                  Accept that results are final unless a formal appeal is
+                  submitted within the time prescribed by the arbiter.
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                4. Payment &amp; Refund Policy
+              </h2>
+              <p className="text-text-secondary mb-2">
+                Tournament entry fees are stated on the event page and are
+                collected by the tournament organiser. Refund eligibility is
+                determined by the organiser&apos;s policy for that event, which
+                will be displayed during registration. MY Chess Tour is not
+                liable for any disputes between players and organisers regarding
+                refunds.
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+                <li>
+                  Prize money disbursement is the sole responsibility of the
+                  tournament organiser.
+                </li>
+                <li>
+                  MY Chess Tour may collect a platform service fee, which will
+                  be disclosed at the time of registration.
+                </li>
+                <li>
+                  All fees are in Malaysian Ringgit (MYR) unless stated
+                  otherwise.
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                5. Code of Conduct
+              </h2>
+              <p className="text-text-secondary mb-2">
+                We are committed to a respectful and inclusive environment. All
+                users must:
+              </p>
+              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+                <li>
+                  Treat fellow players, organisers, and arbiters with respect.
+                </li>
+                <li>
+                  Refrain from harassment, discrimination, or abusive language
+                  on the platform or at events.
+                </li>
+                <li>
+                  Not engage in cheating, sandbagging, or manipulation of
+                  ratings.
+                </li>
+                <li>
+                  Comply with any anti-doping requirements applicable to the
+                  event.
+                </li>
+              </ul>
+              <p className="text-text-secondary mt-2">
+                Violations may result in account suspension, disqualification
+                from events, or reporting to the Malaysian Chess Federation (MCF)
+                and FIDE.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                6. Intellectual Property
+              </h2>
+              <p className="text-text-secondary">
+                All content on the MY Chess Tour platform — including logos,
+                graphics, software, and tournament data — is owned by or licensed
+                to MCT. You may not reproduce, distribute, or create derivative
+                works without our written permission.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                7. Limitation of Liability
+              </h2>
+              <p className="text-text-secondary">
+                MY Chess Tour provides its platform on an &quot;as is&quot;
+                basis. To the fullest extent permitted by Malaysian law, we are
+                not liable for any indirect, incidental, or consequential damages
+                arising from your use of the platform or participation in any
+                event.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                8. Amendments
+              </h2>
+              <p className="text-text-secondary">
+                We may update these Terms from time to time. We will notify you
+                of material changes via email or a prominent notice on the
+                platform. Continued use of the platform after changes constitutes
+                acceptance of the revised Terms.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                9. Governing Law
+              </h2>
+              <p className="text-text-secondary">
+                These Terms are governed by the laws of Malaysia. Any disputes
+                shall be subject to the exclusive jurisdiction of the courts of
+                Kuala Lumpur, Malaysia.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+                10. Contact Us
+              </h2>
+              <p className="text-text-secondary">
+                For questions about these Terms, please contact us at{" "}
+                <strong>support@mychesstour.com</strong>.
+              </p>
+            </section>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -731,6 +731,77 @@
     @apply flex flex-col sm:flex-row-reverse gap-2;
   }
 
+  /* ── Modals ── */
+  .modal-overlay {
+    @apply fixed inset-0 z-200 flex items-center justify-center p-4;
+    background: rgba(0, 0, 0, 0.75);
+    backdrop-filter: blur(2px);
+  }
+
+  .modal {
+    @apply relative bg-bg-surface border border-border rounded-lg w-full max-w-2xl max-h-[85vh] flex flex-col;
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
+  }
+
+  .modal--featured {
+    @apply border-t-2 border-t-gold-bright;
+  }
+
+  .modal-header {
+    @apply flex items-center justify-between px-6 pt-6 pb-4 border-b border-border shrink-0;
+  }
+
+  .modal-title {
+    @apply font-cinzel font-semibold text-xl tracking-wider text-text-primary;
+  }
+
+  .modal-close {
+    @apply w-8 h-8 rounded-full flex items-center justify-center bg-transparent border border-border text-text-muted cursor-pointer transition duration-200 shrink-0;
+  }
+  .modal-close:hover {
+    @apply border-gold-muted text-gold-bright;
+  }
+
+  .modal-body {
+    @apply px-6 py-5 overflow-y-auto flex-1 font-lato text-sm text-text-body leading-relaxed;
+  }
+
+  .modal-footer {
+    @apply px-6 py-4 border-t border-border shrink-0 flex justify-end;
+  }
+
+  .modal-section-title {
+    @apply font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mt-6 mb-2 first:mt-0;
+  }
+
+  .modal-paragraph {
+    @apply mb-3 text-text-secondary;
+  }
+
+  .modal-list {
+    @apply list-disc pl-5 mb-3 space-y-1 text-text-secondary;
+  }
+
+  .modal-table {
+    @apply w-full border-collapse mb-3 text-xs;
+  }
+  .modal-table th {
+    @apply font-cinzel tracking-widest uppercase text-gold-muted text-left px-3 py-2 border-b border-border;
+  }
+  .modal-table td {
+    @apply px-3 py-2 border-b border-border text-text-secondary;
+  }
+  .modal-table tr:last-child td {
+    @apply border-b-0;
+  }
+
+  .modal-trigger-link {
+    @apply text-gold-muted no-underline transition-colors duration-200 bg-transparent border-0 p-0 cursor-pointer font-lato text-sm;
+  }
+  .modal-trigger-link:hover {
+    @apply text-gold-bright;
+  }
+
   /* ── Skeleton shimmer ── */
   .skeleton-shimmer {
     background: linear-gradient(


### PR DESCRIPTION
Closes #179, #180

## Changes

- Replace /terms and /privacy links on sign-up form with modal triggers
- Add `TermsModal` component with Terms of Service content
- Add `PrivacyModal` component with PDPA-compliant Privacy Policy content
- Add modal CSS classes to globals.css
- Add standalone `/terms` and `/privacy` pages for direct URL access

Generated with [Claude Code](https://claude.ai/code)