### PR TITLE
feat: add GET /admin/dashboard API route

### DIFF
--- a/src/app/admin/dashboard/__tests__/page.test.ts
+++ b/src/app/admin/dashboard/__tests__/page.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ─────────────────────────────────────────────────────
+
+const mockHeadersGet = vi.hoisted(() =>
+  vi.fn().mockReturnValue("localhost:3000"),
+);
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue({ get: mockHeadersGet }),
+}));
+
+const mockRedirect = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}));
+
+vi.mock("@/app/admin/dashboard/_components/AdminDashboardClient", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/components/NavBar", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+const mockGetUser = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+
+function makeDashboardPayload() {
+  return {
+    data: {
+      stats: {
+        total_users: 55,
+        organizations: { total: 5, pending: 1, approved: 4, rejected: 0 },
+        tournaments: { total: 15, published: 8, draft: 5, cancelled: 2 },
+        total_registrations: 120,
+        platform_revenue_cents: 50000,
+      },
+      pending_organizations: [
+        {
+          id: "org-1",
+          name: "New Chess Club",
+          email: "newclub@example.com",
+          created_at: "2026-01-15T10:00:00Z",
+        },
+      ],
+      recent_tournaments: [
+        {
+          id: "tour-1",
+          name: "KL Open Rapid 2026",
+          organization_name: "KL Chess Association",
+          start_date: "2026-03-15",
+          status: "published",
+          current_participants: 20,
+          max_participants: 120,
+        },
+      ],
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("AdminDashboardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = mockFetch;
+    mockHeadersGet.mockReturnValue("localhost:3000");
+  });
+
+  it("redirects to login when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { default: AdminDashboardPage } = await import("../page");
+    await AdminDashboardPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith("/auth/login");
+  });
+
+  it("redirects to home when API returns no data", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockFetch.mockResolvedValue({ ok: false, status: 403 });
+
+    const { default: AdminDashboardPage } = await import("../page");
+    await AdminDashboardPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith("/");
+  });
+
+  it("renders page content when admin user is authenticated and data is available", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeDashboardPayload(),
+    });
+
+    const { default: AdminDashboardPage } = await import("../page");
+    const result = await AdminDashboardPage();
+
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("uses http protocol for localhost", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockHeadersGet.mockReturnValue("localhost:3000");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeDashboardPayload(),
+    });
+
+    const { default: AdminDashboardPage } = await import("../page");
+    await AdminDashboardPage();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("http://localhost:3000/api/v1/admin/dashboard"),
+      expect.any(Object),
+    );
+  });
+
+  it("uses https protocol for non-localhost hosts", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockHeadersGet.mockReturnValue("mychessour.com");
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeDashboardPayload(),
+    });
+
+    const { default: AdminDashboardPage } = await import("../page");
+    await AdminDashboardPage();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("https://mychessour.com/api/v1/admin/dashboard"),
+      expect.any(Object),
+    );
+  });
+
+  it("falls back to localhost:3000 when host header is absent", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockHeadersGet.mockReturnValue(null);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => makeDashboardPayload(),
+    });
+
+    const { default: AdminDashboardPage } = await import("../page");
+    await AdminDashboardPage();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("http://localhost:3000/api/v1/admin/dashboard"),
+      expect.any(Object),
+    );
+  });
+
+  it("redirects to home when fetch throws a network error", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockFetch.mockRejectedValue(new Error("Network failure"));
+
+    const { default: AdminDashboardPage } = await import("../page");
+    await AdminDashboardPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith("/");
+  });
+
+  it("redirects to home when API returns null data", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: null }),
+    });
+
+    const { default: AdminDashboardPage } = await import("../page");
+    await AdminDashboardPage();
+
+    expect(mockRedirect).toHaveBeenCalledWith("/");
+  });
+});

