### PR TITLE
feat: create registration + payment records in a database transaction

### DIFF
--- a/db/migrations/009_registration_payment_transaction.sql
+++ b/db/migrations/009_registration_payment_transaction.sql
@@ -1,0 +1,80 @@
+-- =============================================
+-- ATOMIC REGISTRATION + PAYMENT CREATION
+-- Inserts a registration and its corresponding pending payment
+-- record in a single transaction, preventing partial writes.
+--
+-- Commission formula:
+--   platform_fee        = FLOOR(base_fee * commission_rate / 100)
+--   organizer_commission = FLOOR(platform_fee * organizer_commission_pct / 10)
+--   player_commission   = platform_fee - organizer_commission
+--   gross               = base_fee + player_commission  (what the player pays)
+--   net                 = gross - platform_fee           (what the organizer nets)
+-- =============================================
+CREATE OR REPLACE FUNCTION create_registration_with_payment(
+  p_user_id        uuid,
+  p_tournament_id  uuid,
+  p_fee_tier       varchar(50),
+  p_amount_cents   integer
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_registration               registrations;
+  v_commission_rate            smallint;
+  v_organizer_commission_pct   smallint;
+  v_organization_id            uuid;
+  v_platform_fee_cents         integer;
+  v_organizer_commission_cents integer;
+  v_player_commission_cents    integer;
+  v_gross_amount_cents         integer;
+  v_net_amount_cents           integer;
+BEGIN
+  INSERT INTO registrations (user_id, tournament_id, fee_tier, status)
+  VALUES (p_user_id, p_tournament_id, p_fee_tier, 'pending_payment')
+  RETURNING * INTO v_registration;
+
+  SELECT commission_rate, organizer_commission_pct, organization_id
+  INTO v_commission_rate, v_organizer_commission_pct, v_organization_id
+  FROM tournaments
+  WHERE id = p_tournament_id;
+
+  v_platform_fee_cents         := FLOOR(p_amount_cents::numeric * v_commission_rate / 100)::integer;
+  v_organizer_commission_cents := FLOOR(v_platform_fee_cents::numeric * v_organizer_commission_pct / 10)::integer;
+  v_player_commission_cents    := v_platform_fee_cents - v_organizer_commission_cents;
+  v_gross_amount_cents         := p_amount_cents + v_player_commission_cents;
+  v_net_amount_cents           := v_gross_amount_cents - v_platform_fee_cents;
+
+  INSERT INTO payments (
+    type,
+    tournament_id,
+    registration_id,
+    user_id,
+    organization_id,
+    gross_amount_cents,
+    platform_fee_cents,
+    organizer_commission_cents,
+    player_commission_cents,
+    net_amount_cents,
+    currency,
+    status
+  ) VALUES (
+    'registration',
+    p_tournament_id,
+    v_registration.id,
+    p_user_id,
+    v_organization_id,
+    v_gross_amount_cents,
+    v_platform_fee_cents,
+    v_organizer_commission_cents,
+    v_player_commission_cents,
+    v_net_amount_cents,
+    'MYR',
+    'pending'
+  );
+
+  RETURN row_to_json(v_registration)::jsonb;
+END;
+$$;

--- a/src/app/api/v1/tournaments/[id]/registrations/__tests__/route.test.ts
+++ b/src/app/api/v1/tournaments/[id]/registrations/__tests__/route.test.ts
@@ -10,8 +10,9 @@ const {
   mockProfileBuilder,
   mockCapacityBuilder,
   mockExistingBuilder,
-  mockInsertBuilder,
+  mockRpcBuilder,
   mockFrom,
+  mockRpc,
   mockGetUser,
   resetRegCallCount,
 } = vi.hoisted(() => {
@@ -35,7 +36,7 @@ const {
   const mockProfileBuilder = makeBuilder({ data: null, error: null });
   const mockCapacityBuilder = makeBuilder({ count: 0, error: null });
   const mockExistingBuilder = makeBuilder({ data: null, error: null });
-  const mockInsertBuilder = makeBuilder({ data: null, error: null });
+  const mockRpcBuilder = makeBuilder({ data: null, error: null });
 
   let regCallCount = 0;
   const resetRegCallCount = () => {
@@ -45,31 +46,29 @@ const {
     if (table === "tournaments") return mockTournamentBuilder;
     if (table === "player_profiles") return mockProfileBuilder;
     if (table === "registrations") {
-      const builders = [
-        mockCapacityBuilder,
-        mockExistingBuilder,
-        mockInsertBuilder,
-      ];
-      return builders[regCallCount++] ?? mockInsertBuilder;
+      const builders = [mockCapacityBuilder, mockExistingBuilder];
+      return builders[regCallCount++] ?? mockExistingBuilder;
     }
     return makeBuilder({ data: null, error: null });
   });
 
+  const mockRpc = vi.fn(() => mockRpcBuilder);
   const mockGetUser = vi.fn();
   return {
     mockTournamentBuilder,
     mockProfileBuilder,
     mockCapacityBuilder,
     mockExistingBuilder,
-    mockInsertBuilder,
+    mockRpcBuilder,
     mockFrom,
+    mockRpc,
     mockGetUser,
     resetRegCallCount,
   };
 });
 
 vi.mock("@/services/supabase/admin", () => ({
-  supabaseAdmin: { from: mockFrom },
+  supabaseAdmin: { from: mockFrom, rpc: mockRpc },
 }));
 
 vi.mock("@/services/supabase/server", () => ({
@@ -161,8 +160,8 @@ function setExistingResult(data: unknown, error: unknown = null) {
   ) => Promise.resolve({ data, error }).then(r);
 }
 
-function setInsertResult(data: unknown, error: unknown = null) {
-  (mockInsertBuilder as Record<string, unknown>).then = (
+function setRpcResult(data: unknown, error: unknown = null) {
+  (mockRpcBuilder as Record<string, unknown>).then = (
     r: (v: unknown) => unknown,
   ) => Promise.resolve({ data, error }).then(r);
 }
@@ -188,7 +187,7 @@ describe("POST /api/v1/tournaments/:id/register", () => {
     setCapacityResult(0);
     setProfileResult(null);
     setExistingResult(null);
-    setInsertResult(makeRegistration());
+    setRpcResult(makeRegistration());
   });
 
   afterEach(() => {
@@ -574,7 +573,7 @@ describe("POST /api/v1/tournaments/:id/register", () => {
     });
 
     it("returns 422 when insert fails due to tournament capacity trigger", async () => {
-      setInsertResult(null, {
+      setRpcResult(null, {
         code: "P0001",
         message: "Tournament is full (100 / 100 participants)",
       });
@@ -587,7 +586,7 @@ describe("POST /api/v1/tournaments/:id/register", () => {
     });
 
     it("returns 500 on an unexpected insert error", async () => {
-      setInsertResult(null, { code: "23505", message: "Unexpected DB error" });
+      setRpcResult(null, { code: "23505", message: "Unexpected DB error" });
       const res = await POST(makeRequest(VALID_UUID), {
         params: Promise.resolve({ id: VALID_UUID }),
       });

--- a/src/app/api/v1/tournaments/[id]/registrations/route.ts
+++ b/src/app/api/v1/tournaments/[id]/registrations/route.ts
@@ -228,16 +228,15 @@ export async function POST(
     );
   }
 
-  const { data: registration, error: insertErr } = await supabaseAdmin
-    .from("registrations")
-    .insert({
-      user_id: user.id,
-      tournament_id: id,
-      fee_tier,
-      status: "pending_payment",
-    })
-    .select()
-    .single();
+  const { data: registration, error: insertErr } = await supabaseAdmin.rpc(
+    "create_registration_with_payment",
+    {
+      p_user_id: user.id,
+      p_tournament_id: id,
+      p_fee_tier: fee_tier,
+      p_amount_cents: matchedTier.amount_cents,
+    },
+  );
 
   if (insertErr) {
     if (


### PR DESCRIPTION
Closes #42

## Changes

- New migration `009_registration_payment_transaction.sql` adds `create_registration_with_payment` PostgreSQL RPC function that atomically inserts both a `registrations` row and a `payments` row
- Route handler now calls `supabase.rpc("create_registration_with_payment", {...})` instead of a bare `.insert()`
- Tests updated to mock the new RPC call (837 tests pass)

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/nzmksk/my-chess-tour/tree/claude/issue-42-20260523-0150