### PR TITLE
feat: add GET /organizer/:orgId/members API route

### DIFF
--- a/src/app/api/v1/organizer/[orgId]/members/__tests__/route.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/__tests__/route.test.ts
@@ -1,0 +1,429 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockOrgBuilder,
+  mockMembershipCheckBuilder,
+  mockMembersListBuilder,
+  mockFrom,
+  mockGetUser,
+} = vi.hoisted(() => {
+  function makeBuilder(finalResult: {
+    data?: unknown;
+    count?: unknown;
+    error?: unknown;
+  }) {
+    const b: Record<string, unknown> = {};
+    for (const m of [
+      "select",
+      "eq",
+      "in",
+      "is",
+      "order",
+      "limit",
+      "single",
+      "maybeSingle",
+    ]) {
+      b[m] = vi.fn(() => b);
+    }
+    b.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return b;
+  }
+
+  const mockOrgBuilder = makeBuilder({ data: null, error: null });
+  const mockMembershipCheckBuilder = makeBuilder({ count: 0, error: null });
+  const mockMembersListBuilder = makeBuilder({ data: [], error: null });
+
+  // Track call index to distinguish the two organization_memberships queries:
+  // first call = membership check (count), second call = members list
+  let membershipCallIndex = 0;
+
+  const mockFrom = vi.fn((table: string) => {
+    if (table === "organizations") return mockOrgBuilder;
+    if (table === "organization_memberships") {
+      return membershipCallIndex++ % 2 === 0
+        ? mockMembershipCheckBuilder
+        : mockMembersListBuilder;
+    }
+    return mockOrgBuilder;
+  });
+
+  (mockFrom as unknown as { _resetIndex: () => void })._resetIndex = () => {
+    membershipCallIndex = 0;
+  };
+
+  const mockGetUser = vi.fn();
+
+  return {
+    mockOrgBuilder,
+    mockMembershipCheckBuilder,
+    mockMembersListBuilder,
+    mockFrom,
+    mockGetUser,
+  };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+import { GET } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const USER_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const ORG_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+const OTHER_USER_ID = "aaaaaaaa-0000-0000-0000-000000000002";
+
+const APPROVED_ORG = {
+  id: ORG_ID,
+  name: "KL Chess Association",
+  approval_status: "approved",
+  created_by: USER_ID,
+};
+
+const MEMBER_ROW = {
+  user_id: USER_ID,
+  joined_at: "2026-01-01T00:00:00Z",
+  users: {
+    email: "organizer@example.com",
+    first_name: "Ahmad",
+    last_name: "Kamaruddin",
+    avatar_url: null,
+  },
+  roles: { name: "owner" },
+};
+
+const SECOND_MEMBER_ROW = {
+  user_id: OTHER_USER_ID,
+  joined_at: "2026-02-01T00:00:00Z",
+  users: {
+    email: "member@example.com",
+    first_name: "Wei",
+    last_name: "Ming",
+    avatar_url: "https://example.com/avatar.png",
+  },
+  roles: { name: "member" },
+};
+
+function makeRequest(orgId: string = ORG_ID): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/organizer/${orgId}/members`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setUser(id = USER_ID) {
+  mockGetUser.mockResolvedValue({ data: { user: { id } }, error: null });
+}
+
+function setNoUser() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+function setOrgResult(data: unknown, error: unknown = null) {
+  (mockOrgBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setMembershipCheckResult(count: number | null, error: unknown = null) {
+  (mockMembershipCheckBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ count, error }).then(onfulfilled, onrejected);
+}
+
+function setMembersListResult(data: unknown, error: unknown = null) {
+  (mockMembersListBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function resetCallIndex() {
+  (mockFrom as unknown as { _resetIndex: () => void })._resetIndex();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/organizer/:orgId/members", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCallIndex();
+    setUser();
+    setOrgResult(APPROVED_ORG);
+    setMembershipCheckResult(1);
+    setMembersListResult([MEMBER_ROW]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  describe("validation", () => {
+    it("returns 400 for a non-UUID orgId", async () => {
+      const res = await GET(makeRequest("not-a-uuid"), {
+        params: Promise.resolve({ orgId: "not-a-uuid" }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/invalid organization id/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------------
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorization
+  // -------------------------------------------------------------------------
+
+  describe("authorization", () => {
+    it("returns 404 when organization does not exist", async () => {
+      setOrgResult(null, { code: "PGRST116", message: "No rows found" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 500 on org query error", async () => {
+      setOrgResult(null, { code: "500", message: "DB error" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 on membership check query error", async () => {
+      setMembershipCheckResult(null, { message: "DB error" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 403 when organization is not approved", async () => {
+      setOrgResult({ ...APPROVED_ORG, approval_status: "pending" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/not approved/i);
+    });
+
+    it("returns 403 when org is rejected", async () => {
+      setOrgResult({ ...APPROVED_ORG, approval_status: "rejected" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 when user is not a member and not the creator", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: OTHER_USER_ID });
+      setMembershipCheckResult(0);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/access denied/i);
+    });
+
+    it("returns 403 when member count is null and user is not the creator", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: OTHER_USER_ID });
+      setMembershipCheckResult(null);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 200 when user is the creator but not an explicit member", async () => {
+      setMembershipCheckResult(0);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Response shape
+  // -------------------------------------------------------------------------
+
+  describe("response shape", () => {
+    it("returns 200 with data array", async () => {
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toHaveProperty("data");
+      expect(Array.isArray(json.data)).toBe(true);
+    });
+
+    it("shapes each member entry correctly", async () => {
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      const m = data[0];
+      expect(m).toHaveProperty("user_id");
+      expect(m).toHaveProperty("email");
+      expect(m).toHaveProperty("first_name");
+      expect(m).toHaveProperty("last_name");
+      expect(m).toHaveProperty("avatar_url");
+      expect(m).toHaveProperty("role");
+      expect(m).toHaveProperty("joined_at");
+    });
+
+    it("maps member fields from joined tables correctly", async () => {
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      const m = data[0];
+      expect(m.user_id).toBe(USER_ID);
+      expect(m.email).toBe("organizer@example.com");
+      expect(m.first_name).toBe("Ahmad");
+      expect(m.last_name).toBe("Kamaruddin");
+      expect(m.avatar_url).toBeNull();
+      expect(m.role).toBe("owner");
+      expect(m.joined_at).toBe("2026-01-01T00:00:00Z");
+    });
+
+    it("includes avatar_url when present", async () => {
+      setMembersListResult([SECOND_MEMBER_ROW]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data[0].avatar_url).toBe("https://example.com/avatar.png");
+    });
+
+    it("returns empty array when org has no members", async () => {
+      setMembersListResult([]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data).toEqual([]);
+    });
+
+    it("returns multiple members", async () => {
+      setMembersListResult([MEMBER_ROW, SECOND_MEMBER_ROW]);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data).toHaveLength(2);
+      expect(data[0].user_id).toBe(USER_ID);
+      expect(data[1].user_id).toBe(OTHER_USER_ID);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling — data fetch phase
+  // -------------------------------------------------------------------------
+
+  describe("error handling — data fetch", () => {
+    it("returns 500 when members list query fails", async () => {
+      setMembersListResult(null, { message: "DB error" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Query behaviour
+  // -------------------------------------------------------------------------
+
+  describe("query behaviour", () => {
+    it("filters membership check by organization_id and user_id", async () => {
+      await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const eqMock = mockMembershipCheckBuilder.eq as ReturnType<typeof vi.fn>;
+      expect(eqMock).toHaveBeenCalledWith("organization_id", ORG_ID);
+      expect(eqMock).toHaveBeenCalledWith("user_id", USER_ID);
+    });
+
+    it("filters members list by organization_id", async () => {
+      await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const eqMock = mockMembersListBuilder.eq as ReturnType<typeof vi.fn>;
+      expect(eqMock).toHaveBeenCalledWith("organization_id", ORG_ID);
+    });
+
+    it("orders members list by joined_at ascending", async () => {
+      await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const orderMock = mockMembersListBuilder.order as ReturnType<typeof vi.fn>;
+      expect(orderMock).toHaveBeenCalledWith("joined_at", { ascending: true });
+    });
+  });
+});

--- a/src/app/api/v1/organizer/[orgId]/members/route.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/route.ts
@@ -1,0 +1,138 @@
+import { supabaseAdmin } from "@/services/supabase/admin";
+import { createClient } from "@/services/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type MemberRow = {
+  user_id: string;
+  joined_at: string;
+  users: {
+    email: string;
+    first_name: string;
+    last_name: string;
+    avatar_url: string | null;
+  };
+  roles: {
+    name: string;
+  };
+};
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+): Promise<NextResponse> {
+  const { orgId } = await params;
+
+  if (!UUID_RE.test(orgId)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid organization ID",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  const [
+    { data: org, error: orgError },
+    { count: memberCount, error: memberError },
+  ] = await Promise.all([
+    supabaseAdmin
+      .from("organizations")
+      .select("id, name, approval_status, created_by")
+      .eq("id", orgId)
+      .is("deleted_at", null)
+      .single(),
+    supabaseAdmin
+      .from("organization_memberships")
+      .select("*", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("user_id", user.id),
+  ]);
+
+  if (orgError) {
+    if (orgError.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Organization not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: orgError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (memberError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: memberError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (org.approval_status !== "approved") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "Organization is not approved",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const isCreator = org.created_by === user.id;
+  if (!isCreator && !memberCount) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied" } },
+      { status: 403 },
+    );
+  }
+
+  const { data: members, error: membersError } = await supabaseAdmin
+    .from("organization_memberships")
+    .select("user_id, joined_at, users(email, first_name, last_name, avatar_url), roles(name)")
+    .eq("organization_id", orgId)
+    .order("joined_at", { ascending: true });
+
+  if (membersError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: membersError.message } },
+      { status: 500 },
+    );
+  }
+
+  const rows = (members ?? []) as unknown as MemberRow[];
+
+  return NextResponse.json(
+    {
+      data: rows.map((m) => ({
+        user_id: m.user_id,
+        email: m.users.email,
+        first_name: m.users.first_name,
+        last_name: m.users.last_name,
+        avatar_url: m.users.avatar_url,
+        role: m.roles.name,
+        joined_at: m.joined_at,
+      })),
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/organizer/[orgId]/dashboard/_components/DashboardClient.tsx
+++ b/src/app/organizer/[orgId]/dashboard/_components/DashboardClient.tsx
@@ -103,6 +103,26 @@ export default function DashboardClient({ data }: Props) {
         <StatCard label="Pending Payout" value={formatCents(stats.pending_payout_cents)} />
       </div>
 
+      {/* Quick Links */}
+      <div className="mb-8">
+        <h2 className="font-cinzel text-base font-bold text-text-primary tracking-wide mb-3">
+          Manage
+        </h2>
+        <Link
+          href={`/organizer/${organization.id}/members`}
+          className="flex items-center justify-between card px-5 py-4 no-underline transition-shadow duration-150 hover:shadow-[0_4px_20px_var(--color-grandiose-hover)]"
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-xl text-gold-bright">♟</span>
+            <div>
+              <p className="font-lato text-sm font-semibold text-text-primary">Members</p>
+              <p className="font-lato text-xs text-text-muted mt-0.5">View and manage organization members</p>
+            </div>
+          </div>
+          <span className="text-text-muted text-lg">›</span>
+        </Link>
+      </div>
+
       {/* Recent Tournaments */}
       <div>
         <h2 className="font-cinzel text-base font-bold text-text-primary tracking-wide mb-3">

--- a/src/app/organizer/[orgId]/members/_components/MembersClient.tsx
+++ b/src/app/organizer/[orgId]/members/_components/MembersClient.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import Link from "next/link";
+
+interface Member {
+  user_id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  avatar_url: string | null;
+  role: string;
+  joined_at: string;
+}
+
+interface Props {
+  orgId: string;
+  orgName: string;
+  members: Member[];
+  currentUserId: string;
+}
+
+type Role = "owner" | "admin" | "member";
+
+const ROLE_CONFIG: Record<Role, { label: string; className: string }> = {
+  owner: {
+    label: "Owner",
+    className:
+      "bg-gold-ghost text-gold-bright border border-gold-dim",
+  },
+  admin: {
+    label: "Admin",
+    className: "bg-info-bg text-info border border-info-border",
+  },
+  member: {
+    label: "Member",
+    className: "bg-bg-raised text-text-secondary border border-border",
+  },
+};
+
+function getRoleConfig(role: string) {
+  return ROLE_CONFIG[(role as Role)] ?? ROLE_CONFIG.member;
+}
+
+function MemberCard({
+  member,
+  isCurrentUser,
+}: {
+  member: Member;
+  isCurrentUser: boolean;
+}) {
+  const fullName = [member.first_name, member.last_name].filter(Boolean).join(" ");
+  const initials =
+    `${member.first_name[0] ?? ""}${member.last_name[0] ?? ""}`.toUpperCase() ||
+    member.email[0]?.toUpperCase() ||
+    "?";
+
+  const joinedDate = new Date(member.joined_at).toLocaleDateString("en-MY", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+  const roleConfig = getRoleConfig(member.role);
+
+  return (
+    <div className="card px-5 py-4 flex items-center gap-4">
+      <div className="bg-gold-ghost border-2 border-gold-dim font-cinzel text-gold-bright flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold">
+        {initials}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-lato text-sm font-semibold text-text-primary truncate">
+            {fullName || member.email}
+          </span>
+          {isCurrentUser && (
+            <span className="font-cinzel text-xs font-bold tracking-widest uppercase px-1.5 py-0.5 rounded bg-bg-raised text-text-muted border border-border">
+              You
+            </span>
+          )}
+        </div>
+        <p className="font-lato text-xs text-text-muted mt-0.5 truncate">
+          {member.email}
+        </p>
+        <p className="font-lato text-xs text-text-disabled mt-0.5">
+          Joined {joinedDate}
+        </p>
+      </div>
+
+      <span
+        className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${roleConfig.className}`}
+      >
+        {roleConfig.label}
+      </span>
+    </div>
+  );
+}
+
+export default function MembersClient({
+  orgId,
+  orgName,
+  members,
+  currentUserId,
+}: Props) {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8">
+      <div className="mb-6">
+        <Link
+          href={`/organizer/${orgId}/dashboard`}
+          className="font-lato text-xs text-text-muted hover:text-text-secondary transition-colors duration-150 inline-flex items-center gap-1 mb-3"
+        >
+          ← Back to Dashboard
+        </Link>
+        <h1 className="font-cinzel text-2xl font-bold text-text-primary tracking-wide">
+          {orgName}
+        </h1>
+        <p className="font-lato text-sm text-text-muted mt-1">
+          Members · {members.length} {members.length === 1 ? "person" : "people"}
+        </p>
+      </div>
+
+      {/* Role permissions reference */}
+      <div className="rounded-lg bg-bg-raised border border-border px-5 py-4 mb-6">
+        <p className="font-cinzel text-xs font-bold tracking-widest uppercase text-gold-muted mb-2">
+          Role Permissions
+        </p>
+        <div className="flex flex-col gap-1.5">
+          {(["owner", "admin", "member"] as Role[]).map((role) => {
+            const config = ROLE_CONFIG[role];
+            const descriptions: Record<Role, string> = {
+              owner: "Full control: tournaments, members, payouts, settings.",
+              admin: "Create and manage tournaments, view participants and payouts.",
+              member: "View tournaments and participants only.",
+            };
+            return (
+              <div key={role} className="flex items-start gap-2">
+                <span
+                  className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2 py-0.5 rounded shrink-0 ${config.className}`}
+                >
+                  {config.label}
+                </span>
+                <span className="font-lato text-xs text-text-muted leading-relaxed">
+                  {descriptions[role]}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Members list */}
+      {members.length === 0 ? (
+        <div className="text-center py-12 px-5">
+          <div className="text-4xl mb-4 opacity-20">♟</div>
+          <p className="font-lato text-sm text-text-muted leading-relaxed">
+            No members yet.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {members.map((member) => (
+            <MemberCard
+              key={member.user_id}
+              member={member}
+              isCurrentUser={member.user_id === currentUserId}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/organizer/[orgId]/members/page.tsx
+++ b/src/app/organizer/[orgId]/members/page.tsx
@@ -1,0 +1,111 @@
+import { headers } from "next/headers";
+import { redirect, notFound } from "next/navigation";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import { createClient } from "@/services/supabase/server";
+import MembersClient from "./_components/MembersClient";
+
+export const metadata: Metadata = {
+  title: "Organization Members",
+  description: "View and manage your organization's members.",
+};
+
+interface Member {
+  user_id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  avatar_url: string | null;
+  role: string;
+  joined_at: string;
+}
+
+interface MembersData {
+  members: Member[];
+  orgName: string;
+}
+
+async function fetchMembers(
+  orgId: string,
+  host: string,
+  cookieHeader: string,
+): Promise<MembersData | null> {
+  const protocol =
+    host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https";
+
+  try {
+    const [membersRes, dashboardRes] = await Promise.all([
+      fetch(`${protocol}://${host}/api/v1/organizer/${orgId}/members`, {
+        cache: "no-store",
+        headers: { cookie: cookieHeader },
+      }),
+      fetch(`${protocol}://${host}/api/v1/organizer/${orgId}/dashboard`, {
+        cache: "no-store",
+        headers: { cookie: cookieHeader },
+      }),
+    ]);
+
+    if (
+      membersRes.status === 404 ||
+      membersRes.status === 403 ||
+      membersRes.status === 401 ||
+      !membersRes.ok
+    ) {
+      return null;
+    }
+
+    const membersJson = await membersRes.json();
+    const members: Member[] = membersJson.data ?? [];
+
+    let orgName = "Organization";
+    if (dashboardRes.ok) {
+      const dashJson = await dashboardRes.json();
+      orgName = dashJson.data?.organization?.name ?? orgName;
+    }
+
+    return { members, orgName };
+  } catch {
+    return null;
+  }
+}
+
+export default async function OrganizerMembersPage({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/login");
+  }
+
+  const headersList = await headers();
+  const host = headersList.get("host") ?? "localhost:3000";
+  const cookieHeader = headersList.get("cookie") ?? "";
+
+  const data = await fetchMembers(orgId, host, cookieHeader);
+
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <MembersClient
+        orgId={orgId}
+        orgName={data.orgName}
+        members={data.members}
+        currentUserId={user.id}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Implements the GET /organizer/:orgId/members endpoint for listing organization members.

Closes #70

Generated with [Claude Code](https://claude.ai/code)