### PR TITLE
feat: add GET /organizer/:orgId/dashboard API route

### DIFF
--- a/src/app/api/v1/organizer/[orgId]/dashboard/__tests__/route.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/dashboard/__tests__/route.test.ts
@@ -1,0 +1,602 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockOrgBuilder,
+  mockMemberBuilder,
+  mockTournamentsBuilder,
+  mockPayoutBuilder,
+  mockRegistrationsCountBuilder,
+  mockRegistrationsListBuilder,
+  mockFrom,
+  mockGetUser,
+} = vi.hoisted(() => {
+  function makeBuilder(finalResult: {
+    data?: unknown;
+    count?: unknown;
+    error?: unknown;
+  }) {
+    const b: Record<string, unknown> = {};
+    for (const m of [
+      "select",
+      "eq",
+      "in",
+      "is",
+      "order",
+      "limit",
+      "single",
+      "maybeSingle",
+    ]) {
+      b[m] = vi.fn(() => b);
+    }
+    b.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return b;
+  }
+
+  const mockOrgBuilder = makeBuilder({ data: null, error: null });
+  const mockMemberBuilder = makeBuilder({ count: 0, error: null });
+  const mockTournamentsBuilder = makeBuilder({ data: [], error: null });
+  const mockPayoutBuilder = makeBuilder({ data: [], error: null });
+  // Two separate registrations builders: one for count, one for list.
+  // The route calls registrations twice in parallel when there are tournaments.
+  let regCallIndex = 0;
+  const mockRegistrationsCountBuilder = makeBuilder({ count: 0, error: null });
+  const mockRegistrationsListBuilder = makeBuilder({ data: [], error: null });
+
+  const mockFrom = vi.fn((table: string) => {
+    if (table === "organizations") return mockOrgBuilder;
+    if (table === "organization_memberships") return mockMemberBuilder;
+    if (table === "tournaments") return mockTournamentsBuilder;
+    if (table === "tournament_payout_summary") return mockPayoutBuilder;
+    if (table === "registrations") {
+      // Alternate between count builder and list builder on successive calls
+      return regCallIndex++ % 2 === 0
+        ? mockRegistrationsCountBuilder
+        : mockRegistrationsListBuilder;
+    }
+    return mockOrgBuilder;
+  });
+
+  // Reset regCallIndex via hoisted so tests can reset it
+  (mockFrom as unknown as { _resetRegIndex: () => void })._resetRegIndex =
+    () => {
+      regCallIndex = 0;
+    };
+
+  const mockGetUser = vi.fn();
+
+  return {
+    mockOrgBuilder,
+    mockMemberBuilder,
+    mockTournamentsBuilder,
+    mockPayoutBuilder,
+    mockRegistrationsCountBuilder,
+    mockRegistrationsListBuilder,
+    mockFrom,
+    mockGetUser,
+  };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+import { GET } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const USER_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const ORG_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+const TOUR_ID_1 = "cccccccc-0000-0000-0000-000000000001";
+const TOUR_ID_2 = "cccccccc-0000-0000-0000-000000000002";
+
+const APPROVED_ORG = {
+  id: ORG_ID,
+  name: "KL Chess Association",
+  approval_status: "approved",
+};
+
+const PUBLISHED_TOURNAMENT = {
+  id: TOUR_ID_1,
+  name: "KL Open Rapid 2026",
+  start_date: "2026-03-15",
+  max_participants: 120,
+  status: "published",
+};
+
+const DRAFT_TOURNAMENT = {
+  id: TOUR_ID_2,
+  name: "KL Blitz 2026",
+  start_date: "2026-06-01",
+  max_participants: 60,
+  status: "draft",
+};
+
+const PAYOUT_ROW = {
+  total_registration_cents: 100000,
+  net_payout_cents: 90000,
+};
+
+function makeRequest(orgId: string = ORG_ID): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/organizer/${orgId}/dashboard`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setUser(id = USER_ID) {
+  mockGetUser.mockResolvedValue({ data: { user: { id } }, error: null });
+}
+
+function setNoUser() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+function setOrgResult(data: unknown, error: unknown = null) {
+  (mockOrgBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setMemberResult(count: number | null, error: unknown = null) {
+  (mockMemberBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ count, error }).then(onfulfilled, onrejected);
+}
+
+function setTournamentsResult(data: unknown, error: unknown = null) {
+  (mockTournamentsBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setPayoutResult(data: unknown, error: unknown = null) {
+  (mockPayoutBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setRegistrationsCountResult(count: number | null, error: unknown = null) {
+  (mockRegistrationsCountBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ count, error }).then(onfulfilled, onrejected);
+}
+
+function setRegistrationsListResult(data: unknown, error: unknown = null) {
+  (mockRegistrationsListBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function resetRegCallIndex() {
+  (mockFrom as unknown as { _resetRegIndex: () => void })._resetRegIndex();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/organizer/:orgId/dashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRegCallIndex();
+    setUser();
+    setOrgResult(APPROVED_ORG);
+    setMemberResult(1);
+    setTournamentsResult([PUBLISHED_TOURNAMENT]);
+    setPayoutResult([PAYOUT_ROW]);
+    setRegistrationsCountResult(5);
+    setRegistrationsListResult([
+      { tournament_id: TOUR_ID_1 },
+      { tournament_id: TOUR_ID_1 },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  describe("validation", () => {
+    it("returns 400 for a non-UUID orgId", async () => {
+      const res = await GET(makeRequest("not-a-uuid"), {
+        params: Promise.resolve({ orgId: "not-a-uuid" }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/invalid organization id/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------------
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorization
+  // -------------------------------------------------------------------------
+
+  describe("authorization", () => {
+    it("returns 404 when organization does not exist", async () => {
+      setOrgResult(null, { code: "PGRST116", message: "No rows found" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 500 on org query error", async () => {
+      setOrgResult(null, { code: "500", message: "DB error" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 on membership query error", async () => {
+      setMemberResult(null, { message: "DB error" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 403 when organization is not approved", async () => {
+      setOrgResult({ ...APPROVED_ORG, approval_status: "pending" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/not approved/i);
+    });
+
+    it("returns 403 when org is rejected", async () => {
+      setOrgResult({ ...APPROVED_ORG, approval_status: "rejected" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 when user is not a member of the organization", async () => {
+      setMemberResult(0);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/access denied/i);
+    });
+
+    it("returns 403 when member count is null", async () => {
+      setMemberResult(null);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Response shape
+  // -------------------------------------------------------------------------
+
+  describe("response shape", () => {
+    it("returns 200 with data object containing organization, stats, and recent_tournaments", async () => {
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toHaveProperty("data");
+      expect(json.data).toHaveProperty("organization");
+      expect(json.data).toHaveProperty("stats");
+      expect(json.data).toHaveProperty("recent_tournaments");
+    });
+
+    it("includes organization id, name, and approval_status", async () => {
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.organization.id).toBe(ORG_ID);
+      expect(data.organization.name).toBe("KL Chess Association");
+      expect(data.organization.approval_status).toBe("approved");
+    });
+
+    it("includes all four stats fields", async () => {
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.stats).toHaveProperty("active_tournaments");
+      expect(data.stats).toHaveProperty("total_registrations");
+      expect(data.stats).toHaveProperty("total_revenue_cents");
+      expect(data.stats).toHaveProperty("pending_payout_cents");
+    });
+
+    it("shapes each recent_tournament correctly", async () => {
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(Array.isArray(data.recent_tournaments)).toBe(true);
+      const t = data.recent_tournaments[0];
+      expect(t).toHaveProperty("id");
+      expect(t).toHaveProperty("name");
+      expect(t).toHaveProperty("start_date");
+      expect(t).toHaveProperty("current_participants");
+      expect(t).toHaveProperty("max_participants");
+      expect(t).toHaveProperty("status");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stats calculation
+  // -------------------------------------------------------------------------
+
+  describe("stats calculation", () => {
+    it("counts only published tournaments as active", async () => {
+      setTournamentsResult([PUBLISHED_TOURNAMENT, DRAFT_TOURNAMENT]);
+      resetRegCallIndex();
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.stats.active_tournaments).toBe(1);
+    });
+
+    it("reports 0 active tournaments when all are drafts", async () => {
+      setTournamentsResult([DRAFT_TOURNAMENT]);
+      resetRegCallIndex();
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.stats.active_tournaments).toBe(0);
+    });
+
+    it("uses the registration count for total_registrations", async () => {
+      setRegistrationsCountResult(42);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.stats.total_registrations).toBe(42);
+    });
+
+    it("defaults total_registrations to 0 when count is null", async () => {
+      setRegistrationsCountResult(null);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.stats.total_registrations).toBe(0);
+    });
+
+    it("sums total_registration_cents from payout summary for revenue", async () => {
+      setPayoutResult([
+        { total_registration_cents: 50000, net_payout_cents: 45000 },
+        { total_registration_cents: 30000, net_payout_cents: 27000 },
+      ]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.stats.total_revenue_cents).toBe(80000);
+    });
+
+    it("sums net_payout_cents from payout summary for pending_payout", async () => {
+      setPayoutResult([
+        { total_registration_cents: 50000, net_payout_cents: 45000 },
+        { total_registration_cents: 30000, net_payout_cents: 27000 },
+      ]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.stats.pending_payout_cents).toBe(72000);
+    });
+
+    it("returns 0 for revenue and payout when there are no payment records", async () => {
+      setPayoutResult([]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.stats.total_revenue_cents).toBe(0);
+      expect(data.stats.pending_payout_cents).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Recent tournaments
+  // -------------------------------------------------------------------------
+
+  describe("recent_tournaments", () => {
+    it("returns at most 5 recent tournaments", async () => {
+      const manyTournaments = Array.from({ length: 8 }, (_, i) => ({
+        id: `cccccccc-0000-0000-0000-00000000000${i + 1}`,
+        name: `Tournament ${i + 1}`,
+        start_date: "2026-03-15",
+        max_participants: 120,
+        status: "published",
+      }));
+      setTournamentsResult(manyTournaments);
+      resetRegCallIndex();
+      setRegistrationsListResult([]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.recent_tournaments).toHaveLength(5);
+    });
+
+    it("returns empty array when org has no tournaments", async () => {
+      setTournamentsResult([]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.recent_tournaments).toEqual([]);
+      expect(data.stats.total_registrations).toBe(0);
+    });
+
+    it("counts current_participants for recent tournaments", async () => {
+      setRegistrationsListResult([
+        { tournament_id: TOUR_ID_1 },
+        { tournament_id: TOUR_ID_1 },
+        { tournament_id: TOUR_ID_1 },
+      ]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      const t = data.recent_tournaments.find(
+        (r: { id: string }) => r.id === TOUR_ID_1,
+      );
+      expect(t.current_participants).toBe(3);
+    });
+
+    it("defaults current_participants to 0 when no confirmed registrations", async () => {
+      setRegistrationsListResult([]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.recent_tournaments[0].current_participants).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling — data fetch phase
+  // -------------------------------------------------------------------------
+
+  describe("error handling — data fetch", () => {
+    it("returns 500 when tournaments query fails", async () => {
+      setTournamentsResult(null, { message: "DB error" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when payout summary query fails", async () => {
+      setPayoutResult(null, { message: "DB error" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Query behaviour
+  // -------------------------------------------------------------------------
+
+  describe("query behaviour", () => {
+    it("filters tournaments by organization_id", async () => {
+      await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const eqMock = mockTournamentsBuilder.eq as ReturnType<typeof vi.fn>;
+      expect(eqMock).toHaveBeenCalledWith("organization_id", ORG_ID);
+    });
+
+    it("filters membership by organization_id and user_id", async () => {
+      await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const eqMock = mockMemberBuilder.eq as ReturnType<typeof vi.fn>;
+      expect(eqMock).toHaveBeenCalledWith("organization_id", ORG_ID);
+      expect(eqMock).toHaveBeenCalledWith("user_id", USER_ID);
+    });
+
+    it("filters payout summary by organization_id", async () => {
+      await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const eqMock = mockPayoutBuilder.eq as ReturnType<typeof vi.fn>;
+      expect(eqMock).toHaveBeenCalledWith("organization_id", ORG_ID);
+    });
+
+    it("does not query registrations when org has no tournaments", async () => {
+      setTournamentsResult([]);
+      vi.clearAllMocks();
+      // Re-set the required mocks after clearAllMocks
+      setUser();
+      setOrgResult(APPROVED_ORG);
+      setMemberResult(1);
+      setTournamentsResult([]);
+      setPayoutResult([]);
+      await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      // registrations builder should not have been called
+      const regInMock = mockRegistrationsCountBuilder.in as ReturnType<
+        typeof vi.fn
+      >;
+      expect(regInMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/v1/organizer/[orgId]/dashboard/__tests__/route.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/dashboard/__tests__/route.test.ts
@@ -112,10 +112,13 @@ const ORG_ID = "bbbbbbbb-0000-0000-0000-000000000001";
 const TOUR_ID_1 = "cccccccc-0000-0000-0000-000000000001";
 const TOUR_ID_2 = "cccccccc-0000-0000-0000-000000000002";
 
+const OTHER_USER_ID = "aaaaaaaa-0000-0000-0000-000000000002";
+
 const APPROVED_ORG = {
   id: ORG_ID,
   name: "KL Chess Association",
   approval_status: "approved",
+  created_by: USER_ID,
 };
 
 const PUBLISHED_TOURNAMENT = {
@@ -313,7 +316,8 @@ describe("GET /api/v1/organizer/:orgId/dashboard", () => {
       expect(res.status).toBe(403);
     });
 
-    it("returns 403 when user is not a member of the organization", async () => {
+    it("returns 403 when user is not a member and not the creator", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: OTHER_USER_ID });
       setMemberResult(0);
       const res = await GET(makeRequest(), {
         params: Promise.resolve({ orgId: ORG_ID }),
@@ -324,12 +328,21 @@ describe("GET /api/v1/organizer/:orgId/dashboard", () => {
       expect(json.error.message).toMatch(/access denied/i);
     });
 
-    it("returns 403 when member count is null", async () => {
+    it("returns 403 when member count is null and user is not the creator", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: OTHER_USER_ID });
       setMemberResult(null);
       const res = await GET(makeRequest(), {
         params: Promise.resolve({ orgId: ORG_ID }),
       });
       expect(res.status).toBe(403);
+    });
+
+    it("returns 200 when user is the creator but not an explicit member", async () => {
+      setMemberResult(0);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(200);
     });
   });
 

--- a/src/app/api/v1/organizer/[orgId]/dashboard/route.ts
+++ b/src/app/api/v1/organizer/[orgId]/dashboard/route.ts
@@ -1,0 +1,211 @@
+import { supabaseAdmin } from "@/services/supabase/admin";
+import { createClient } from "@/services/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type TournamentRow = {
+  id: string;
+  name: string;
+  start_date: string;
+  max_participants: number;
+  status: string;
+};
+
+type PayoutSummaryRow = {
+  total_registration_cents: number;
+  net_payout_cents: number;
+};
+
+type RegistrationRow = {
+  tournament_id: string;
+};
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+): Promise<NextResponse> {
+  const { orgId } = await params;
+
+  if (!UUID_RE.test(orgId)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid organization ID",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  const [
+    { data: org, error: orgError },
+    { count: memberCount, error: memberError },
+  ] = await Promise.all([
+    supabaseAdmin
+      .from("organizations")
+      .select("id, name, approval_status")
+      .eq("id", orgId)
+      .is("deleted_at", null)
+      .single(),
+    supabaseAdmin
+      .from("organization_memberships")
+      .select("*", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("user_id", user.id),
+  ]);
+
+  if (orgError) {
+    if (orgError.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Organization not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: orgError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (memberError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: memberError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (org.approval_status !== "approved") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "Organization is not approved",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  if (!memberCount) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied" } },
+      { status: 403 },
+    );
+  }
+
+  const [
+    { data: tournaments, error: tourError },
+    { data: payoutRows, error: payoutError },
+  ] = await Promise.all([
+    supabaseAdmin
+      .from("tournaments")
+      .select("id, name, start_date, max_participants, status")
+      .eq("organization_id", orgId)
+      .order("created_at", { ascending: false }),
+    supabaseAdmin
+      .from("tournament_payout_summary")
+      .select("total_registration_cents, net_payout_cents")
+      .eq("organization_id", orgId),
+  ]);
+
+  if (tourError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: tourError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (payoutError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: payoutError.message } },
+      { status: 500 },
+    );
+  }
+
+  const allTournaments = (tournaments ?? []) as TournamentRow[];
+  const allIds = allTournaments.map((t) => t.id);
+  const recentTournaments = allTournaments.slice(0, 5);
+  const recentIds = recentTournaments.map((t) => t.id);
+
+  const payout = (payoutRows ?? []) as PayoutSummaryRow[];
+  const totalRevenueCents = payout.reduce(
+    (sum, row) => sum + (row.total_registration_cents ?? 0),
+    0,
+  );
+  const pendingPayoutCents = payout.reduce(
+    (sum, row) => sum + (row.net_payout_cents ?? 0),
+    0,
+  );
+
+  const activeTournaments = allTournaments.filter(
+    (t) => t.status === "published",
+  ).length;
+
+  let totalRegistrations = 0;
+  const participantCounts: Record<string, number> = {};
+
+  if (allIds.length > 0) {
+    const [{ count: regCount }, { data: recentRegs }] = await Promise.all([
+      supabaseAdmin
+        .from("registrations")
+        .select("*", { count: "exact", head: true })
+        .in("tournament_id", allIds)
+        .eq("status", "confirmed"),
+      supabaseAdmin
+        .from("registrations")
+        .select("tournament_id")
+        .in("tournament_id", recentIds)
+        .eq("status", "confirmed"),
+    ]);
+
+    totalRegistrations = regCount ?? 0;
+
+    const regs = (recentRegs ?? []) as RegistrationRow[];
+    for (const reg of regs) {
+      participantCounts[reg.tournament_id] =
+        (participantCounts[reg.tournament_id] ?? 0) + 1;
+    }
+  }
+
+  return NextResponse.json(
+    {
+      data: {
+        organization: {
+          id: org.id,
+          name: org.name,
+          approval_status: org.approval_status,
+        },
+        stats: {
+          active_tournaments: activeTournaments,
+          total_registrations: totalRegistrations,
+          total_revenue_cents: totalRevenueCents,
+          pending_payout_cents: pendingPayoutCents,
+        },
+        recent_tournaments: recentTournaments.map((t) => ({
+          id: t.id,
+          name: t.name,
+          start_date: t.start_date,
+          current_participants: participantCounts[t.id] ?? 0,
+          max_participants: t.max_participants,
+          status: t.status,
+        })),
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/api/v1/organizer/[orgId]/dashboard/route.ts
+++ b/src/app/api/v1/organizer/[orgId]/dashboard/route.ts
@@ -160,7 +160,10 @@ export async function GET(
   const participantCounts: Record<string, number> = {};
 
   if (allIds.length > 0) {
-    const [{ count: regCount }, { data: recentRegs }] = await Promise.all([
+    const [
+      { count: regCount, error: regCountError },
+      { data: recentRegs, error: recentRegsError },
+    ] = await Promise.all([
       supabaseAdmin
         .from("registrations")
         .select("*", { count: "exact", head: true })
@@ -172,6 +175,25 @@ export async function GET(
         .in("tournament_id", recentIds)
         .eq("status", "confirmed"),
     ]);
+
+    if (regCountError) {
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: regCountError.message } },
+        { status: 500 },
+      );
+    }
+
+    if (recentRegsError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "INTERNAL_ERROR",
+            message: recentRegsError.message,
+          },
+        },
+        { status: 500 },
+      );
+    }
 
     totalRegistrations = regCount ?? 0;
 

--- a/src/app/api/v1/organizer/[orgId]/dashboard/route.ts
+++ b/src/app/api/v1/organizer/[orgId]/dashboard/route.ts
@@ -58,7 +58,7 @@ export async function GET(
   ] = await Promise.all([
     supabaseAdmin
       .from("organizations")
-      .select("id, name, approval_status")
+      .select("id, name, approval_status, created_by")
       .eq("id", orgId)
       .is("deleted_at", null)
       .single(),
@@ -101,7 +101,8 @@ export async function GET(
     );
   }
 
-  if (!memberCount) {
+  const isCreator = org.created_by === user.id;
+  if (!isCreator && !memberCount) {
     return NextResponse.json(
       { error: { code: "FORBIDDEN", message: "Access denied" } },
       { status: 403 },

--- a/src/app/my/organizations/_components/ApplicationsClient.tsx
+++ b/src/app/my/organizations/_components/ApplicationsClient.tsx
@@ -34,7 +34,7 @@ function StatusBadge({ status }: { status: ApprovalStatus }) {
   );
 }
 
-function ApplicationCard({ application }: { application: OrgApplication }) {
+function ApplicationCardContent({ application }: { application: OrgApplication }) {
   const submittedDate = new Date(application.created_at);
   const month = submittedDate
     .toLocaleString("en-MY", { month: "short" })
@@ -42,7 +42,7 @@ function ApplicationCard({ application }: { application: OrgApplication }) {
   const day = submittedDate.getDate();
 
   return (
-    <div className="flex items-center gap-4 card px-5 py-4">
+    <>
       {/* Date block */}
       <div className="text-center min-w-12 shrink-0">
         <div className="font-cinzel text-xs font-bold tracking-widest text-gold-bright">
@@ -75,6 +75,25 @@ function ApplicationCard({ application }: { application: OrgApplication }) {
 
       {/* Status badge */}
       <StatusBadge status={application.approval_status} />
+    </>
+  );
+}
+
+function ApplicationCard({ application }: { application: OrgApplication }) {
+  if (application.approval_status === "approved") {
+    return (
+      <Link
+        href={`/organizer/${application.id}/dashboard`}
+        className="flex items-center gap-4 card px-5 py-4 no-underline transition-shadow duration-150 hover:shadow-[0_4px_20px_var(--color-grandiose-hover)]"
+      >
+        <ApplicationCardContent application={application} />
+      </Link>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-4 card px-5 py-4">
+      <ApplicationCardContent application={application} />
     </div>
   );
 }

--- a/src/app/organizer/[orgId]/dashboard/_components/DashboardClient.tsx
+++ b/src/app/organizer/[orgId]/dashboard/_components/DashboardClient.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import Link from "next/link";
+
+type TournamentStatus = "draft" | "published" | "ongoing" | "completed" | "cancelled";
+
+interface RecentTournament {
+  id: string;
+  name: string;
+  start_date: string;
+  current_participants: number;
+  max_participants: number;
+  status: TournamentStatus;
+}
+
+interface Stats {
+  active_tournaments: number;
+  total_registrations: number;
+  total_revenue_cents: number;
+  pending_payout_cents: number;
+}
+
+interface DashboardData {
+  organization: { id: string; name: string };
+  stats: Stats;
+  recent_tournaments: RecentTournament[];
+}
+
+interface Props {
+  data: DashboardData;
+}
+
+const STATUS_CONFIG: Record<TournamentStatus, { label: string; className: string }> = {
+  draft: { label: "Draft", className: "bg-bg-raised text-text-muted border border-border" },
+  published: { label: "Open", className: "bg-success/10 text-success border border-success/20" },
+  ongoing: { label: "Ongoing", className: "bg-warning/15 text-warning border border-warning/20" },
+  completed: { label: "Completed", className: "bg-bg-raised text-text-muted border border-border" },
+  cancelled: { label: "Cancelled", className: "bg-danger/15 text-danger border border-danger/20" },
+};
+
+function formatCents(cents: number): string {
+  return `MYR ${(cents / 100).toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="card px-5 py-4 flex flex-col gap-1">
+      <p className="font-lato text-xs text-text-muted uppercase tracking-widest">{label}</p>
+      <p className="font-cinzel text-2xl font-bold text-text-primary">{value}</p>
+    </div>
+  );
+}
+
+function TournamentRow({ tournament }: { tournament: RecentTournament }) {
+  const startDate = new Date(tournament.start_date + "T00:00:00");
+  const month = startDate.toLocaleString("en-MY", { month: "short" }).toUpperCase();
+  const day = startDate.getDate();
+  const statusConfig = STATUS_CONFIG[tournament.status] ?? STATUS_CONFIG.draft;
+
+  return (
+    <Link
+      href={`/tournaments/${tournament.id}`}
+      className="flex items-center gap-4 card px-5 py-4 no-underline transition-shadow duration-150 hover:shadow-[0_4px_20px_var(--color-grandiose-hover)]"
+    >
+      <div className="text-center min-w-12 shrink-0">
+        <div className="font-cinzel text-xs font-bold tracking-widest text-gold-bright">{month}</div>
+        <div className="font-cinzel text-2xl font-bold text-text-primary leading-tight">{day}</div>
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <h4 className="font-lato text-sm font-semibold text-text-primary truncate">{tournament.name}</h4>
+        <p className="font-lato text-xs text-text-muted mt-0.5">
+          {tournament.current_participants} / {tournament.max_participants} participants
+        </p>
+      </div>
+
+      <span
+        className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${statusConfig.className}`}
+      >
+        {statusConfig.label}
+      </span>
+    </Link>
+  );
+}
+
+export default function DashboardClient({ data }: Props) {
+  const { organization, stats, recent_tournaments } = data;
+
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8">
+      <div className="mb-6">
+        <h1 className="font-cinzel text-2xl font-bold text-text-primary tracking-wide">
+          {organization.name}
+        </h1>
+        <p className="font-lato text-sm text-text-muted mt-1">Organizer Dashboard</p>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-3 mb-8">
+        <StatCard label="Active Tournaments" value={stats.active_tournaments} />
+        <StatCard label="Total Registrations" value={stats.total_registrations} />
+        <StatCard label="Total Revenue" value={formatCents(stats.total_revenue_cents)} />
+        <StatCard label="Pending Payout" value={formatCents(stats.pending_payout_cents)} />
+      </div>
+
+      {/* Recent Tournaments */}
+      <div>
+        <h2 className="font-cinzel text-base font-bold text-text-primary tracking-wide mb-3">
+          Recent Tournaments
+        </h2>
+
+        {recent_tournaments.length === 0 ? (
+          <div className="text-center py-12 px-5">
+            <div className="text-4xl mb-4 opacity-20">♟</div>
+            <p className="font-lato text-sm text-text-muted leading-relaxed">
+              No tournaments yet. Create your first tournament to get started.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {recent_tournaments.map((t) => (
+              <TournamentRow key={t.id} tournament={t} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/organizer/[orgId]/dashboard/page.tsx
+++ b/src/app/organizer/[orgId]/dashboard/page.tsx
@@ -24,7 +24,7 @@ interface DashboardData {
     start_date: string;
     current_participants: number;
     max_participants: number;
-    status: string;
+    status: "draft" | "published" | "ongoing" | "completed" | "cancelled";
   }[];
 }
 

--- a/src/app/organizer/[orgId]/dashboard/page.tsx
+++ b/src/app/organizer/[orgId]/dashboard/page.tsx
@@ -1,0 +1,91 @@
+import { headers } from "next/headers";
+import { redirect, notFound } from "next/navigation";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import { createClient } from "@/services/supabase/server";
+import DashboardClient from "./_components/DashboardClient";
+
+export const metadata: Metadata = {
+  title: "Organizer Dashboard",
+  description: "Manage your organization, tournaments, and registrations.",
+};
+
+interface DashboardData {
+  organization: { id: string; name: string; approval_status: string };
+  stats: {
+    active_tournaments: number;
+    total_registrations: number;
+    total_revenue_cents: number;
+    pending_payout_cents: number;
+  };
+  recent_tournaments: {
+    id: string;
+    name: string;
+    start_date: string;
+    current_participants: number;
+    max_participants: number;
+    status: string;
+  }[];
+}
+
+async function fetchDashboard(
+  orgId: string,
+  host: string,
+  cookieHeader: string,
+): Promise<DashboardData | null> {
+  const protocol =
+    host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https";
+
+  try {
+    const res = await fetch(
+      `${protocol}://${host}/api/v1/organizer/${orgId}/dashboard`,
+      {
+        cache: "no-store",
+        headers: { cookie: cookieHeader },
+      },
+    );
+    if (res.status === 404) return null;
+    if (res.status === 403 || res.status === 401) return null;
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function OrganizerDashboardPage({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/login");
+  }
+
+  const headersList = await headers();
+  const host = headersList.get("host") ?? "localhost:3000";
+  const cookieHeader = headersList.get("cookie") ?? "";
+
+  const data = await fetchDashboard(orgId, host, cookieHeader);
+
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <DashboardClient data={data} />
+    </div>
+  );
+}


### PR DESCRIPTION
Implements the organizer dashboard endpoint resolving issues #65 and #66.

Returns organization info, stats row (active tournaments, total registrations, total revenue, pending payouts) and up to 5 recent tournaments with participant counts.

Closes #65
Closes #66

Generated with [Claude Code](https://claude.ai/code)