### PR TITLE
feat: add post-application navigation buttons with auto-redirect

### DIFF
--- a/src/app/organizations/apply/_components/ApplyForm.tsx
+++ b/src/app/organizations/apply/_components/ApplyForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 
 const LINK_TYPES = [
   { value: "website", label: "Website" },
@@ -25,6 +26,7 @@ interface PendingOrg {
 }
 
 export default function ApplyForm() {
+  const router = useRouter();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [links, setLinks] = useState<LinkEntry[]>([]);
@@ -34,6 +36,17 @@ export default function ApplyForm() {
   const [status, setStatus] = useState<FormStatus>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingOrg, setPendingOrg] = useState<PendingOrg | null>(null);
+  const [countdown, setCountdown] = useState(5);
+
+  useEffect(() => {
+    if (status !== "success") return;
+    if (countdown <= 0) {
+      router.push("/my/organizations");
+      return;
+    }
+    const timer = setTimeout(() => setCountdown((c) => c - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [status, countdown, router]);
 
   function addLink() {
     setLinks((prev) => [...prev, { type: "website", url: "" }]);
@@ -109,9 +122,26 @@ export default function ApplyForm() {
           under review. We&apos;ll notify you by email once it&apos;s been
           processed.
         </p>
-        <p className="font-lato text-text-muted text-xs">
+        <p className="font-lato text-text-muted text-xs mb-8">
           Typically reviewed within 1–2 business days.
         </p>
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={() => router.push("/my/organizations")}
+            className="btn-primary rounded-md w-full"
+          >
+            View My Organizations
+            <span className="ml-2 font-lato text-xs opacity-70">
+              ({countdown}s)
+            </span>
+          </button>
+          <button
+            onClick={() => router.push("/tournaments")}
+            className="btn-secondary rounded-md w-full"
+          >
+            Back to Tournaments
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/app/organizations/apply/_components/__tests__/ApplyForm.test.tsx
+++ b/src/app/organizations/apply/_components/__tests__/ApplyForm.test.tsx
@@ -14,6 +14,11 @@ import ApplyForm from "../ApplyForm";
 // Mocks
 // ---------------------------------------------------------------------------
 
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
@@ -133,9 +138,14 @@ describe("ApplyForm", () => {
   describe("handleSubmit — success", () => {
     beforeEach(() => {
       mockFetch.mockResolvedValueOnce(makeSuccessFetch("Test Org"));
+      vi.useFakeTimers();
     });
 
-    it("shows the success state after a successful API response", async () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function submitForm() {
       render(<ApplyForm />);
       const nameInput = screen.getByPlaceholderText(
         "e.g., KL Chess Association",
@@ -143,13 +153,49 @@ describe("ApplyForm", () => {
       const emailInput = screen.getByPlaceholderText("chess@org.com");
       fireEvent.change(nameInput, { target: { value: "Test Org" } });
       fireEvent.change(emailInput, { target: { value: "test@org.com" } });
-
       await act(async () => {
         fireEvent.submit(document.querySelector("form")!);
       });
+    }
 
+    it("shows the success state after a successful API response", async () => {
+      await submitForm();
       expect(screen.getByText("Application Submitted")).toBeDefined();
       expect(screen.getByText(/Test Org/)).toBeDefined();
+    });
+
+    it("shows navigation buttons after successful submission", async () => {
+      await submitForm();
+      expect(
+        screen.getByRole("button", { name: /View My Organizations/ }),
+      ).toBeDefined();
+      expect(
+        screen.getByRole("button", { name: "Back to Tournaments" }),
+      ).toBeDefined();
+    });
+
+    it("redirects to /my/organizations when primary button is clicked", async () => {
+      await submitForm();
+      fireEvent.click(
+        screen.getByRole("button", { name: /View My Organizations/ }),
+      );
+      expect(mockPush).toHaveBeenCalledWith("/my/organizations");
+    });
+
+    it("redirects to /tournaments when secondary button is clicked", async () => {
+      await submitForm();
+      fireEvent.click(
+        screen.getByRole("button", { name: "Back to Tournaments" }),
+      );
+      expect(mockPush).toHaveBeenCalledWith("/tournaments");
+    });
+
+    it("auto-redirects to /my/organizations after 5 seconds", async () => {
+      await submitForm();
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(mockPush).toHaveBeenCalledWith("/my/organizations");
     });
 
     it("passes filtered links (non-empty URLs only) in the request body", async () => {

--- a/src/app/organizations/apply/_components/__tests__/ApplyForm.test.tsx
+++ b/src/app/organizations/apply/_components/__tests__/ApplyForm.test.tsx
@@ -192,9 +192,11 @@ describe("ApplyForm", () => {
 
     it("auto-redirects to /my/organizations after 5 seconds", async () => {
       await submitForm();
-      await act(async () => {
-        vi.advanceTimersByTime(5000);
-      });
+      for (let i = 0; i < 5; i++) {
+        await act(async () => {
+          vi.advanceTimersByTime(1000);
+        });
+      }
       expect(mockPush).toHaveBeenCalledWith("/my/organizations");
     });
 


### PR DESCRIPTION
After a user successfully applies to become a tournament organizer, show two navigation buttons:

- "View My Organizations" (primary): navigates to `/my/organizations` immediately, with a 5-second auto-redirect countdown
- "Back to Tournaments" (secondary): navigates to `/tournaments`

Closes #63

Generated with [Claude Code](https://claude.ai/code)