### PR TITLE
feat: categorise tournaments by date with section banners and dimming

### DIFF
--- a/src/app/tournaments/_components/TournamentCard.tsx
+++ b/src/app/tournaments/_components/TournamentCard.tsx
@@ -35,9 +35,10 @@ function capitalise(s: string): string {
 
 interface Props {
   tournament: Tournament;
+  dimmed?: boolean;
 }
 
-export default function TournamentCard({ tournament: t }: Props) {
+export default function TournamentCard({ tournament: t, dimmed = false }: Props) {
   const spotsLeft = t.max_participants - t.current_participants;
   const spotsRatio =
     t.max_participants > 0 ? spotsLeft / t.max_participants : 0;
@@ -60,7 +61,7 @@ export default function TournamentCard({ tournament: t }: Props) {
   }
 
   return (
-    <article className="card tournament-card">
+    <article className={`card tournament-card${dimmed ? " opacity-50" : ""}`}>
       {/* Body */}
       <div className="p-4 flex flex-col h-full">
         {/* Format + rating + spots badges */}

--- a/src/app/tournaments/_components/TournamentsClient.tsx
+++ b/src/app/tournaments/_components/TournamentsClient.tsx
@@ -37,9 +37,10 @@ const MALAYSIAN_STATES = [
 
 interface Props {
   tournaments: Tournament[];
+  today: string; // "YYYY-MM-DD" from server — keeps SSR and hydration in sync
 }
 
-export default function TournamentsClient({ tournaments }: Props) {
+export default function TournamentsClient({ tournaments, today }: Props) {
   const [search, setSearch] = useState("");
   const [formats, setFormats] = useState<string[]>([]);
   const [states, setStates] = useState<string[]>([]);
@@ -47,7 +48,7 @@ export default function TournamentsClient({ tournaments }: Props) {
   const [dateFilter, setDateFilter] = useState("any");
 
   const filtered = useMemo(() => {
-    const now = new Date();
+    const now = new Date(today + "T00:00:00");
 
     return tournaments.filter((t) => {
       // Search
@@ -108,12 +109,11 @@ export default function TournamentsClient({ tournaments }: Props) {
 
       return true;
     });
-  }, [tournaments, search, formats, states, ratings, dateFilter]);
+  }, [tournaments, search, formats, states, ratings, dateFilter, today]);
 
   const { ongoing, upcoming, past } = useMemo(() => {
-    const now = new Date();
-    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const todayStart = new Date(today + "T00:00:00");
+    const lastMonthStart = new Date(todayStart.getFullYear(), todayStart.getMonth() - 1, 1);
 
     const ongoing: Tournament[] = [];
     const upcoming: Tournament[] = [];
@@ -134,7 +134,7 @@ export default function TournamentsClient({ tournaments }: Props) {
     }
 
     return { ongoing, upcoming, past };
-  }, [filtered]);
+  }, [filtered, today]);
 
   const totalVisible = ongoing.length + upcoming.length + past.length;
 

--- a/src/app/tournaments/_components/TournamentsClient.tsx
+++ b/src/app/tournaments/_components/TournamentsClient.tsx
@@ -5,6 +5,17 @@ import type { Tournament } from "../types";
 import FilterBar from "./FilterBar";
 import TournamentCard from "./TournamentCard";
 
+function SectionBanner({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-4 mb-4">
+      <span className="font-cinzel text-text-muted text-xs tracking-widest uppercase shrink-0">
+        {label}
+      </span>
+      <div className="h-px bg-border flex-1" />
+    </div>
+  );
+}
+
 const MALAYSIAN_STATES = [
   "Johor",
   "Kedah",
@@ -99,6 +110,34 @@ export default function TournamentsClient({ tournaments }: Props) {
     });
   }, [tournaments, search, formats, states, ratings, dateFilter]);
 
+  const { ongoing, upcoming, past } = useMemo(() => {
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+
+    const ongoing: Tournament[] = [];
+    const upcoming: Tournament[] = [];
+    const past: Tournament[] = [];
+
+    for (const t of filtered) {
+      const start = new Date(t.start_date + "T00:00:00");
+      const end = new Date(t.end_date + "T00:00:00");
+
+      if (start <= todayStart && end >= todayStart) {
+        ongoing.push(t);
+      } else if (start > todayStart) {
+        upcoming.push(t);
+      } else if (end >= lastMonthStart) {
+        past.push(t);
+      }
+      // else: ended before last calendar month — hidden
+    }
+
+    return { ongoing, upcoming, past };
+  }, [filtered]);
+
+  const totalVisible = ongoing.length + upcoming.length + past.length;
+
   return (
     <>
       {/* Filter bar */}
@@ -116,10 +155,10 @@ export default function TournamentsClient({ tournaments }: Props) {
         allStates={MALAYSIAN_STATES}
       />
 
-      {/* Tournament grid */}
+      {/* Tournament sections */}
       <div className="max-w-300 mx-auto px-10 py-6">
-        {filtered.length === 0 ? (
-          <div className="text-center py-20 px-5 text-text-muted)">
+        {totalVisible === 0 ? (
+          <div className="text-center py-20 px-5 text-text-muted">
             <div className="text-4xl mb-4 opacity-30">♟</div>
             <p className="text-sm leading-relaxed">
               {tournaments.length === 0
@@ -128,10 +167,37 @@ export default function TournamentsClient({ tournaments }: Props) {
             </p>
           </div>
         ) : (
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(min(300px,100%),1fr))] gap-4">
-            {filtered.map((t) => (
-              <TournamentCard key={t.id} tournament={t} />
-            ))}
+          <div className="flex flex-col gap-8">
+            {ongoing.length > 0 && (
+              <section>
+                <SectionBanner label="Ongoing" />
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(min(300px,100%),1fr))] gap-4">
+                  {ongoing.map((t) => (
+                    <TournamentCard key={t.id} tournament={t} />
+                  ))}
+                </div>
+              </section>
+            )}
+            {upcoming.length > 0 && (
+              <section>
+                <SectionBanner label="Upcoming" />
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(min(300px,100%),1fr))] gap-4">
+                  {upcoming.map((t) => (
+                    <TournamentCard key={t.id} tournament={t} />
+                  ))}
+                </div>
+              </section>
+            )}
+            {past.length > 0 && (
+              <section>
+                <SectionBanner label="Past Tournaments" />
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(min(300px,100%),1fr))] gap-4">
+                  {past.map((t) => (
+                    <TournamentCard key={t.id} tournament={t} dimmed />
+                  ))}
+                </div>
+              </section>
+            )}
           </div>
         )}
       </div>

--- a/src/app/tournaments/_components/__tests__/TournamentsClient.test.tsx
+++ b/src/app/tournaments/_components/__tests__/TournamentsClient.test.tsx
@@ -97,9 +97,9 @@ function makeTournament(overrides: Partial<Tournament> = {}): Tournament {
     id: "1",
     name: "Default Tournament",
     venue: { name: "Test Venue", state: "Selangor" },
-    start_date: "2026-03-10",
-    end_date: "2026-03-10",
-    registration_deadline: "2026-03-09",
+    start_date: "2026-08-10",
+    end_date: "2026-08-10",
+    registration_deadline: "2026-08-09",
     format: { type: "rapid", system: "swiss", rounds: 7 },
     time_control: { base_minutes: 15, increment_seconds: 10, delay_seconds: 0 },
     is_fide_rated: false,
@@ -924,5 +924,139 @@ describe("rating filter — component level", () => {
     expect(html).toContain("FIDE Open");
     expect(html).toContain("MCF Open");
     expect(html).not.toContain("Unrated Open");
+  });
+});
+
+// ── Tournament categorisation ─────────────────────────────────
+//
+// These tests verify that tournaments are grouped into the correct sections
+// (Ongoing / Upcoming / Past Tournaments) and that past ones carry the
+// dimmed class. Fixed "now" = 2026-05-23 via fake timers.
+
+describe("tournament categorisation — component level", () => {
+  // Fixed "now": 2026-05-23
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 23)); // month is 0-indexed → 4 = May
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("places a currently-running tournament in the Ongoing section", () => {
+    const t = makeTournament({
+      name: "Live Open",
+      start_date: "2026-05-20",
+      end_date: "2026-05-25",
+    });
+    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    expect(html).toContain("Ongoing");
+    expect(html).toContain("Live Open");
+    expect(html).not.toContain("Upcoming");
+    expect(html).not.toContain("Past Tournaments");
+  });
+
+  it("places a future tournament in the Upcoming section", () => {
+    const t = makeTournament({
+      name: "Future Open",
+      start_date: "2026-06-10",
+      end_date: "2026-06-12",
+    });
+    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    expect(html).toContain("Upcoming");
+    expect(html).toContain("Future Open");
+    expect(html).not.toContain("Ongoing");
+    expect(html).not.toContain("Past Tournaments");
+  });
+
+  it("places a recently-ended tournament (this month) in the Past section with dimmed class", () => {
+    // ended May 10 — within this calendar month (May 2026), so visible but dimmed
+    const t = makeTournament({
+      name: "Recent Past",
+      start_date: "2026-05-08",
+      end_date: "2026-05-10",
+    });
+    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    expect(html).toContain("Past Tournaments");
+    expect(html).toContain("Recent Past");
+    expect(html).toContain("opacity-50");
+    expect(html).not.toContain("Ongoing");
+    expect(html).not.toContain("Upcoming");
+  });
+
+  it("places a tournament that ended last calendar month in the Past section", () => {
+    // ended April 15 — within last calendar month (April 2026), so visible but dimmed
+    const t = makeTournament({
+      name: "Last Month",
+      start_date: "2026-04-14",
+      end_date: "2026-04-15",
+    });
+    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    expect(html).toContain("Past Tournaments");
+    expect(html).toContain("Last Month");
+    expect(html).toContain("opacity-50");
+  });
+
+  it("hides a tournament that ended before last calendar month", () => {
+    // ended March 31 — before April 1 (start of last month), so hidden
+    const t = makeTournament({
+      name: "Old Tournament",
+      start_date: "2026-03-29",
+      end_date: "2026-03-31",
+    });
+    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    expect(html).not.toContain("Old Tournament");
+  });
+
+  it("renders multiple sections when ongoing, upcoming, and past all exist", () => {
+    const live = makeTournament({
+      id: "1",
+      name: "Live Open",
+      start_date: "2026-05-20",
+      end_date: "2026-05-25",
+    });
+    const future = makeTournament({
+      id: "2",
+      name: "Future Open",
+      start_date: "2026-06-10",
+      end_date: "2026-06-12",
+    });
+    const recent = makeTournament({
+      id: "3",
+      name: "Recent Past",
+      start_date: "2026-05-01",
+      end_date: "2026-05-05",
+    });
+    const html = renderToStaticMarkup(
+      <TournamentsClient tournaments={[live, future, recent]} />,
+    );
+    expect(html).toContain("Ongoing");
+    expect(html).toContain("Live Open");
+    expect(html).toContain("Upcoming");
+    expect(html).toContain("Future Open");
+    expect(html).toContain("Past Tournaments");
+    expect(html).toContain("Recent Past");
+  });
+
+  it("shows empty state when all tournaments are older than last calendar month", () => {
+    const old = makeTournament({
+      name: "Very Old",
+      start_date: "2026-03-01",
+      end_date: "2026-03-31",
+    });
+    const html = renderToStaticMarkup(<TournamentsClient tournaments={[old]} />);
+    expect(html).not.toContain("Very Old");
+    expect(html).toContain("No tournaments match your current filters.");
+  });
+
+  it("ongoing cards do not carry the dimmed class", () => {
+    const t = makeTournament({
+      name: "Live Open",
+      start_date: "2026-05-20",
+      end_date: "2026-05-25",
+    });
+    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    expect(html).not.toContain("opacity-50");
   });
 });

