### PR TITLE
feat: player profile page with chess details view and edit

### DIFF
--- a/src/app/api/v1/profile/route.ts
+++ b/src/app/api/v1/profile/route.ts
@@ -1,0 +1,233 @@
+import { createClient } from "@/services/supabase/server";
+import { supabaseAdmin } from "@/services/supabase/admin";
+import { NextRequest, NextResponse } from "next/server";
+import type {
+  ChessTitle,
+  Gender,
+  UpdateProfilePayload,
+} from "@/app/profile/types";
+
+const VALID_GENDERS = new Set<string>(["male", "female"]);
+const VALID_TITLES = new Set<string>([
+  "GM",
+  "WGM",
+  "IM",
+  "WIM",
+  "FM",
+  "WFM",
+  "CM",
+  "WCM",
+]);
+
+export async function GET(): Promise<NextResponse> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  const [{ data: userData, error: userError }, { data: profileData }] =
+    await Promise.all([
+      supabaseAdmin
+        .from("users")
+        .select("id, first_name, last_name, email, avatar_url")
+        .eq("id", user.id)
+        .single(),
+      supabaseAdmin
+        .from("player_profiles")
+        .select(
+          "date_of_birth, gender, nationality, is_oku, fide_id, fide_rating, title, mcf_id, national_rating",
+        )
+        .eq("user_id", user.id)
+        .maybeSingle(),
+    ]);
+
+  if (userError || !userData) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "User not found" } },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({
+    data: {
+      id: userData.id,
+      email: userData.email,
+      first_name: userData.first_name,
+      last_name: userData.last_name,
+      avatar_url: userData.avatar_url ?? null,
+      date_of_birth: profileData?.date_of_birth ?? null,
+      gender: profileData?.gender ?? null,
+      nationality: profileData?.nationality ?? null,
+      is_oku: profileData?.is_oku ?? false,
+      fide_id: profileData?.fide_id ?? null,
+      fide_rating: profileData?.fide_rating ?? null,
+      title: profileData?.title ?? null,
+      mcf_id: profileData?.mcf_id ?? null,
+      national_rating: profileData?.national_rating ?? null,
+    },
+  });
+}
+
+export async function PATCH(request: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "INVALID_JSON", message: "Invalid JSON body" } },
+      { status: 400 },
+    );
+  }
+
+  const errors: string[] = [];
+  const update: UpdateProfilePayload = {};
+
+  if ("gender" in body) {
+    if (body.gender === null) {
+      update.gender = null;
+    } else if (typeof body.gender === "string" && VALID_GENDERS.has(body.gender)) {
+      update.gender = body.gender as Gender;
+    } else {
+      errors.push("gender must be 'male', 'female', or null");
+    }
+  }
+
+  if ("title" in body) {
+    if (body.title === null) {
+      update.title = null;
+    } else if (typeof body.title === "string" && VALID_TITLES.has(body.title)) {
+      update.title = body.title as ChessTitle;
+    } else {
+      errors.push(
+        `title must be one of: ${[...VALID_TITLES].join(", ")}, or null`,
+      );
+    }
+  }
+
+  if ("fide_id" in body) {
+    if (body.fide_id === null) {
+      update.fide_id = null;
+    } else if (
+      typeof body.fide_id === "number" &&
+      Number.isInteger(body.fide_id) &&
+      body.fide_id > 0
+    ) {
+      update.fide_id = body.fide_id;
+    } else {
+      errors.push("fide_id must be a positive integer or null");
+    }
+  }
+
+  if ("mcf_id" in body) {
+    if (body.mcf_id === null) {
+      update.mcf_id = null;
+    } else if (
+      typeof body.mcf_id === "number" &&
+      Number.isInteger(body.mcf_id) &&
+      body.mcf_id > 0
+    ) {
+      update.mcf_id = body.mcf_id;
+    } else {
+      errors.push("mcf_id must be a positive integer or null");
+    }
+  }
+
+  if ("national_rating" in body) {
+    if (body.national_rating === null) {
+      update.national_rating = null;
+    } else if (
+      typeof body.national_rating === "number" &&
+      Number.isInteger(body.national_rating) &&
+      body.national_rating >= 0
+    ) {
+      update.national_rating = body.national_rating;
+    } else {
+      errors.push("national_rating must be a non-negative integer or null");
+    }
+  }
+
+  if ("date_of_birth" in body) {
+    if (body.date_of_birth === null) {
+      update.date_of_birth = null;
+    } else if (
+      typeof body.date_of_birth === "string" &&
+      /^\d{4}-\d{2}-\d{2}$/.test(body.date_of_birth)
+    ) {
+      update.date_of_birth = body.date_of_birth;
+    } else {
+      errors.push("date_of_birth must be a date string (YYYY-MM-DD) or null");
+    }
+  }
+
+  if ("nationality" in body) {
+    if (body.nationality === null) {
+      update.nationality = null;
+    } else if (typeof body.nationality === "string" && body.nationality.trim()) {
+      update.nationality = body.nationality.trim();
+    } else {
+      errors.push("nationality must be a non-empty string or null");
+    }
+  }
+
+  if ("is_oku" in body) {
+    if (typeof body.is_oku === "boolean") {
+      update.is_oku = body.is_oku;
+    } else {
+      errors.push("is_oku must be a boolean");
+    }
+  }
+
+  if (errors.length > 0) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: errors.join("; "),
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "No valid fields provided" } },
+      { status: 400 },
+    );
+  }
+
+  const { error } = await supabaseAdmin
+    .from("player_profiles")
+    .upsert(
+      { user_id: user.id, ...update },
+      { onConflict: "user_id" },
+    );
+
+  if (error) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/src/app/api/v1/profile/route.ts
+++ b/src/app/api/v1/profile/route.ts
@@ -175,9 +175,19 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
       typeof body.date_of_birth === "string" &&
       /^\d{4}-\d{2}-\d{2}$/.test(body.date_of_birth)
     ) {
-      update.date_of_birth = body.date_of_birth;
+      const [y, m, d] = body.date_of_birth.split("-").map(Number);
+      const dt = new Date(Date.UTC(y, m - 1, d));
+      if (
+        dt.getUTCFullYear() === y &&
+        dt.getUTCMonth() + 1 === m &&
+        dt.getUTCDate() === d
+      ) {
+        update.date_of_birth = body.date_of_birth;
+      } else {
+        errors.push("date_of_birth must be a valid calendar date (YYYY-MM-DD) or null");
+      }
     } else {
-      errors.push("date_of_birth must be a date string (YYYY-MM-DD) or null");
+      errors.push("date_of_birth must be a valid calendar date (YYYY-MM-DD) or null");
     }
   }
 

