### PR TITLE
feat: allow multiple org applications with unique name enforcement

### DIFF
--- a/db/migrations/010_org_name_unique.sql
+++ b/db/migrations/010_org_name_unique.sql
@@ -1,0 +1,2 @@
+-- Case-insensitive unique organization names among active (non-deleted) organizations
+CREATE UNIQUE INDEX idx_organizations_name_active ON organizations (lower(name)) WHERE deleted_at IS NULL;

--- a/src/app/api/v1/organizations/applications/__tests__/route.test.ts
+++ b/src/app/api/v1/organizations/applications/__tests__/route.test.ts
@@ -12,6 +12,7 @@ const { mockBuilder, mockFrom, mockGetUser } = vi.hoisted(() => {
       "select",
       "eq",
       "in",
+      "ilike",
       "is",
       "order",
       "single",
@@ -344,29 +345,20 @@ describe("POST /api/v1/organizations/applications", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Duplicate application check
+  // Name uniqueness check
   // -------------------------------------------------------------------------
 
-  describe("duplicate check", () => {
-    it("returns 409 when user already has a pending application", async () => {
-      setQueryResult({ id: ORG_ID, approval_status: "pending" });
+  describe("name uniqueness", () => {
+    it("returns 409 when an organization with the same name already exists", async () => {
+      setQueryResult({ id: ORG_ID });
       const res = await POST(makePostRequest());
       expect(res.status).toBe(409);
       const json = await res.json();
-      expect(json.error.code).toBe("ALREADY_APPLIED");
-      expect(json.error.message).toMatch(/pending/i);
+      expect(json.error.code).toBe("NAME_TAKEN");
+      expect(json.error.message).toMatch(/already exists/i);
     });
 
-    it("returns 409 when user already has an approved organization", async () => {
-      setQueryResult({ id: ORG_ID, approval_status: "approved" });
-      const res = await POST(makePostRequest());
-      expect(res.status).toBe(409);
-      const json = await res.json();
-      expect(json.error.code).toBe("ALREADY_APPLIED");
-      expect(json.error.message).toMatch(/approved/i);
-    });
-
-    it("returns 500 when the duplicate check query fails", async () => {
+    it("returns 500 when the name uniqueness check query fails", async () => {
       setQueryResult(null, { message: "DB connection error" });
       const res = await POST(makePostRequest());
       expect(res.status).toBe(500);

--- a/src/app/api/v1/organizations/applications/route.ts
+++ b/src/app/api/v1/organizations/applications/route.ts
@@ -62,10 +62,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if ("error" in validated) return validated.error;
   const body = validated.data;
 
+  // Escape ILIKE wildcards so names containing % or _ match literally
+  const escapedName = body.name.replace(/[\\%_]/g, "\\$&");
   const { data: nameConflict, error: nameErr } = await supabaseAdmin
     .from("organizations")
     .select("id")
-    .ilike("name", body.name)
+    .ilike("name", escapedName)
     .is("deleted_at", null)
     .maybeSingle();
 

--- a/src/app/api/v1/organizations/applications/route.ts
+++ b/src/app/api/v1/organizations/applications/route.ts
@@ -62,29 +62,26 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if ("error" in validated) return validated.error;
   const body = validated.data;
 
-  const { data: existing, error: existingErr } = await supabaseAdmin
+  const { data: nameConflict, error: nameErr } = await supabaseAdmin
     .from("organizations")
-    .select("id, approval_status")
-    .eq("created_by", user.id)
-    .in("approval_status", ["pending", "approved"])
+    .select("id")
+    .ilike("name", body.name)
+    .is("deleted_at", null)
     .maybeSingle();
 
-  if (existingErr) {
+  if (nameErr) {
     return NextResponse.json(
-      { error: { code: "INTERNAL_ERROR", message: existingErr.message } },
+      { error: { code: "INTERNAL_ERROR", message: nameErr.message } },
       { status: 500 },
     );
   }
 
-  if (existing) {
+  if (nameConflict) {
     return NextResponse.json(
       {
         error: {
-          code: "ALREADY_APPLIED",
-          message:
-            existing.approval_status === "approved"
-              ? "You already have an approved organization"
-              : "You already have a pending application",
+          code: "NAME_TAKEN",
+          message: "An organization with this name already exists",
         },
       },
       { status: 409 },


### PR DESCRIPTION
Closes #294

## Changes

- Users can now apply for more than one organization
- Organization names must be unique (case-insensitive) across all active organizations
- API returns `409 NAME_TAKEN` when a duplicate name is submitted
- New DB migration adds a partial unique index on `lower(name)` where `deleted_at IS NULL`

Generated with [Claude Code](https://claude.ai/code)