--- a/src/app/admin/dashboard/_components/AdminDashboardClient.tsx
+++ b/src/app/admin/dashboard/_components/AdminDashboardClient.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import Link from "next/link";
+
+type TournamentStatus = "draft" | "published" | "ongoing" | "completed" | "cancelled";
+
+interface PendingOrganization {
+  id: string;
+  name: string;
+  email: string | null;
+  created_at: string;
+}
+
+interface RecentTournament {
+  id: string;
+  name: string;
+  organization_name: string | null;
+  start_date: string;
+  status: string;
+  current_participants: number;
+  max_participants: number;
+}
+
+interface AdminDashboardData {
+  stats: {
+    total_users: number;
+    organizations: {
+      total: number;
+      pending: number;
+      approved: number;
+      rejected: number;
+    };
+    tournaments: {
+      total: number;
+      published: number;
+      draft: number;
+      cancelled: number;
+    };
+    total_registrations: number;
+    platform_revenue_cents: number;
+  };
+  pending_organizations: PendingOrganization[];
+  recent_tournaments: RecentTournament[];
+}
+
+interface Props {
+  data: AdminDashboardData;
+}
+
+const TOUR_STATUS_CONFIG: Record<TournamentStatus, { label: string; className: string }> = {
+  draft: { label: "Draft", className: "bg-bg-raised text-text-muted border border-border" },
+  published: { label: "Open", className: "bg-success/10 text-success border border-success/20" },
+  ongoing: { label: "Ongoing", className: "bg-warning/15 text-warning border border-warning/20" },
+  completed: { label: "Completed", className: "bg-bg-raised text-text-muted border border-border" },
+  cancelled: { label: "Cancelled", className: "bg-danger/15 text-danger border border-danger/20" },
+};
+
+function formatCents(cents: number): string {
+  return `MYR ${(cents / 100).toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="card px-5 py-4 flex flex-col gap-1">
+      <p className="font-lato text-xs text-text-muted uppercase tracking-widest">{label}</p>
+      <p className="font-cinzel text-2xl font-bold text-text-primary">{value}</p>
+    </div>
+  );
+}
+
+function SubStatRow({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="font-lato text-xs text-text-muted">{label}</span>
+      <span className="font-lato text-xs font-semibold text-text-primary">{value}</span>
+    </div>
+  );
+}
+
+function GroupCard({
+  label,
+  total,
+  breakdown,
+}: {
+  label: string;
+  total: number;
+  breakdown: { label: string; value: number }[];
+}) {
+  return (
+    <div className="card px-5 py-4 flex flex-col gap-3">
+      <div className="flex flex-col gap-0.5">
+        <p className="font-lato text-xs text-text-muted uppercase tracking-widest">{label}</p>
+        <p className="font-cinzel text-2xl font-bold text-text-primary">{total}</p>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {breakdown.map((b) => (
+          <SubStatRow key={b.label} label={b.label} value={b.value} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PendingOrgRow({ org }: { org: PendingOrganization }) {
+  const createdAt = new Date(org.created_at);
+  const dateStr = createdAt.toLocaleDateString("en-MY", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+  return (
+    <div className="card px-5 py-4 flex items-center justify-between gap-4">
+      <div className="flex-1 min-w-0">
+        <h4 className="font-lato text-sm font-semibold text-text-primary truncate">{org.name}</h4>
+        {org.email && (
+          <p className="font-lato text-xs text-text-muted mt-0.5 truncate">{org.email}</p>
+        )}
+        <p className="font-lato text-xs text-text-muted mt-0.5">Applied {dateStr}</p>
+      </div>
+      <span className="font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap bg-warning/15 text-warning border border-warning/20">
+        Pending
+      </span>
+    </div>
+  );
+}
+
+function TournamentRow({ tournament }: { tournament: RecentTournament }) {
+  const startDate = new Date(tournament.start_date + "T00:00:00");
+  const month = startDate.toLocaleString("en-MY", { month: "short" }).toUpperCase();
+  const day = startDate.getDate();
+  const status = tournament.status as TournamentStatus;
+  const statusConfig = TOUR_STATUS_CONFIG[status] ?? TOUR_STATUS_CONFIG.draft;
+
+  return (
+    <Link
+      href={`/tournaments/${tournament.id}`}
+      className="flex items-center gap-4 card px-5 py-4 no-underline transition-shadow duration-150 hover:shadow-[0_4px_20px_var(--color-grandiose-hover)]"
+    >
+      <div className="text-center min-w-12 shrink-0">
+        <div className="font-cinzel text-xs font-bold tracking-widest text-gold-bright">{month}</div>
+        <div className="font-cinzel text-2xl font-bold text-text-primary leading-tight">{day}</div>
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <h4 className="font-lato text-sm font-semibold text-text-primary truncate">{tournament.name}</h4>
+        {tournament.organization_name && (
+          <p className="font-lato text-xs text-text-muted mt-0.5 truncate">{tournament.organization_name}</p>
+        )}
+        <p className="font-lato text-xs text-text-muted mt-0.5">
+          {tournament.current_participants} / {tournament.max_participants} participants
+        </p>
+      </div>
+
+      <span
+        className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${statusConfig.className}`}
+      >
+        {statusConfig.label}
+      </span>
+    </Link>
+  );
+}
+
+export default function AdminDashboardClient({ data }: Props) {
+  const { stats, pending_organizations, recent_tournaments } = data;
+
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8">
+      <div className="mb-6">
+        <h1 className="font-cinzel text-2xl font-bold text-text-primary tracking-wide">
+          Platform Admin
+        </h1>
+        <p className="font-lato text-sm text-text-muted mt-1">Admin Dashboard</p>
+      </div>
+
+      {/* Top-level stats */}
+      <div className="grid grid-cols-2 gap-3 mb-4">
+        <StatCard label="Total Users" value={stats.total_users} />
+        <StatCard label="Total Registrations" value={stats.total_registrations} />
+      </div>
+
+      {/* Group stats */}
+      <div className="grid grid-cols-2 gap-3 mb-4">
+        <GroupCard
+          label="Organizations"
+          total={stats.organizations.total}
+          breakdown={[
+            { label: "Approved", value: stats.organizations.approved },
+            { label: "Pending", value: stats.organizations.pending },
+            { label: "Rejected", value: stats.organizations.rejected },
+          ]}
+        />
+        <GroupCard
+          label="Tournaments"
+          total={stats.tournaments.total}
+          breakdown={[
+            { label: "Published", value: stats.tournaments.published },
+            { label: "Draft", value: stats.tournaments.draft },
+            { label: "Cancelled", value: stats.tournaments.cancelled },
+          ]}
+        />
+      </div>
+
+      {/* Revenue */}
+      <div className="mb-8">
+        <StatCard label="Platform Revenue" value={formatCents(stats.platform_revenue_cents)} />
+      </div>
+
+      {/* Pending org applications */}
+      <div className="mb-8">
+        <h2 className="font-cinzel text-base font-bold text-text-primary tracking-wide mb-3">
+          Pending Applications
+        </h2>
+
+        {pending_organizations.length === 0 ? (
+          <div className="text-center py-10 px-5">
+            <div className="text-4xl mb-4 opacity-20">♟</div>
+            <p className="font-lato text-sm text-text-muted leading-relaxed">
+              No pending organization applications.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {pending_organizations.map((org) => (
+              <PendingOrgRow key={org.id} org={org} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Recent tournaments */}
+      <div>
+        <h2 className="font-cinzel text-base font-bold text-text-primary tracking-wide mb-3">
+          Recent Tournaments
+        </h2>
+
+        {recent_tournaments.length === 0 ? (
+          <div className="text-center py-10 px-5">
+            <div className="text-4xl mb-4 opacity-20">♟</div>
+            <p className="font-lato text-sm text-text-muted leading-relaxed">
+              No tournaments on the platform yet.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {recent_tournaments.map((t) => (
+              <TournamentRow key={t.id} tournament={t} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,0 +1,96 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import { createClient } from "@/services/supabase/server";
+import AdminDashboardClient from "./_components/AdminDashboardClient";
+
+export const metadata: Metadata = {
+  title: "Admin Dashboard",
+  description: "Platform administration dashboard.",
+};
+
+interface AdminDashboardData {
+  stats: {
+    total_users: number;
+    organizations: {
+      total: number;
+      pending: number;
+      approved: number;
+      rejected: number;
+    };
+    tournaments: {
+      total: number;
+      published: number;
+      draft: number;
+      cancelled: number;
+    };
+    total_registrations: number;
+    platform_revenue_cents: number;
+  };
+  pending_organizations: {
+    id: string;
+    name: string;
+    email: string | null;
+    created_at: string;
+  }[];
+  recent_tournaments: {
+    id: string;
+    name: string;
+    organization_name: string | null;
+    start_date: string;
+    status: string;
+    current_participants: number;
+    max_participants: number;
+  }[];
+}
+
+async function fetchAdminDashboard(
+  host: string,
+  cookieHeader: string,
+): Promise<AdminDashboardData | null> {
+  const protocol =
+    host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https";
+
+  try {
+    const res = await fetch(`${protocol}://${host}/api/v1/admin/dashboard`, {
+      cache: "no-store",
+      headers: { cookie: cookieHeader },
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function AdminDashboardPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/login");
+  }
+
+  const headersList = await headers();
+  const host = headersList.get("host") ?? "localhost:3000";
+  const cookieHeader = headersList.get("cookie") ?? "";
+
+  const data = await fetchAdminDashboard(host, cookieHeader);
+
+  if (!data) {
+    redirect("/");
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <AdminDashboardClient data={data} />
+    </div>
+  );
+}

--- a/src/app/api/v1/admin/dashboard/__tests__/route.test.ts
+++ b/src/app/api/v1/admin/dashboard/__tests__/route.test.ts
@@ -601,6 +601,14 @@ describe("GET /api/v1/admin/dashboard", () => {
       const json = await res.json();
       expect(json.error.code).toBe("INTERNAL_ERROR");
     });
+
+    it("returns 500 when has_global_permission RPC call fails", async () => {
+      mockRpc.mockResolvedValue({ data: null, error: { message: "RPC error" } });
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/app/api/v1/admin/dashboard/__tests__/route.test.ts
+++ b/src/app/api/v1/admin/dashboard/__tests__/route.test.ts
@@ -1,0 +1,629 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockUsersBuilder,
+  mockOrgStatusBuilder,
+  mockTourStatusBuilder,
+  mockRegCountBuilder,
+  mockPayoutBuilder,
+  mockPendingOrgsBuilder,
+  mockRecentToursBuilder,
+  mockRecentRegsBuilder,
+  mockOrgNamesBuilder,
+  mockFrom,
+  mockGetUser,
+  mockRpc,
+} = vi.hoisted(() => {
+  function makeBuilder(finalResult: {
+    data?: unknown;
+    count?: unknown;
+    error?: unknown;
+  }) {
+    const b: Record<string, unknown> = {};
+    for (const m of [
+      "select",
+      "eq",
+      "in",
+      "is",
+      "order",
+      "limit",
+      "single",
+      "maybeSingle",
+    ]) {
+      b[m] = vi.fn(() => b);
+    }
+    b.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return b;
+  }
+
+  const mockUsersBuilder = makeBuilder({ count: 55, error: null });
+  const mockOrgStatusBuilder = makeBuilder({ data: [], error: null });
+  const mockTourStatusBuilder = makeBuilder({ data: [], error: null });
+  const mockRegCountBuilder = makeBuilder({ count: 0, error: null });
+  const mockPayoutBuilder = makeBuilder({ data: [], error: null });
+  const mockPendingOrgsBuilder = makeBuilder({ data: [], error: null });
+  const mockRecentToursBuilder = makeBuilder({ data: [], error: null });
+  const mockRecentRegsBuilder = makeBuilder({ data: [], error: null });
+  const mockOrgNamesBuilder = makeBuilder({ data: [], error: null });
+
+  // Track which "organizations" call this is — first for status, second for pending list
+  let orgCallIndex = 0;
+  // Track which "tournaments" call this is — first for status, second for recent
+  let tourCallIndex = 0;
+  // Track registrations calls — first for count, second for recent regs list
+  let regCallIndex = 0;
+  // Track org names lookup (phase 2)
+  let orgNamesCallIndex = 0;
+
+  const mockFrom = vi.fn((table: string) => {
+    if (table === "users") return mockUsersBuilder;
+    if (table === "tournament_payout_summary") return mockPayoutBuilder;
+    if (table === "organizations") {
+      const idx = orgCallIndex++;
+      if (idx === 0) return mockOrgStatusBuilder;
+      if (idx === 1) return mockPendingOrgsBuilder;
+      return mockOrgNamesBuilder; // phase 2 org names
+    }
+    if (table === "tournaments") {
+      const idx = tourCallIndex++;
+      if (idx === 0) return mockTourStatusBuilder;
+      return mockRecentToursBuilder;
+    }
+    if (table === "registrations") {
+      const idx = regCallIndex++;
+      if (idx === 0) return mockRegCountBuilder;
+      return mockRecentRegsBuilder;
+    }
+    return mockUsersBuilder;
+  });
+
+  (mockFrom as unknown as { _reset: () => void })._reset = () => {
+    orgCallIndex = 0;
+    tourCallIndex = 0;
+    regCallIndex = 0;
+    orgNamesCallIndex = 0;
+  };
+
+  const mockGetUser = vi.fn();
+  const mockRpc = vi.fn();
+
+  return {
+    mockUsersBuilder,
+    mockOrgStatusBuilder,
+    mockTourStatusBuilder,
+    mockRegCountBuilder,
+    mockPayoutBuilder,
+    mockPendingOrgsBuilder,
+    mockRecentToursBuilder,
+    mockRecentRegsBuilder,
+    mockOrgNamesBuilder,
+    mockFrom,
+    mockGetUser,
+    mockRpc,
+  };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+    rpc: mockRpc,
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+import { GET } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ADMIN_USER_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const NON_ADMIN_USER_ID = "aaaaaaaa-0000-0000-0000-000000000002";
+
+const ORG_ID_1 = "bbbbbbbb-0000-0000-0000-000000000001";
+const ORG_ID_2 = "bbbbbbbb-0000-0000-0000-000000000002";
+
+const TOUR_ID_1 = "cccccccc-0000-0000-0000-000000000001";
+const TOUR_ID_2 = "cccccccc-0000-0000-0000-000000000002";
+
+const APPROVED_ORG_STATUS = { approval_status: "approved" };
+const PENDING_ORG_STATUS = { approval_status: "pending" };
+const REJECTED_ORG_STATUS = { approval_status: "rejected" };
+
+const PUBLISHED_TOUR_STATUS = { status: "published" };
+const DRAFT_TOUR_STATUS = { status: "draft" };
+const CANCELLED_TOUR_STATUS = { status: "cancelled" };
+
+const RECENT_TOUR_1 = {
+  id: TOUR_ID_1,
+  name: "KL Open Rapid 2026",
+  start_date: "2026-03-15",
+  status: "published",
+  max_participants: 120,
+  organization_id: ORG_ID_1,
+};
+
+const RECENT_TOUR_2 = {
+  id: TOUR_ID_2,
+  name: "Selangor Blitz 2026",
+  start_date: "2026-04-01",
+  status: "draft",
+  max_participants: 60,
+  organization_id: ORG_ID_2,
+};
+
+const PENDING_ORG_1 = {
+  id: ORG_ID_2,
+  name: "New Chess Club",
+  email: "newclub@example.com",
+  created_at: "2026-01-15T10:00:00Z",
+};
+
+function makeRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/v1/admin/dashboard");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setUser(id = ADMIN_USER_ID) {
+  mockGetUser.mockResolvedValue({ data: { user: { id } }, error: null });
+}
+
+function setNoUser() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+function setAdminPermission(isAdmin: boolean) {
+  mockRpc.mockResolvedValue({ data: isAdmin, error: null });
+}
+
+function setResult(
+  builder: Record<string, unknown>,
+  result: { data?: unknown; count?: unknown; error?: unknown },
+) {
+  builder.then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve(result).then(onfulfilled, onrejected);
+}
+
+function resetCallIndexes() {
+  (mockFrom as unknown as { _reset: () => void })._reset();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/admin/dashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCallIndexes();
+    setUser();
+    setAdminPermission(true);
+    setResult(mockUsersBuilder, { count: 55, error: null });
+    setResult(mockOrgStatusBuilder, {
+      data: [APPROVED_ORG_STATUS, APPROVED_ORG_STATUS, PENDING_ORG_STATUS],
+      error: null,
+    });
+    setResult(mockTourStatusBuilder, {
+      data: [PUBLISHED_TOUR_STATUS, DRAFT_TOUR_STATUS],
+      error: null,
+    });
+    setResult(mockRegCountBuilder, { count: 120, error: null });
+    setResult(mockPayoutBuilder, {
+      data: [{ effective_platform_fee_cents: 10000 }],
+      error: null,
+    });
+    setResult(mockPendingOrgsBuilder, { data: [PENDING_ORG_1], error: null });
+    setResult(mockRecentToursBuilder, {
+      data: [RECENT_TOUR_1, RECENT_TOUR_2],
+      error: null,
+    });
+    setResult(mockRecentRegsBuilder, {
+      data: [{ tournament_id: TOUR_ID_1 }, { tournament_id: TOUR_ID_1 }],
+      error: null,
+    });
+    setResult(mockOrgNamesBuilder, {
+      data: [
+        { id: ORG_ID_1, name: "KL Chess Association" },
+        { id: ORG_ID_2, name: "Selangor Chess Federation" },
+      ],
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------------
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorization
+  // -------------------------------------------------------------------------
+
+  describe("authorization", () => {
+    it("returns 403 when user does not have platform.manage permission", async () => {
+      setAdminPermission(false);
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/admin access required/i);
+    });
+
+    it("checks the platform.manage permission with the correct user id", async () => {
+      await GET(makeRequest());
+      expect(mockRpc).toHaveBeenCalledWith("has_global_permission", {
+        p_user_id: ADMIN_USER_ID,
+        p_permission: "platform.manage",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Response shape
+  // -------------------------------------------------------------------------
+
+  describe("response shape", () => {
+    it("returns 200 with data object containing stats, pending_organizations, and recent_tournaments", async () => {
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toHaveProperty("data");
+      expect(json.data).toHaveProperty("stats");
+      expect(json.data).toHaveProperty("pending_organizations");
+      expect(json.data).toHaveProperty("recent_tournaments");
+    });
+
+    it("stats includes all expected fields", async () => {
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats).toHaveProperty("total_users");
+      expect(data.stats).toHaveProperty("organizations");
+      expect(data.stats).toHaveProperty("tournaments");
+      expect(data.stats).toHaveProperty("total_registrations");
+      expect(data.stats).toHaveProperty("platform_revenue_cents");
+    });
+
+    it("organizations stats has total, pending, approved, rejected", async () => {
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.organizations).toHaveProperty("total");
+      expect(data.stats.organizations).toHaveProperty("pending");
+      expect(data.stats.organizations).toHaveProperty("approved");
+      expect(data.stats.organizations).toHaveProperty("rejected");
+    });
+
+    it("tournaments stats has total, published, draft, cancelled", async () => {
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.tournaments).toHaveProperty("total");
+      expect(data.stats.tournaments).toHaveProperty("published");
+      expect(data.stats.tournaments).toHaveProperty("draft");
+      expect(data.stats.tournaments).toHaveProperty("cancelled");
+    });
+
+    it("shapes each pending_organization correctly", async () => {
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(Array.isArray(data.pending_organizations)).toBe(true);
+      const org = data.pending_organizations[0];
+      expect(org).toHaveProperty("id");
+      expect(org).toHaveProperty("name");
+      expect(org).toHaveProperty("email");
+      expect(org).toHaveProperty("created_at");
+    });
+
+    it("shapes each recent_tournament correctly", async () => {
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(Array.isArray(data.recent_tournaments)).toBe(true);
+      const t = data.recent_tournaments[0];
+      expect(t).toHaveProperty("id");
+      expect(t).toHaveProperty("name");
+      expect(t).toHaveProperty("organization_name");
+      expect(t).toHaveProperty("start_date");
+      expect(t).toHaveProperty("status");
+      expect(t).toHaveProperty("current_participants");
+      expect(t).toHaveProperty("max_participants");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stats calculation
+  // -------------------------------------------------------------------------
+
+  describe("stats calculation", () => {
+    it("reports correct total_users from count query", async () => {
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.total_users).toBe(55);
+    });
+
+    it("defaults total_users to 0 when count is null", async () => {
+      setResult(mockUsersBuilder, { count: null, error: null });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.total_users).toBe(0);
+    });
+
+    it("counts organizations by approval_status", async () => {
+      setResult(mockOrgStatusBuilder, {
+        data: [
+          APPROVED_ORG_STATUS,
+          APPROVED_ORG_STATUS,
+          APPROVED_ORG_STATUS,
+          PENDING_ORG_STATUS,
+          PENDING_ORG_STATUS,
+          REJECTED_ORG_STATUS,
+        ],
+        error: null,
+      });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.organizations.total).toBe(6);
+      expect(data.stats.organizations.approved).toBe(3);
+      expect(data.stats.organizations.pending).toBe(2);
+      expect(data.stats.organizations.rejected).toBe(1);
+    });
+
+    it("counts tournaments by status", async () => {
+      setResult(mockTourStatusBuilder, {
+        data: [
+          PUBLISHED_TOUR_STATUS,
+          PUBLISHED_TOUR_STATUS,
+          DRAFT_TOUR_STATUS,
+          CANCELLED_TOUR_STATUS,
+        ],
+        error: null,
+      });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.tournaments.total).toBe(4);
+      expect(data.stats.tournaments.published).toBe(2);
+      expect(data.stats.tournaments.draft).toBe(1);
+      expect(data.stats.tournaments.cancelled).toBe(1);
+    });
+
+    it("reports correct total_registrations", async () => {
+      setResult(mockRegCountBuilder, { count: 42, error: null });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.total_registrations).toBe(42);
+    });
+
+    it("defaults total_registrations to 0 when count is null", async () => {
+      setResult(mockRegCountBuilder, { count: null, error: null });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.total_registrations).toBe(0);
+    });
+
+    it("sums effective_platform_fee_cents for platform_revenue_cents", async () => {
+      setResult(mockPayoutBuilder, {
+        data: [
+          { effective_platform_fee_cents: 10000 },
+          { effective_platform_fee_cents: 5000 },
+          { effective_platform_fee_cents: 3000 },
+        ],
+        error: null,
+      });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.platform_revenue_cents).toBe(18000);
+    });
+
+    it("returns 0 for platform_revenue_cents when no payout records", async () => {
+      setResult(mockPayoutBuilder, { data: [], error: null });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.stats.platform_revenue_cents).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pending organizations
+  // -------------------------------------------------------------------------
+
+  describe("pending_organizations", () => {
+    it("returns pending organizations with correct fields", async () => {
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.pending_organizations).toHaveLength(1);
+      expect(data.pending_organizations[0].id).toBe(ORG_ID_2);
+      expect(data.pending_organizations[0].name).toBe("New Chess Club");
+      expect(data.pending_organizations[0].email).toBe("newclub@example.com");
+    });
+
+    it("returns empty array when no orgs are pending", async () => {
+      setResult(mockPendingOrgsBuilder, { data: [], error: null });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.pending_organizations).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Recent tournaments
+  // -------------------------------------------------------------------------
+
+  describe("recent_tournaments", () => {
+    it("returns recent tournaments with organization_name resolved", async () => {
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      const t = data.recent_tournaments.find(
+        (r: { id: string }) => r.id === TOUR_ID_1,
+      );
+      expect(t.organization_name).toBe("KL Chess Association");
+    });
+
+    it("counts current_participants for recent tournaments", async () => {
+      setResult(mockRecentRegsBuilder, {
+        data: [
+          { tournament_id: TOUR_ID_1 },
+          { tournament_id: TOUR_ID_1 },
+          { tournament_id: TOUR_ID_1 },
+        ],
+        error: null,
+      });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      const t = data.recent_tournaments.find(
+        (r: { id: string }) => r.id === TOUR_ID_1,
+      );
+      expect(t.current_participants).toBe(3);
+    });
+
+    it("defaults current_participants to 0 when no confirmed registrations", async () => {
+      setResult(mockRecentRegsBuilder, { data: [], error: null });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.recent_tournaments[0].current_participants).toBe(0);
+    });
+
+    it("returns empty array when there are no tournaments", async () => {
+      setResult(mockRecentToursBuilder, { data: [], error: null });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.recent_tournaments).toEqual([]);
+    });
+
+    it("sets organization_name to null when tournament has no organization_id", async () => {
+      setResult(mockRecentToursBuilder, {
+        data: [{ ...RECENT_TOUR_1, organization_id: null }],
+        error: null,
+      });
+      const res = await GET(makeRequest());
+      const { data } = await res.json();
+      expect(data.recent_tournaments[0].organization_name).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("returns 500 when users query fails", async () => {
+      setResult(mockUsersBuilder, { count: null, error: { message: "DB error" } });
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when organizations status query fails", async () => {
+      setResult(mockOrgStatusBuilder, { data: null, error: { message: "DB error" } });
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when tournaments status query fails", async () => {
+      setResult(mockTourStatusBuilder, { data: null, error: { message: "DB error" } });
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when registrations count query fails", async () => {
+      setResult(mockRegCountBuilder, { count: null, error: { message: "DB error" } });
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when payout summary query fails", async () => {
+      setResult(mockPayoutBuilder, { data: null, error: { message: "DB error" } });
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when pending orgs query fails", async () => {
+      setResult(mockPendingOrgsBuilder, { data: null, error: { message: "DB error" } });
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when recent tournaments query fails", async () => {
+      setResult(mockRecentToursBuilder, { data: null, error: { message: "DB error" } });
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when phase-2 registrations query fails", async () => {
+      setResult(mockRecentRegsBuilder, { data: null, error: { message: "DB error" } });
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Query behaviour
+  // -------------------------------------------------------------------------
+
+  describe("query behaviour", () => {
+    it("does not query registrations or org names when there are no recent tournaments", async () => {
+      setResult(mockRecentToursBuilder, { data: [], error: null });
+      vi.clearAllMocks();
+      resetCallIndexes();
+      setUser();
+      setAdminPermission(true);
+      setResult(mockUsersBuilder, { count: 0, error: null });
+      setResult(mockOrgStatusBuilder, { data: [], error: null });
+      setResult(mockTourStatusBuilder, { data: [], error: null });
+      setResult(mockRegCountBuilder, { count: 0, error: null });
+      setResult(mockPayoutBuilder, { data: [], error: null });
+      setResult(mockPendingOrgsBuilder, { data: [], error: null });
+      setResult(mockRecentToursBuilder, { data: [], error: null });
+      await GET(makeRequest());
+      const regInMock = mockRecentRegsBuilder.in as ReturnType<typeof vi.fn>;
+      expect(regInMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/v1/admin/dashboard/route.ts
+++ b/src/app/api/v1/admin/dashboard/route.ts
@@ -1,0 +1,244 @@
+import { supabaseAdmin } from "@/services/supabase/admin";
+import { createClient } from "@/services/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+type OrgStatusRow = { approval_status: string };
+type TournamentStatusRow = { status: string };
+type PayoutSummaryRow = { effective_platform_fee_cents: number };
+type PendingOrgRow = { id: string; name: string; email: string | null; created_at: string };
+type RecentTournamentRow = {
+  id: string;
+  name: string;
+  start_date: string;
+  status: string;
+  max_participants: number;
+  organization_id: string | null;
+};
+type RegistrationRow = { tournament_id: string };
+type OrgNameRow = { id: string; name: string };
+
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  const { data: isAdmin } = await supabase.rpc("has_global_permission", {
+    p_user_id: user.id,
+    p_permission: "platform.manage",
+  });
+
+  if (!isAdmin) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Admin access required" } },
+      { status: 403 },
+    );
+  }
+
+  const [
+    { count: userCount, error: userError },
+    { data: orgStatusRows, error: orgError },
+    { data: tournamentStatusRows, error: tourError },
+    { count: totalRegistrations, error: regError },
+    { data: payoutRows, error: payoutError },
+    { data: pendingOrgs, error: pendingOrgsError },
+    { data: recentTournamentRows, error: recentTourError },
+  ] = await Promise.all([
+    supabaseAdmin
+      .from("users")
+      .select("*", { count: "exact", head: true })
+      .is("deleted_at", null),
+    supabaseAdmin
+      .from("organizations")
+      .select("approval_status")
+      .is("deleted_at", null),
+    supabaseAdmin.from("tournaments").select("status"),
+    supabaseAdmin
+      .from("registrations")
+      .select("*", { count: "exact", head: true })
+      .eq("status", "confirmed"),
+    supabaseAdmin
+      .from("tournament_payout_summary")
+      .select("effective_platform_fee_cents"),
+    supabaseAdmin
+      .from("organizations")
+      .select("id, name, email, created_at")
+      .eq("approval_status", "pending")
+      .is("deleted_at", null)
+      .order("created_at", { ascending: true })
+      .limit(5),
+    supabaseAdmin
+      .from("tournaments")
+      .select("id, name, start_date, status, max_participants, organization_id")
+      .order("created_at", { ascending: false })
+      .limit(5),
+  ]);
+
+  if (userError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: userError.message } },
+      { status: 500 },
+    );
+  }
+  if (orgError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: orgError.message } },
+      { status: 500 },
+    );
+  }
+  if (tourError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: tourError.message } },
+      { status: 500 },
+    );
+  }
+  if (regError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: regError.message } },
+      { status: 500 },
+    );
+  }
+  if (payoutError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: payoutError.message } },
+      { status: 500 },
+    );
+  }
+  if (pendingOrgsError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: pendingOrgsError.message } },
+      { status: 500 },
+    );
+  }
+  if (recentTourError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: recentTourError.message } },
+      { status: 500 },
+    );
+  }
+
+  const allOrgStatuses = (orgStatusRows ?? []) as OrgStatusRow[];
+  const pendingOrgCount = allOrgStatuses.filter(
+    (o) => o.approval_status === "pending",
+  ).length;
+  const approvedOrgCount = allOrgStatuses.filter(
+    (o) => o.approval_status === "approved",
+  ).length;
+  const rejectedOrgCount = allOrgStatuses.filter(
+    (o) => o.approval_status === "rejected",
+  ).length;
+
+  const allTournamentStatuses = (tournamentStatusRows ?? []) as TournamentStatusRow[];
+  const publishedCount = allTournamentStatuses.filter(
+    (t) => t.status === "published",
+  ).length;
+  const draftCount = allTournamentStatuses.filter(
+    (t) => t.status === "draft",
+  ).length;
+  const cancelledCount = allTournamentStatuses.filter(
+    (t) => t.status === "cancelled",
+  ).length;
+
+  const platformRevenueCents = (payoutRows ?? []).reduce(
+    (sum: number, row: PayoutSummaryRow) =>
+      sum + (row.effective_platform_fee_cents ?? 0),
+    0,
+  );
+
+  const recentTours = (recentTournamentRows ?? []) as RecentTournamentRow[];
+  const recentIds = recentTours.map((t) => t.id);
+  const orgIds = [
+    ...new Set(recentTours.map((t) => t.organization_id).filter(Boolean)),
+  ] as string[];
+
+  const participantCounts: Record<string, number> = {};
+  const orgNameMap: Record<string, string> = {};
+
+  if (recentIds.length > 0) {
+    const [{ data: recentRegs, error: recentRegsError }, { data: orgs, error: orgsError }] =
+      await Promise.all([
+        supabaseAdmin
+          .from("registrations")
+          .select("tournament_id")
+          .in("tournament_id", recentIds)
+          .eq("status", "confirmed"),
+        orgIds.length > 0
+          ? supabaseAdmin
+              .from("organizations")
+              .select("id, name")
+              .in("id", orgIds)
+          : Promise.resolve({ data: [], error: null }),
+      ]);
+
+    if (recentRegsError) {
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: recentRegsError.message } },
+        { status: 500 },
+      );
+    }
+    if (orgsError) {
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: orgsError.message } },
+        { status: 500 },
+      );
+    }
+
+    for (const reg of (recentRegs ?? []) as RegistrationRow[]) {
+      participantCounts[reg.tournament_id] =
+        (participantCounts[reg.tournament_id] ?? 0) + 1;
+    }
+
+    for (const org of (orgs ?? []) as OrgNameRow[]) {
+      orgNameMap[org.id] = org.name;
+    }
+  }
+
+  return NextResponse.json(
+    {
+      data: {
+        stats: {
+          total_users: userCount ?? 0,
+          organizations: {
+            total: allOrgStatuses.length,
+            pending: pendingOrgCount,
+            approved: approvedOrgCount,
+            rejected: rejectedOrgCount,
+          },
+          tournaments: {
+            total: allTournamentStatuses.length,
+            published: publishedCount,
+            draft: draftCount,
+            cancelled: cancelledCount,
+          },
+          total_registrations: totalRegistrations ?? 0,
+          platform_revenue_cents: platformRevenueCents,
+        },
+        pending_organizations: (pendingOrgs ?? []).map((o: PendingOrgRow) => ({
+          id: o.id,
+          name: o.name,
+          email: o.email,
+          created_at: o.created_at,
+        })),
+        recent_tournaments: recentTours.map((t) => ({
+          id: t.id,
+          name: t.name,
+          organization_name: t.organization_id
+            ? (orgNameMap[t.organization_id] ?? null)
+            : null,
+          start_date: t.start_date,
+          status: t.status,
+          current_participants: participantCounts[t.id] ?? 0,
+          max_participants: t.max_participants,
+        })),
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/api/v1/admin/dashboard/route.ts
+++ b/src/app/api/v1/admin/dashboard/route.ts
@@ -30,10 +30,17 @@ export async function GET(_request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const { data: isAdmin } = await supabase.rpc("has_global_permission", {
-    p_user_id: user.id,
-    p_permission: "platform.manage",
-  });
+  const { data: isAdmin, error: permissionError } = await supabase.rpc(
+    "has_global_permission",
+    { p_user_id: user.id, p_permission: "platform.manage" },
+  );
+
+  if (permissionError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: permissionError.message } },
+      { status: 500 },
+    );
+  }
 
   if (!isAdmin) {
     return NextResponse.json(


### PR DESCRIPTION
Closes #99

Implements the platform admin dashboard endpoint at `GET /api/v1/admin/dashboard`.

## Changes
- New route: `src/app/api/v1/admin/dashboard/route.ts`
- Tests: `src/app/api/v1/admin/dashboard/__tests__/route.test.ts` (33 tests)

Requires `platform.manage` global permission. Returns platform-wide stats, pending org applications, and recent tournaments.

Generated with [Claude Code](https://claude.ai/code)