--- a/src/app/api/v1/profile/route.ts
+++ b/src/app/api/v1/profile/route.ts
@@ -129,11 +129,12 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
     } else if (
       typeof body.fide_id === "number" &&
       Number.isInteger(body.fide_id) &&
-      body.fide_id > 0
+      body.fide_id > 0 &&
+      body.fide_id <= 2147483647
     ) {
       update.fide_id = body.fide_id;
     } else {
-      errors.push("fide_id must be a positive integer or null");
+      errors.push("fide_id must be a positive integer no greater than 2147483647 or null");
     }
   }
 
@@ -143,11 +144,12 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
     } else if (
       typeof body.mcf_id === "number" &&
       Number.isInteger(body.mcf_id) &&
-      body.mcf_id > 0
+      body.mcf_id > 0 &&
+      body.mcf_id <= 2147483647
     ) {
       update.mcf_id = body.mcf_id;
     } else {
-      errors.push("mcf_id must be a positive integer or null");
+      errors.push("mcf_id must be a positive integer no greater than 2147483647 or null");
     }
   }
 
@@ -157,11 +159,12 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
     } else if (
       typeof body.national_rating === "number" &&
       Number.isInteger(body.national_rating) &&
-      body.national_rating >= 0
+      body.national_rating >= 0 &&
+      body.national_rating <= 3000
     ) {
       update.national_rating = body.national_rating;
     } else {
-      errors.push("national_rating must be a non-negative integer or null");
+      errors.push("national_rating must be a non-negative integer no greater than 3000 or null");
     }
   }
 