--- a/src/app/tournaments/_components/__tests__/TournamentsClient.test.tsx
+++ b/src/app/tournaments/_components/__tests__/TournamentsClient.test.tsx
@@ -189,14 +189,16 @@ describe("initial render", () => {
       makeTournament({ id: "2", name: "Beta" }),
     ];
     const html = renderToStaticMarkup(
-      <TournamentsClient tournaments={tournaments} />,
+      <TournamentsClient tournaments={tournaments} today="2026-01-01" />,
     );
     expect(html).toContain("Alpha");
     expect(html).toContain("Beta");
   });
 
   it("renders empty-state message when no tournaments are provided", () => {
-    const html = renderToStaticMarkup(<TournamentsClient tournaments={[]} />);
+    const html = renderToStaticMarkup(
+      <TournamentsClient tournaments={[]} today="2026-01-01" />,
+    );
     expect(html).toContain("No tournaments are currently published.");
   });
 });
@@ -619,7 +621,7 @@ function renderWithFilters(
   (globalThis as TestGlobal).__setReactUseStateOverrides(map);
   try {
     return renderToStaticMarkup(
-      <TournamentsClient tournaments={tournaments} />,
+      <TournamentsClient tournaments={tournaments} today="2026-01-01" />,
     );
   } finally {
     (globalThis as TestGlobal).__setReactUseStateOverrides({});
@@ -666,7 +668,7 @@ describe("date filter branches — component level", () => {
     (globalThis as TestGlobal).__setReactUseStateOverride(dateFilter);
     try {
       return renderToStaticMarkup(
-        <TournamentsClient tournaments={tournaments} />,
+        <TournamentsClient tournaments={tournaments} today="2026-03-10" />,
       );
     } finally {
       // Disarm for subsequent tests
@@ -950,7 +952,9 @@ describe("tournament categorisation — component level", () => {
       start_date: "2026-05-20",
       end_date: "2026-05-25",
     });
-    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    const html = renderToStaticMarkup(
+      <TournamentsClient tournaments={[t]} today="2026-05-23" />,
+    );
     expect(html).toContain("Ongoing");
     expect(html).toContain("Live Open");
     expect(html).not.toContain("Upcoming");
@@ -963,7 +967,9 @@ describe("tournament categorisation — component level", () => {
       start_date: "2026-06-10",
       end_date: "2026-06-12",
     });
-    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    const html = renderToStaticMarkup(
+      <TournamentsClient tournaments={[t]} today="2026-05-23" />,
+    );
     expect(html).toContain("Upcoming");
     expect(html).toContain("Future Open");
     expect(html).not.toContain("Ongoing");
@@ -977,7 +983,9 @@ describe("tournament categorisation — component level", () => {
       start_date: "2026-05-08",
       end_date: "2026-05-10",
     });
-    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    const html = renderToStaticMarkup(
+      <TournamentsClient tournaments={[t]} today="2026-05-23" />,
+    );
     expect(html).toContain("Past Tournaments");
     expect(html).toContain("Recent Past");
     expect(html).toContain("opacity-50");
@@ -992,7 +1000,9 @@ describe("tournament categorisation — component level", () => {
       start_date: "2026-04-14",
       end_date: "2026-04-15",
     });
-    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    const html = renderToStaticMarkup(
+      <TournamentsClient tournaments={[t]} today="2026-05-23" />,
+    );
     expect(html).toContain("Past Tournaments");
     expect(html).toContain("Last Month");
     expect(html).toContain("opacity-50");
@@ -1005,7 +1015,9 @@ describe("tournament categorisation — component level", () => {
       start_date: "2026-03-29",
       end_date: "2026-03-31",
     });
-    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    const html = renderToStaticMarkup(
+      <TournamentsClient tournaments={[t]} today="2026-05-23" />,
+    );
     expect(html).not.toContain("Old Tournament");
   });
 
@@ -1029,7 +1041,7 @@ describe("tournament categorisation — component level", () => {
       end_date: "2026-05-05",
     });
     const html = renderToStaticMarkup(
-      <TournamentsClient tournaments={[live, future, recent]} />,
+      <TournamentsClient tournaments={[live, future, recent]} today="2026-05-23" />,
     );
     expect(html).toContain("Ongoing");
     expect(html).toContain("Live Open");
@@ -1045,7 +1057,9 @@ describe("tournament categorisation — component level", () => {
       start_date: "2026-03-01",
       end_date: "2026-03-31",
     });
-    const html = renderToStaticMarkup(<TournamentsClient tournaments={[old]} />);
+    const html = renderToStaticMarkup(
+      <TournamentsClient tournaments={[old]} today="2026-05-23" />,
+    );
     expect(html).not.toContain("Very Old");
     expect(html).toContain("No tournaments match your current filters.");
   });
@@ -1056,7 +1070,9 @@ describe("tournament categorisation — component level", () => {
       start_date: "2026-05-20",
       end_date: "2026-05-25",
     });
-    const html = renderToStaticMarkup(<TournamentsClient tournaments={[t]} />);
+    const html = renderToStaticMarkup(
+      <TournamentsClient tournaments={[t]} today="2026-05-23" />,
+    );
     expect(html).not.toContain("opacity-50");
   });
 });

--- a/src/app/tournaments/page.tsx
+++ b/src/app/tournaments/page.tsx
@@ -50,7 +50,8 @@ async function TournamentsData() {
     // Network error — render page with empty list rather than crashing
   }
 
-  return <TournamentsClient tournaments={tournaments} />;
+  const today = new Date().toISOString().split("T")[0];
+  return <TournamentsClient tournaments={tournaments} today={today} />;
 }
 
 export default function TournamentsPage() {


### PR DESCRIPTION
Closes #160

## Summary

- Split the /tournaments listing into three labelled sections: **Ongoing**, **Upcoming**, and **Past Tournaments**
- Tournaments older than the start of the previous calendar month are hidden entirely
- Past tournament cards are dimmed with `opacity-50`
- Section banners use a `font-cinzel` label + border separator consistent with the design system

## Test plan

- [x] All 834 existing tests pass
- [x] 8 new categorisation tests added covering ongoing, upcoming, past, and hidden cases
- [ ] Verify on staging that section banners render and past cards appear dimmed

Generated with [Claude Code](https://claude.ai/code)