### PR TITLE
feat: GET /organizations/applications API route & My Organizations UI

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,6 +2,7 @@
   "permissions": {
     "allow": [
       "Bash(cd:*)",
+      "Bash(claude doctor *)",
       "Bash(cp:*)",
       "Bash(find:*)",
       "Bash(gh:*)",

--- a/src/app/api/v1/organizations/applications/__tests__/route.test.ts
+++ b/src/app/api/v1/organizations/applications/__tests__/route.test.ts
@@ -5,16 +5,19 @@ import { NextRequest } from "next/server";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const {
-  mockExistingBuilder,
-  mockInsertBuilder,
-  mockFrom,
-  mockGetUser,
-  resetOrgCallCount,
-} = vi.hoisted(() => {
+const { mockBuilder, mockFrom, mockGetUser } = vi.hoisted(() => {
   function makeBuilder(finalResult: { data?: unknown; error?: unknown }) {
     const b: Record<string, unknown> = {};
-    for (const m of ["select", "eq", "in", "single", "maybeSingle", "insert"]) {
+    for (const m of [
+      "select",
+      "eq",
+      "in",
+      "is",
+      "order",
+      "single",
+      "maybeSingle",
+      "insert",
+    ]) {
       b[m] = vi.fn(() => b);
     }
     b.then = (
@@ -24,31 +27,12 @@ const {
     return b;
   }
 
-  const mockExistingBuilder = makeBuilder({ data: null, error: null });
-  const mockInsertBuilder = makeBuilder({ data: null, error: null });
-
-  let orgCallCount = 0;
-  const resetOrgCallCount = () => {
-    orgCallCount = 0;
-  };
-
-  const mockFrom = vi.fn((table: string) => {
-    if (table === "organizations") {
-      const builders = [mockExistingBuilder, mockInsertBuilder];
-      return builders[orgCallCount++] ?? mockInsertBuilder;
-    }
-    return makeBuilder({ data: null, error: null });
-  });
-
+  // A single configurable builder used by all queries in a given test
+  const mockBuilder = makeBuilder({ data: null, error: null });
+  const mockFrom = vi.fn(() => mockBuilder);
   const mockGetUser = vi.fn();
 
-  return {
-    mockExistingBuilder,
-    mockInsertBuilder,
-    mockFrom,
-    mockGetUser,
-    resetOrgCallCount,
-  };
+  return { mockBuilder, mockFrom, mockGetUser };
 });
 
 vi.mock("@/services/supabase/admin", () => ({
@@ -68,7 +52,7 @@ vi.mock("next/headers", () => ({
   }),
 }));
 
-import { POST } from "../route";
+import { GET, POST } from "../route";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -92,19 +76,28 @@ function makeOrg(overrides: Record<string, unknown> = {}) {
     phone: null,
     past_tournament_refs: null,
     approval_status: "pending",
+    rejection_reason: null,
     created_by: USER_ID,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
+    reviewed_at: null,
     ...overrides,
   };
 }
 
-function makeRequest(body: unknown = VALID_BODY): NextRequest {
-  return new NextRequest("http://localhost/api/v1/organizer/apply", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/v1/organizations/applications");
+}
+
+function makePostRequest(body: unknown = VALID_BODY): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/v1/organizations/applications",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -119,29 +112,132 @@ function setNoUser() {
   mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
 }
 
-function setExistingResult(data: unknown, error: unknown = null) {
-  (mockExistingBuilder as Record<string, unknown>).then = (
-    r: (v: unknown) => unknown,
-  ) => Promise.resolve({ data, error }).then(r);
-}
-
-function setInsertResult(data: unknown, error: unknown = null) {
-  (mockInsertBuilder as Record<string, unknown>).then = (
-    r: (v: unknown) => unknown,
-  ) => Promise.resolve({ data, error }).then(r);
+function setQueryResult(data: unknown, error: unknown = null) {
+  (mockBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// GET Tests
 // ---------------------------------------------------------------------------
 
-describe("POST /api/v1/organizer/apply", () => {
+describe("GET /api/v1/organizations/applications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    resetOrgCallCount();
     setUser();
-    setExistingResult(null);
-    setInsertResult(makeOrg());
+    setQueryResult([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await GET(makeGetRequest());
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("queries only applications belonging to the authenticated user", async () => {
+      setQueryResult([]);
+      await GET(makeGetRequest());
+      const eqMock = mockBuilder.eq as ReturnType<typeof vi.fn>;
+      expect(eqMock).toHaveBeenCalledWith("created_by", USER_ID);
+    });
+  });
+
+  describe("response shape", () => {
+    it("returns 200 with data array", async () => {
+      const org = makeOrg();
+      setQueryResult([
+        {
+          id: org.id,
+          name: org.name,
+          approval_status: org.approval_status,
+          rejection_reason: org.rejection_reason,
+          created_at: org.created_at,
+          reviewed_at: org.reviewed_at,
+        },
+      ]);
+
+      const res = await GET(makeGetRequest());
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(Array.isArray(json.data)).toBe(true);
+      expect(json.data).toHaveLength(1);
+      expect(json.data[0].id).toBe(ORG_ID);
+      expect(json.data[0].approval_status).toBe("pending");
+    });
+
+    it("returns empty array when user has no applications", async () => {
+      setQueryResult([]);
+      const res = await GET(makeGetRequest());
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.data).toEqual([]);
+    });
+
+    it("returns multiple applications ordered by created_at desc", async () => {
+      const orgs = [
+        {
+          id: "bbbbbbbb-0000-0000-0000-000000000002",
+          name: "Penang Chess Club",
+          approval_status: "rejected",
+          rejection_reason: "Insufficient history",
+          created_at: "2026-02-01T00:00:00Z",
+          reviewed_at: "2026-02-03T00:00:00Z",
+        },
+        {
+          id: ORG_ID,
+          name: "KL Chess Association",
+          approval_status: "pending",
+          rejection_reason: null,
+          created_at: "2026-01-01T00:00:00Z",
+          reviewed_at: null,
+        },
+      ];
+      setQueryResult(orgs);
+
+      const res = await GET(makeGetRequest());
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.data).toHaveLength(2);
+    });
+
+    it("excludes soft-deleted organizations", async () => {
+      await GET(makeGetRequest());
+      const isMock = mockBuilder.is as ReturnType<typeof vi.fn>;
+      expect(isMock).toHaveBeenCalledWith("deleted_at", null);
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns 500 when Supabase returns an error", async () => {
+      setQueryResult(null, { message: "DB connection failed" });
+      const res = await GET(makeGetRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+      expect(json.error.message).toBe("DB connection failed");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/organizations/applications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setUser();
+    // Default: no existing org, successful insert
+    setQueryResult(null);
   });
 
   afterEach(() => {
@@ -155,7 +251,7 @@ describe("POST /api/v1/organizer/apply", () => {
   describe("authentication", () => {
     it("returns 401 when user is not authenticated", async () => {
       setNoUser();
-      const res = await POST(makeRequest());
+      const res = await POST(makePostRequest());
       expect(res.status).toBe(401);
       const json = await res.json();
       expect(json.error.code).toBe("UNAUTHORIZED");
@@ -168,10 +264,13 @@ describe("POST /api/v1/organizer/apply", () => {
 
   describe("input validation", () => {
     it("returns 400 when body is not valid JSON", async () => {
-      const req = new NextRequest("http://localhost/api/v1/organizer/apply", {
-        method: "POST",
-        body: "not json",
-      });
+      const req = new NextRequest(
+        "http://localhost/api/v1/organizations/applications",
+        {
+          method: "POST",
+          body: "not json",
+        },
+      );
       const res = await POST(req);
       expect(res.status).toBe(400);
       const json = await res.json();
@@ -179,7 +278,7 @@ describe("POST /api/v1/organizer/apply", () => {
     });
 
     it("returns 400 when name is missing", async () => {
-      const res = await POST(makeRequest({ email: "chess@klca.com" }));
+      const res = await POST(makePostRequest({ email: "chess@klca.com" }));
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.error.message).toMatch(/name/i);
@@ -187,7 +286,7 @@ describe("POST /api/v1/organizer/apply", () => {
 
     it("returns 400 when name is empty string", async () => {
       const res = await POST(
-        makeRequest({ name: "  ", email: "chess@klca.com" }),
+        makePostRequest({ name: "  ", email: "chess@klca.com" }),
       );
       expect(res.status).toBe(400);
       const json = await res.json();
@@ -195,7 +294,7 @@ describe("POST /api/v1/organizer/apply", () => {
     });
 
     it("returns 400 when email is missing", async () => {
-      const res = await POST(makeRequest({ name: "KL Chess" }));
+      const res = await POST(makePostRequest({ name: "KL Chess" }));
       expect(res.status).toBe(400);
       const json = await res.json();
       expect(json.error.message).toMatch(/email/i);
@@ -203,7 +302,7 @@ describe("POST /api/v1/organizer/apply", () => {
 
     it("returns 400 when email is invalid", async () => {
       const res = await POST(
-        makeRequest({ name: "KL Chess", email: "not-an-email" }),
+        makePostRequest({ name: "KL Chess", email: "not-an-email" }),
       );
       expect(res.status).toBe(400);
       const json = await res.json();
@@ -212,7 +311,7 @@ describe("POST /api/v1/organizer/apply", () => {
 
     it("returns 400 when links is not an array", async () => {
       const res = await POST(
-        makeRequest({ ...VALID_BODY, links: "https://example.com" }),
+        makePostRequest({ ...VALID_BODY, links: "https://example.com" }),
       );
       expect(res.status).toBe(400);
       const json = await res.json();
@@ -221,7 +320,7 @@ describe("POST /api/v1/organizer/apply", () => {
 
     it("returns 400 when a link has an empty label", async () => {
       const res = await POST(
-        makeRequest({
+        makePostRequest({
           ...VALID_BODY,
           links: [{ label: "", url: "https://facebook.com/..." }],
         }),
@@ -233,7 +332,7 @@ describe("POST /api/v1/organizer/apply", () => {
 
     it("returns 400 when a link has an empty url", async () => {
       const res = await POST(
-        makeRequest({
+        makePostRequest({
           ...VALID_BODY,
           links: [{ label: "Facebook", url: "" }],
         }),
@@ -250,8 +349,8 @@ describe("POST /api/v1/organizer/apply", () => {
 
   describe("duplicate check", () => {
     it("returns 409 when user already has a pending application", async () => {
-      setExistingResult({ id: ORG_ID, approval_status: "pending" });
-      const res = await POST(makeRequest());
+      setQueryResult({ id: ORG_ID, approval_status: "pending" });
+      const res = await POST(makePostRequest());
       expect(res.status).toBe(409);
       const json = await res.json();
       expect(json.error.code).toBe("ALREADY_APPLIED");
@@ -259,8 +358,8 @@ describe("POST /api/v1/organizer/apply", () => {
     });
 
     it("returns 409 when user already has an approved organization", async () => {
-      setExistingResult({ id: ORG_ID, approval_status: "approved" });
-      const res = await POST(makeRequest());
+      setQueryResult({ id: ORG_ID, approval_status: "approved" });
+      const res = await POST(makePostRequest());
       expect(res.status).toBe(409);
       const json = await res.json();
       expect(json.error.code).toBe("ALREADY_APPLIED");
@@ -268,8 +367,8 @@ describe("POST /api/v1/organizer/apply", () => {
     });
 
     it("returns 500 when the duplicate check query fails", async () => {
-      setExistingResult(null, { message: "DB connection error" });
-      const res = await POST(makeRequest());
+      setQueryResult(null, { message: "DB connection error" });
+      const res = await POST(makePostRequest());
       expect(res.status).toBe(500);
       const json = await res.json();
       expect(json.error.code).toBe("INTERNAL_ERROR");
@@ -282,7 +381,20 @@ describe("POST /api/v1/organizer/apply", () => {
 
   describe("insert", () => {
     it("returns 201 with the created organization on success", async () => {
-      const res = await POST(makeRequest());
+      // First call (maybeSingle check) returns null, second call (insert) returns org
+      let callIndex = 0;
+      (mockBuilder as Record<string, unknown>).then = (
+        onfulfilled: (v: unknown) => unknown,
+        onrejected?: (r: unknown) => unknown,
+      ) => {
+        const result =
+          callIndex++ === 0
+            ? { data: null, error: null }
+            : { data: makeOrg(), error: null };
+        return Promise.resolve(result).then(onfulfilled, onrejected);
+      };
+
+      const res = await POST(makePostRequest());
       expect(res.status).toBe(201);
       const json = await res.json();
       expect(json.data.id).toBe(ORG_ID);
@@ -290,6 +402,18 @@ describe("POST /api/v1/organizer/apply", () => {
     });
 
     it("returns 201 when optional fields are provided", async () => {
+      let callIndex = 0;
+      (mockBuilder as Record<string, unknown>).then = (
+        onfulfilled: (v: unknown) => unknown,
+        onrejected?: (r: unknown) => unknown,
+      ) => {
+        const result =
+          callIndex++ === 0
+            ? { data: null, error: null }
+            : { data: makeOrg({ description: "A chess club" }), error: null };
+        return Promise.resolve(result).then(onfulfilled, onrejected);
+      };
+
       const body = {
         name: "KL Chess",
         email: "chess@klca.com",
@@ -298,14 +422,24 @@ describe("POST /api/v1/organizer/apply", () => {
         past_tournament_refs: "KL Open 2025",
         links: [{ label: "Facebook", url: "https://facebook.com/klchess" }],
       };
-      setInsertResult(makeOrg({ description: "A chess club" }));
-      const res = await POST(makeRequest(body));
+      const res = await POST(makePostRequest(body));
       expect(res.status).toBe(201);
     });
 
     it("returns 500 on an unexpected insert error", async () => {
-      setInsertResult(null, { message: "Unexpected DB error" });
-      const res = await POST(makeRequest());
+      let callIndex = 0;
+      (mockBuilder as Record<string, unknown>).then = (
+        onfulfilled: (v: unknown) => unknown,
+        onrejected?: (r: unknown) => unknown,
+      ) => {
+        const result =
+          callIndex++ === 0
+            ? { data: null, error: null }
+            : { data: null, error: { message: "Unexpected DB error" } };
+        return Promise.resolve(result).then(onfulfilled, onrejected);
+      };
+
+      const res = await POST(makePostRequest());
       expect(res.status).toBe(500);
       const json = await res.json();
       expect(json.error.code).toBe("INTERNAL_ERROR");

--- a/src/app/api/v1/organizations/applications/route.ts
+++ b/src/app/api/v1/organizations/applications/route.ts
@@ -3,6 +3,38 @@ import { createClient } from "@/services/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { validateApplyRequest } from "./validators";
 
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("organizations")
+    .select(
+      "id, name, approval_status, rejection_reason, created_at, reviewed_at",
+    )
+    .eq("created_by", user.id)
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ data: data ?? [] }, { status: 200 });
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const supabase = await createClient();
   const {

--- a/src/app/my/organizations/_components/ApplicationsClient.tsx
+++ b/src/app/my/organizations/_components/ApplicationsClient.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+import type { OrgApplication, ApprovalStatus } from "../types";
+
+interface Props {
+  applications: OrgApplication[];
+}
+
+function StatusBadge({ status }: { status: ApprovalStatus }) {
+  const config: Record<ApprovalStatus, { label: string; className: string }> = {
+    pending: {
+      label: "Under Review",
+      className: "bg-warning/15 text-warning border border-warning/20",
+    },
+    approved: {
+      label: "Approved",
+      className: "bg-success/10 text-success border border-success/20",
+    },
+    rejected: {
+      label: "Rejected",
+      className: "bg-danger/15 text-danger border border-danger/20",
+    },
+  };
+
+  const { label, className } = config[status] ?? config.pending;
+
+  return (
+    <span
+      className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${className}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function ApplicationCard({ application }: { application: OrgApplication }) {
+  const submittedDate = new Date(application.created_at);
+  const month = submittedDate
+    .toLocaleString("en-MY", { month: "short" })
+    .toUpperCase();
+  const day = submittedDate.getDate();
+
+  return (
+    <div className="flex items-center gap-4 card px-5 py-4">
+      {/* Date block */}
+      <div className="text-center min-w-12 shrink-0">
+        <div className="font-cinzel text-xs font-bold tracking-widest text-gold-bright">
+          {month}
+        </div>
+        <div className="font-cinzel text-2xl font-bold text-text-primary leading-tight">
+          {day}
+        </div>
+      </div>
+
+      {/* Application info */}
+      <div className="flex-1 min-w-0">
+        <h4 className="font-lato text-sm font-semibold text-text-primary truncate">
+          {application.name}
+        </h4>
+        {application.rejection_reason ? (
+          <p className="font-lato text-xs text-danger mt-0.5 line-clamp-1">
+            {application.rejection_reason}
+          </p>
+        ) : (
+          <p className="font-lato text-xs text-text-muted mt-0.5">
+            {application.approval_status === "pending"
+              ? "Typically reviewed within 1–2 business days"
+              : application.reviewed_at
+                ? `Reviewed on ${new Date(application.reviewed_at).toLocaleDateString("en-MY", { day: "numeric", month: "short", year: "numeric" })}`
+                : ""}
+          </p>
+        )}
+      </div>
+
+      {/* Status badge */}
+      <StatusBadge status={application.approval_status} />
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="text-center py-16 px-5">
+      <div className="text-4xl mb-4 opacity-20">♟</div>
+      <p className="font-lato text-sm text-text-muted leading-relaxed">
+        You haven&apos;t applied to become an organizer yet.
+      </p>
+      <Link
+        href="/organizations/apply"
+        className="btn-secondary mt-4 inline-block px-5 py-2 text-xs"
+      >
+        Apply as Organizer
+      </Link>
+    </div>
+  );
+}
+
+export default function ApplicationsClient({ applications }: Props) {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8">
+      <div className="flex items-center justify-between mb-1">
+        <h1 className="font-cinzel text-2xl font-bold text-text-primary tracking-wide">
+          My Organizations
+        </h1>
+        {applications.length > 0 && (
+          <Link
+            href="/organizations/apply"
+            className="btn-secondary text-xs px-4 py-2"
+          >
+            Apply Again
+          </Link>
+        )}
+      </div>
+      <p className="font-lato text-sm text-text-muted mb-6">
+        Track your organizer applications and their review status.
+      </p>
+
+      {applications.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {applications.map((app) => (
+            <ApplicationCard key={app.id} application={app} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/my/organizations/page.tsx
+++ b/src/app/my/organizations/page.tsx
@@ -1,0 +1,60 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import { createClient } from "@/services/supabase/server";
+import ApplicationsClient from "./_components/ApplicationsClient";
+import type { OrgApplication } from "./types";
+
+export const metadata: Metadata = {
+  title: "My Organizations",
+  description: "Track your organizer applications and their review status.",
+};
+
+async function fetchApplications(
+  host: string,
+  cookieHeader: string,
+): Promise<OrgApplication[]> {
+  const protocol =
+    host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https";
+
+  try {
+    const res = await fetch(
+      `${protocol}://${host}/api/v1/organizations/applications`,
+      {
+        cache: "no-store",
+        headers: { cookie: cookieHeader },
+      },
+    );
+    if (!res.ok) return [];
+    const json = await res.json();
+    return json.data ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export default async function MyOrganizationsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/login");
+  }
+
+  const headersList = await headers();
+  const host = headersList.get("host") ?? "localhost:3000";
+  const cookieHeader = headersList.get("cookie") ?? "";
+  const applications = await fetchApplications(host, cookieHeader);
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <ApplicationsClient applications={applications} />
+    </div>
+  );
+}

--- a/src/app/my/organizations/page.tsx
+++ b/src/app/my/organizations/page.tsx
@@ -1,8 +1,8 @@
-import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import NavBar from "@/components/NavBar";
 import { createClient } from "@/services/supabase/server";
+import { supabaseAdmin } from "@/services/supabase/admin";
 import ApplicationsClient from "./_components/ApplicationsClient";
 import type { OrgApplication } from "./types";
 
@@ -10,31 +10,6 @@ export const metadata: Metadata = {
   title: "My Organizations",
   description: "Track your organizer applications and their review status.",
 };
-
-async function fetchApplications(
-  host: string,
-  cookieHeader: string,
-): Promise<OrgApplication[]> {
-  const protocol =
-    host.startsWith("localhost") || host.startsWith("127.0.0.1")
-      ? "http"
-      : "https";
-
-  try {
-    const res = await fetch(
-      `${protocol}://${host}/api/v1/organizations/applications`,
-      {
-        cache: "no-store",
-        headers: { cookie: cookieHeader },
-      },
-    );
-    if (!res.ok) return [];
-    const json = await res.json();
-    return json.data ?? [];
-  } catch {
-    return [];
-  }
-}
 
 export default async function MyOrganizationsPage() {
   const supabase = await createClient();
@@ -46,10 +21,16 @@ export default async function MyOrganizationsPage() {
     redirect("/auth/login");
   }
 
-  const headersList = await headers();
-  const host = headersList.get("host") ?? "localhost:3000";
-  const cookieHeader = headersList.get("cookie") ?? "";
-  const applications = await fetchApplications(host, cookieHeader);
+  const { data } = await supabaseAdmin
+    .from("organizations")
+    .select(
+      "id, name, approval_status, rejection_reason, created_at, reviewed_at",
+    )
+    .eq("created_by", user.id)
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false });
+
+  const applications: OrgApplication[] = data ?? [];
 
   return (
     <div className="min-h-screen bg-bg-base">

--- a/src/app/my/organizations/types.ts
+++ b/src/app/my/organizations/types.ts
@@ -1,0 +1,10 @@
+export type ApprovalStatus = "pending" | "approved" | "rejected";
+
+export interface OrgApplication {
+  id: string;
+  name: string;
+  approval_status: ApprovalStatus;
+  rejection_reason: string | null;
+  created_at: string;
+  reviewed_at: string | null;
+}


### PR DESCRIPTION
Closes #61

## Summary
- Add GET handler to `/api/v1/organizations/applications` returning the authenticated user's org applications
- Rewrite route tests to cover both GET and POST (22 tests)
- Add `/my/organizations` page with application cards and status badges

Generated with [Claude Code](https://claude.ai/code)