--- a/src/app/profile/_components/ProfileClient.tsx
+++ b/src/app/profile/_components/ProfileClient.tsx
@@ -1,0 +1,587 @@
+"use client";
+
+import { useState } from "react";
+import type {
+  PlayerProfile,
+  ChessTitle,
+  Gender,
+} from "@/app/profile/types";
+
+const CHESS_TITLES: ChessTitle[] = [
+  "GM",
+  "WGM",
+  "IM",
+  "WIM",
+  "FM",
+  "WFM",
+  "CM",
+  "WCM",
+];
+
+const GENDERS: { value: Gender; label: string }[] = [
+  { value: "male", label: "Male" },
+  { value: "female", label: "Female" },
+];
+
+type EditForm = {
+  date_of_birth: string;
+  gender: Gender | "";
+  nationality: string;
+  is_oku: boolean;
+  fide_id: string;
+  title: ChessTitle | "";
+  mcf_id: string;
+  national_rating: string;
+};
+
+interface ProfileFieldProps {
+  label: string;
+  value: string;
+}
+
+function ProfileField({ label, value }: ProfileFieldProps) {
+  return (
+    <div className="flex flex-col gap-0.5 py-3 border-b border-border last:border-b-0">
+      <span className="font-cinzel text-xs font-semibold tracking-widest uppercase text-gold-muted">
+        {label}
+      </span>
+      <span className="font-lato text-sm text-text-body">
+        {value || "—"}
+      </span>
+    </div>
+  );
+}
+
+interface SectionCardProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function SectionCard({ title, children }: SectionCardProps) {
+  return (
+    <div className="card p-6">
+      <h2 className="font-cinzel text-base font-semibold tracking-wider text-text-primary mb-4 pb-3 border-b border-border">
+        {title}
+      </h2>
+      {children}
+    </div>
+  );
+}
+
+interface Props {
+  profile: PlayerProfile;
+}
+
+export default function ProfileClient({ profile }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [current, setCurrent] = useState<PlayerProfile>(profile);
+
+  const [form, setForm] = useState<EditForm>({
+    date_of_birth: profile.date_of_birth ?? "",
+    gender: profile.gender ?? "",
+    nationality: profile.nationality ?? "",
+    is_oku: profile.is_oku,
+    fide_id: profile.fide_id != null ? String(profile.fide_id) : "",
+    title: profile.title ?? "",
+    mcf_id: profile.mcf_id != null ? String(profile.mcf_id) : "",
+    national_rating:
+      profile.national_rating != null ? String(profile.national_rating) : "",
+  });
+
+  function handleEdit() {
+    setEditing(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+  }
+
+  function handleCancel() {
+    setEditing(false);
+    setSaveError(null);
+    setForm({
+      date_of_birth: current.date_of_birth ?? "",
+      gender: current.gender ?? "",
+      nationality: current.nationality ?? "",
+      is_oku: current.is_oku,
+      fide_id: current.fide_id != null ? String(current.fide_id) : "",
+      title: current.title ?? "",
+      mcf_id: current.mcf_id != null ? String(current.mcf_id) : "",
+      national_rating:
+        current.national_rating != null ? String(current.national_rating) : "",
+    });
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    const payload: Record<string, unknown> = {
+      date_of_birth: form.date_of_birth || null,
+      gender: form.gender || null,
+      nationality: form.nationality.trim() || null,
+      is_oku: form.is_oku,
+      fide_id: form.fide_id ? parseInt(form.fide_id, 10) : null,
+      title: form.title || null,
+      mcf_id: form.mcf_id ? parseInt(form.mcf_id, 10) : null,
+      national_rating: form.national_rating
+        ? parseInt(form.national_rating, 10)
+        : null,
+    };
+
+    try {
+      const res = await fetch("/api/v1/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setSaveError(data.error?.message ?? "Something went wrong. Please try again.");
+        return;
+      }
+
+      setCurrent({
+        ...current,
+        date_of_birth: (payload.date_of_birth as string | null),
+        gender: (payload.gender as Gender | null),
+        nationality: (payload.nationality as string | null),
+        is_oku: payload.is_oku as boolean,
+        fide_id: payload.fide_id as number | null,
+        title: (payload.title as ChessTitle | null),
+        mcf_id: payload.mcf_id as number | null,
+        national_rating: payload.national_rating as number | null,
+      });
+
+      setSaveSuccess(true);
+      setEditing(false);
+    } catch {
+      setSaveError("Network error. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const initials =
+    `${current.first_name[0] ?? ""}${current.last_name[0] ?? ""}`.toUpperCase() ||
+    current.email[0]?.toUpperCase() ||
+    "?";
+
+  const fullName = [current.first_name, current.last_name]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-8">
+      {/* Header */}
+      <div className="flex items-center gap-5 mb-8">
+        <div className="bg-gold-ghost border-2 border-gold-muted font-cinzel text-gold-bright flex h-16 w-16 shrink-0 items-center justify-center rounded-full text-xl font-semibold">
+          {initials}
+        </div>
+        <div className="flex-1 min-w-0">
+          <h1 className="font-cinzel text-2xl font-bold text-text-primary tracking-wide leading-tight">
+            {fullName}
+          </h1>
+          <p className="font-lato text-sm text-text-muted mt-0.5">
+            {current.email}
+          </p>
+          {current.title && (
+            <span className="inline-block mt-1.5 font-cinzel text-xs font-bold tracking-widest uppercase px-2 py-0.5 rounded bg-info-bg text-info border border-info-border">
+              {current.title}
+            </span>
+          )}
+        </div>
+        {!editing && (
+          <button
+            onClick={handleEdit}
+            className="btn-secondary px-4 py-2 text-xs shrink-0"
+          >
+            Edit Profile
+          </button>
+        )}
+      </div>
+
+      {saveSuccess && (
+        <div className="mb-5 flex items-center gap-2 rounded-md border border-success-border bg-success-bg px-4 py-2.5">
+          <span className="text-success text-sm">&#10003;</span>
+          <p className="font-lato text-sm text-success">Profile updated successfully.</p>
+        </div>
+      )}
+
+      {editing ? (
+        <form onSubmit={handleSave} noValidate>
+          {saveError && (
+            <div className="error-banner mb-5" role="alert">
+              <span className="text-sm shrink-0 mt-px">&#9888;</span>
+              <p className="error-text">{saveError}</p>
+            </div>
+          )}
+
+          {/* Personal Info */}
+          <div className="card p-6 mb-4">
+            <h2 className="font-cinzel text-base font-semibold tracking-wider text-text-primary mb-4 pb-3 border-b border-border">
+              Personal Information
+            </h2>
+
+            {/* Read-only name + email */}
+            <div className="mb-4 rounded-md bg-bg-sunken border border-border px-4 py-3">
+              <p className="font-cinzel text-xs font-semibold tracking-widest uppercase text-gold-dim mb-1">
+                Name &amp; Email
+              </p>
+              <p className="font-lato text-sm text-text-secondary">
+                {fullName} · {current.email}
+              </p>
+              <p className="font-lato text-xs text-text-muted mt-1">
+                Contact support to change your name or email.
+              </p>
+            </div>
+
+            {/* Date of Birth */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="dob">
+                  Date of Birth
+                </label>
+                <span className="label-optional">(Optional)</span>
+              </div>
+              <input
+                id="dob"
+                className="input"
+                type="date"
+                value={form.date_of_birth}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, date_of_birth: e.target.value }))
+                }
+              />
+            </div>
+
+            {/* Gender */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="gender">
+                  Gender
+                </label>
+                <span className="label-optional">(Optional)</span>
+              </div>
+              <select
+                id="gender"
+                className="input"
+                value={form.gender}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    gender: e.target.value as Gender | "",
+                  }))
+                }
+              >
+                <option value="">Select…</option>
+                {GENDERS.map(({ value, label }) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Nationality */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="nationality">
+                  Nationality
+                </label>
+                <span className="label-optional">(Optional)</span>
+              </div>
+              <input
+                id="nationality"
+                className="input"
+                type="text"
+                placeholder="Malaysian"
+                value={form.nationality}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, nationality: e.target.value }))
+                }
+              />
+            </div>
+
+            {/* OKU */}
+            <div className="check-row mt-2">
+              <input
+                id="is_oku"
+                type="checkbox"
+                className="checkbox"
+                checked={form.is_oku}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, is_oku: e.target.checked }))
+                }
+              />
+              <label className="check-label" htmlFor="is_oku">
+                I am an OKU (Orang Kurang Upaya) card holder
+              </label>
+            </div>
+          </div>
+
+          {/* Chess Details */}
+          <div className="card p-6 mb-6">
+            <h2 className="font-cinzel text-base font-semibold tracking-wider text-text-primary mb-4 pb-3 border-b border-border">
+              Chess Details
+            </h2>
+
+            {/* Chess Title */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="title">
+                  Chess Title
+                </label>
+                <span className="label-optional">(Optional)</span>
+              </div>
+              <select
+                id="title"
+                className="input"
+                value={form.title}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    title: e.target.value as ChessTitle | "",
+                  }))
+                }
+              >
+                <option value="">No title</option>
+                {CHESS_TITLES.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* FIDE ID */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="fide_id">
+                  FIDE ID
+                </label>
+                <span className="label-optional">(Optional)</span>
+                <span
+                  className="help-icon"
+                  tabIndex={0}
+                  aria-label="FIDE ID help"
+                >
+                  ?
+                  <div className="tooltip" role="tooltip">
+                    Your FIDE player ID number. Your standard, rapid, and blitz
+                    ratings are stored from when your profile was created.
+                  </div>
+                </span>
+              </div>
+              <input
+                id="fide_id"
+                className="input"
+                type="text"
+                inputMode="numeric"
+                placeholder="e.g. 36095765"
+                value={form.fide_id}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    fide_id: e.target.value.replace(/\D/g, ""),
+                  }))
+                }
+              />
+            </div>
+
+            {/* MCF ID */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="mcf_id">
+                  MCF ID
+                </label>
+                <span className="label-optional">(Optional)</span>
+                <span
+                  className="help-icon"
+                  tabIndex={0}
+                  aria-label="MCF ID help"
+                >
+                  ?
+                  <div className="tooltip" role="tooltip">
+                    Your Malaysian Chess Federation membership ID. Used for
+                    MCF-rated tournaments.
+                  </div>
+                </span>
+              </div>
+              <input
+                id="mcf_id"
+                className="input"
+                type="text"
+                inputMode="numeric"
+                placeholder="e.g. 1234567"
+                value={form.mcf_id}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    mcf_id: e.target.value.replace(/\D/g, ""),
+                  }))
+                }
+              />
+            </div>
+
+            {/* National Rating */}
+            <div className="form-group">
+              <div className="label-row">
+                <label className="input-label" htmlFor="national_rating">
+                  National Rating
+                </label>
+                <span className="label-optional">(Optional)</span>
+              </div>
+              <input
+                id="national_rating"
+                className="input"
+                type="text"
+                inputMode="numeric"
+                placeholder="e.g. 1850"
+                value={form.national_rating}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    national_rating: e.target.value.replace(/\D/g, ""),
+                  }))
+                }
+              />
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-col sm:flex-row gap-2">
+            <button
+              type="button"
+              className="btn-secondary w-full"
+              onClick={handleCancel}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn-primary w-full"
+              disabled={saving}
+              aria-disabled={saving}
+            >
+              {saving ? "Saving…" : "Save Changes"}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {/* Personal Info */}
+          <SectionCard title="Personal Information">
+            <ProfileField label="Full Name" value={fullName} />
+            <ProfileField label="Email" value={current.email} />
+            <ProfileField
+              label="Date of Birth"
+              value={
+                current.date_of_birth
+                  ? new Date(current.date_of_birth + "T00:00:00").toLocaleDateString(
+                      "en-MY",
+                      { day: "numeric", month: "long", year: "numeric" },
+                    )
+                  : ""
+              }
+            />
+            <ProfileField
+              label="Gender"
+              value={
+                current.gender
+                  ? current.gender.charAt(0).toUpperCase() +
+                    current.gender.slice(1)
+                  : ""
+              }
+            />
+            <ProfileField
+              label="Nationality"
+              value={current.nationality ?? ""}
+            />
+            <ProfileField
+              label="OKU Status"
+              value={current.is_oku ? "OKU card holder" : "Not applicable"}
+            />
+          </SectionCard>
+
+          {/* Chess Details */}
+          <SectionCard title="Chess Details">
+            <ProfileField
+              label="Chess Title"
+              value={current.title ?? ""}
+            />
+            <ProfileField
+              label="FIDE ID"
+              value={current.fide_id != null ? String(current.fide_id) : ""}
+            />
+            <div className="flex flex-col gap-0.5 py-3 border-b border-border">
+              <span className="font-cinzel text-xs font-semibold tracking-widest uppercase text-gold-muted">
+                FIDE Rating
+              </span>
+              {current.fide_rating ? (
+                <div className="flex flex-wrap gap-3 mt-1">
+                  {current.fide_rating.standard != null && (
+                    <div className="flex flex-col items-center bg-bg-raised border border-border rounded-md px-4 py-2 min-w-16">
+                      <span className="font-cinzel text-xs tracking-widest uppercase text-text-muted">
+                        Std
+                      </span>
+                      <span className="font-lato text-lg font-semibold text-text-primary">
+                        {current.fide_rating.standard}
+                      </span>
+                    </div>
+                  )}
+                  {current.fide_rating.rapid != null && (
+                    <div className="flex flex-col items-center bg-bg-raised border border-border rounded-md px-4 py-2 min-w-16">
+                      <span className="font-cinzel text-xs tracking-widest uppercase text-text-muted">
+                        Rpd
+                      </span>
+                      <span className="font-lato text-lg font-semibold text-text-primary">
+                        {current.fide_rating.rapid}
+                      </span>
+                    </div>
+                  )}
+                  {current.fide_rating.blitz != null && (
+                    <div className="flex flex-col items-center bg-bg-raised border border-border rounded-md px-4 py-2 min-w-16">
+                      <span className="font-cinzel text-xs tracking-widest uppercase text-text-muted">
+                        Blz
+                      </span>
+                      <span className="font-lato text-lg font-semibold text-text-primary">
+                        {current.fide_rating.blitz}
+                      </span>
+                    </div>
+                  )}
+                  {current.fide_rating.standard == null &&
+                    current.fide_rating.rapid == null &&
+                    current.fide_rating.blitz == null && (
+                      <span className="font-lato text-sm text-text-body">—</span>
+                    )}
+                </div>
+              ) : (
+                <span className="font-lato text-sm text-text-body">—</span>
+              )}
+            </div>
+            <ProfileField
+              label="MCF ID"
+              value={current.mcf_id != null ? String(current.mcf_id) : ""}
+            />
+            <ProfileField
+              label="National Rating"
+              value={
+                current.national_rating != null
+                  ? String(current.national_rating)
+                  : ""
+              }
+            />
+          </SectionCard>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,61 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import { createClient } from "@/services/supabase/server";
+import ProfileClient from "./_components/ProfileClient";
+import type { PlayerProfile } from "./types";
+
+export const metadata: Metadata = {
+  title: "My Profile",
+  description: "View and edit your chess player profile.",
+};
+
+async function fetchProfile(
+  host: string,
+  cookieHeader: string,
+): Promise<PlayerProfile | null> {
+  const protocol =
+    host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https";
+
+  try {
+    const res = await fetch(`${protocol}://${host}/api/v1/profile`, {
+      cache: "no-store",
+      headers: { cookie: cookieHeader },
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function ProfilePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/login");
+  }
+
+  const headersList = await headers();
+  const host = headersList.get("host") ?? "localhost:3000";
+  const cookieHeader = headersList.get("cookie") ?? "";
+  const profile = await fetchProfile(host, cookieHeader);
+
+  if (!profile) {
+    redirect("/auth/login");
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <ProfileClient profile={profile} />
+    </div>
+  );
+}

--- a/src/app/profile/types.ts
+++ b/src/app/profile/types.ts
@@ -1,0 +1,36 @@
+export type ChessTitle = "GM" | "WGM" | "IM" | "WIM" | "FM" | "WFM" | "CM" | "WCM";
+export type Gender = "male" | "female";
+
+export type FideRating = {
+  standard?: number | null;
+  rapid?: number | null;
+  blitz?: number | null;
+};
+
+export type PlayerProfile = {
+  id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  avatar_url: string | null;
+  date_of_birth: string | null;
+  gender: Gender | null;
+  nationality: string | null;
+  is_oku: boolean;
+  fide_id: number | null;
+  fide_rating: FideRating | null;
+  title: ChessTitle | null;
+  mcf_id: number | null;
+  national_rating: number | null;
+};
+
+export type UpdateProfilePayload = {
+  date_of_birth?: string | null;
+  gender?: Gender | null;
+  nationality?: string | null;
+  is_oku?: boolean;
+  fide_id?: number | null;
+  title?: ChessTitle | null;
+  mcf_id?: number | null;
+  national_rating?: number | null;
+};

--- a/src/app/profile/types.ts
+++ b/src/app/profile/types.ts
@@ -1,7 +1,7 @@
 export type ChessTitle = "GM" | "WGM" | "IM" | "WIM" | "FM" | "WFM" | "CM" | "WCM";
 export type Gender = "male" | "female";
 
-export type FideRating = {
+type FideRating = {
   standard?: number | null;
   rapid?: number | null;
   blitz?: number | null;


### PR DESCRIPTION
Implements #issue-57

Adds /profile page where players can view and edit their chess details (FIDE ID, ratings, chess title, MCF ID, national rating) and personal info (gender, date of birth, nationality, OKU status).

FIDE ratings are read-only cards (standard/rapid/blitz). A new PATCH /api/v1/profile endpoint validates and persists changes via upsert on player_profiles.

Generated with [Claude Code](https://claude.ai/code)