### PR TITLE
feat: add GET /admin/applications/:id detail view and review page

### DIFF
--- a/src/app/admin/applications/[id]/__tests__/page.test.ts
+++ b/src/app/admin/applications/[id]/__tests__/page.test.ts
@@ -57,7 +57,7 @@ function makeApplicationDetail() {
     id: APP_ID,
     name: "Penang Chess Club",
     description: "Community club",
-    links: { website: "https://penangchess.org" },
+    links: [{ label: "Website", url: "https://penangchess.org" }],
     email: "penang@chess.my",
     phone: "+60123456789",
     past_tournament_refs: "Penang Open 2025",

--- a/src/app/admin/applications/[id]/__tests__/page.test.ts
+++ b/src/app/admin/applications/[id]/__tests__/page.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockRedirect = vi.hoisted(() =>
+  vi.fn().mockImplementation((url: string) => {
+    const err = new Error(`NEXT_REDIRECT:${url}`);
+    (err as Error & { digest?: string }).digest = `NEXT_REDIRECT;replace;${url};303;`;
+    throw err;
+  }),
+);
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}));
+
+vi.mock(
+  "@/app/admin/applications/[id]/_components/ApplicationDetailClient",
+  () => ({
+    default: vi.fn().mockReturnValue(null),
+  }),
+);
+
+vi.mock("@/components/NavBar", () => ({
+  default: vi.fn().mockReturnValue(null),
+}));
+
+const mockGetUser = vi.hoisted(() => vi.fn());
+const mockRpc = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+    rpc: mockRpc,
+  }),
+}));
+
+const mockSingle = vi.hoisted(() => vi.fn());
+const mockIs = vi.hoisted(() => vi.fn().mockReturnValue({ single: mockSingle }));
+const mockEq = vi.hoisted(() => vi.fn().mockReturnValue({ is: mockIs }));
+const mockSelect = vi.hoisted(() => vi.fn().mockReturnValue({ eq: mockEq }));
+const mockFrom = vi.hoisted(() =>
+  vi.fn().mockReturnValue({ select: mockSelect }),
+);
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const APP_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+const NOT_UUID = "not-a-uuid";
+
+function makeApplicationDetail() {
+  return {
+    id: APP_ID,
+    name: "Penang Chess Club",
+    description: "Community club",
+    links: { website: "https://penangchess.org" },
+    email: "penang@chess.my",
+    phone: "+60123456789",
+    past_tournament_refs: "Penang Open 2025",
+    approval_status: "pending",
+    rejection_reason: null,
+    created_at: "2026-02-22T10:00:00Z",
+    reviewed_at: null,
+    applicant: {
+      id: "cccccccc-0000-0000-0000-000000000001",
+      first_name: "Lee",
+      last_name: "Wei Hao",
+      email: "weihao@gmail.com",
+      created_at: "2026-01-15T00:00:00Z",
+      player_profiles: null,
+    },
+  };
+}
+
+async function importPage() {
+  const { default: AdminApplicationDetailPage } = await import("../page");
+  return AdminApplicationDetailPage;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("AdminApplicationDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    mockIs.mockReturnValue({ single: mockSingle });
+    mockEq.mockReturnValue({ is: mockIs });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    mockRedirect.mockImplementation((url: string) => {
+      const err = new Error(`NEXT_REDIRECT:${url}`);
+      (err as Error & { digest?: string }).digest = `NEXT_REDIRECT;replace;${url};303;`;
+      throw err;
+    });
+  });
+
+  it("redirects to /admin/applications when ID is not a valid UUID", async () => {
+    const AdminApplicationDetailPage = await importPage();
+    await expect(
+      AdminApplicationDetailPage({ params: Promise.resolve({ id: NOT_UUID }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/admin/applications");
+  });
+
+  it("redirects to /auth/login when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const AdminApplicationDetailPage = await importPage();
+    await expect(
+      AdminApplicationDetailPage({ params: Promise.resolve({ id: APP_ID }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/auth/login");
+  });
+
+  it("redirects to / when user lacks admin permission", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mockRpc.mockResolvedValue({ data: false, error: null });
+
+    const AdminApplicationDetailPage = await importPage();
+    await expect(
+      AdminApplicationDetailPage({ params: Promise.resolve({ id: APP_ID }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/");
+  });
+
+  it("redirects to /admin/applications when DB query fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockRpc.mockResolvedValue({ data: true, error: null });
+    mockSingle.mockResolvedValue({ data: null, error: { message: "DB error" } });
+
+    const AdminApplicationDetailPage = await importPage();
+    await expect(
+      AdminApplicationDetailPage({ params: Promise.resolve({ id: APP_ID }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/admin/applications");
+  });
+
+  it("redirects to /admin/applications when application is not found", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockRpc.mockResolvedValue({ data: true, error: null });
+    mockSingle.mockResolvedValue({ data: null, error: null });
+
+    const AdminApplicationDetailPage = await importPage();
+    await expect(
+      AdminApplicationDetailPage({ params: Promise.resolve({ id: APP_ID }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/admin/applications");
+  });
+
+  it("renders the page when admin is authenticated and data is found", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockRpc.mockResolvedValue({ data: true, error: null });
+    mockSingle.mockResolvedValue({ data: makeApplicationDetail(), error: null });
+
+    const AdminApplicationDetailPage = await importPage();
+    const result = await AdminApplicationDetailPage({
+      params: Promise.resolve({ id: APP_ID }),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("checks admin permission with correct parameters", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockRpc.mockResolvedValue({ data: true, error: null });
+    mockSingle.mockResolvedValue({ data: makeApplicationDetail(), error: null });
+
+    const AdminApplicationDetailPage = await importPage();
+    await AdminApplicationDetailPage({ params: Promise.resolve({ id: APP_ID }) });
+
+    expect(mockRpc).toHaveBeenCalledWith("has_global_permission", {
+      p_user_id: "admin-1",
+      p_permission: "platform.manage",
+    });
+  });
+
+  it("queries organization with correct ID and excludes deleted records", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    mockRpc.mockResolvedValue({ data: true, error: null });
+    mockSingle.mockResolvedValue({ data: makeApplicationDetail(), error: null });
+
+    const AdminApplicationDetailPage = await importPage();
+    await AdminApplicationDetailPage({ params: Promise.resolve({ id: APP_ID }) });
+
+    expect(mockFrom).toHaveBeenCalledWith("organizations");
+    expect(mockEq).toHaveBeenCalledWith("id", APP_ID);
+    expect(mockIs).toHaveBeenCalledWith("deleted_at", null);
+  });
+});

--- a/src/app/admin/applications/[id]/_components/ApplicationDetailClient.tsx
+++ b/src/app/admin/applications/[id]/_components/ApplicationDetailClient.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import type {
   ApplicationDetail,
   ApprovalStatus,
+  OrgLink,
   OrgLinks,
   PlayerProfile,
 } from "../page";
@@ -55,21 +56,13 @@ function DetailRow({
 }
 
 function LinksDisplay({ links }: { links: OrgLinks | null }) {
-  if (!links) return <span className="text-text-muted">—</span>;
-
-  const entries: { icon: string; label: string; url: string }[] = [];
-  if (links.website) entries.push({ icon: "🌐", label: "Website", url: links.website });
-  if (links.facebook) entries.push({ icon: "📘", label: "Facebook", url: links.facebook });
-  if (links.instagram) entries.push({ icon: "📸", label: "Instagram", url: links.instagram });
-  if (links.twitter) entries.push({ icon: "𝕏", label: "Twitter/X", url: links.twitter });
-
-  if (entries.length === 0) return <span className="text-text-muted">—</span>;
+  if (!links || links.length === 0) return <span className="text-text-muted">—</span>;
 
   return (
     <div className="flex flex-col gap-1">
-      {entries.map((entry) => (
+      {links.map((entry: OrgLink) => (
         <span key={entry.label}>
-          {entry.icon}{" "}
+          <span className="text-text-muted">{entry.label}:</span>{" "}
           <a
             href={entry.url}
             target="_blank"

--- a/src/app/admin/applications/[id]/_components/ApplicationDetailClient.tsx
+++ b/src/app/admin/applications/[id]/_components/ApplicationDetailClient.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import type {
+  ApplicationDetail,
+  ApprovalStatus,
+  OrgLinks,
+  PlayerProfile,
+} from "../page";
+
+const STATUS_CONFIG: Record<
+  ApprovalStatus,
+  { label: string; className: string }
+> = {
+  pending: {
+    label: "Pending",
+    className: "bg-warning/15 text-warning border border-warning/20",
+  },
+  approved: {
+    label: "Approved",
+    className: "bg-success/10 text-success border border-success/20",
+  },
+  rejected: {
+    label: "Rejected",
+    className: "bg-danger/15 text-danger border border-danger/20",
+  },
+};
+
+function StatusBadge({ status }: { status: ApprovalStatus }) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <span
+      className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${config.className}`}
+    >
+      {config.label}
+    </span>
+  );
+}
+
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-[140px_1fr] gap-x-4 gap-y-1 py-2 border-b border-border last:border-0">
+      <span className="font-lato text-xs text-text-muted pt-0.5">{label}</span>
+      <div className="font-lato text-sm text-text-primary">{children}</div>
+    </div>
+  );
+}
+
+function LinksDisplay({ links }: { links: OrgLinks | null }) {
+  if (!links) return <span className="text-text-muted">—</span>;
+
+  const entries: { icon: string; label: string; url: string }[] = [];
+  if (links.website) entries.push({ icon: "🌐", label: "Website", url: links.website });
+  if (links.facebook) entries.push({ icon: "📘", label: "Facebook", url: links.facebook });
+  if (links.instagram) entries.push({ icon: "📸", label: "Instagram", url: links.instagram });
+  if (links.twitter) entries.push({ icon: "𝕏", label: "Twitter/X", url: links.twitter });
+
+  if (entries.length === 0) return <span className="text-text-muted">—</span>;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {entries.map((entry) => (
+        <span key={entry.label}>
+          {entry.icon}{" "}
+          <a
+            href={entry.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gold-bright hover:underline break-all"
+          >
+            {entry.url}
+          </a>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function getPlayerProfile(
+  raw: PlayerProfile | PlayerProfile[] | null | undefined,
+): PlayerProfile | null {
+  if (!raw) return null;
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  return raw;
+}
+
+interface Props {
+  application: ApplicationDetail;
+}
+
+export default function ApplicationDetailClient({ application }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [showRejectForm, setShowRejectForm] = useState(false);
+  const [rejectionReason, setRejectionReason] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const appliedDate = new Date(application.created_at).toLocaleDateString(
+    "en-MY",
+    { day: "numeric", month: "long", year: "numeric" },
+  );
+
+  const appliedTime = new Date(application.created_at).toLocaleTimeString(
+    "en-MY",
+    { hour: "2-digit", minute: "2-digit" },
+  );
+
+  const applicant = application.applicant;
+  const profile = getPlayerProfile(applicant?.player_profiles);
+
+  async function handleApprove() {
+    setActionError(null);
+    startTransition(async () => {
+      const res = await fetch(`/api/v1/admin/applications/${application.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "approve" }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        setActionError(json.error?.message ?? "Failed to approve application.");
+        return;
+      }
+      router.push("/admin/applications");
+      router.refresh();
+    });
+  }
+
+  async function handleReject() {
+    if (!rejectionReason.trim()) {
+      setActionError("Please provide a rejection reason.");
+      return;
+    }
+    setActionError(null);
+    startTransition(async () => {
+      const res = await fetch(`/api/v1/admin/applications/${application.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "reject",
+          rejection_reason: rejectionReason.trim(),
+        }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        setActionError(json.error?.message ?? "Failed to reject application.");
+        return;
+      }
+      router.push("/admin/applications");
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-8">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        <Link
+          href="/admin/applications"
+          className="font-lato text-sm text-text-muted hover:text-text-primary transition-colors"
+        >
+          ← Back
+        </Link>
+        <h1 className="font-cinzel text-2xl font-bold text-text-primary tracking-wide">
+          {application.name}
+        </h1>
+        <StatusBadge status={application.approval_status} />
+      </div>
+
+      {/* Action bar */}
+      {application.approval_status === "pending" && (
+        <div className="card px-5 py-4 flex flex-wrap items-center gap-3 mb-4">
+          <span className="font-lato text-sm text-text-muted">
+            Applied on {appliedDate} at {appliedTime}
+            {applicant && (
+              <>
+                {" "}
+                by{" "}
+                <strong className="text-text-primary">
+                  {applicant.first_name} {applicant.last_name}
+                </strong>
+              </>
+            )}
+          </span>
+          <div className="flex gap-2 ml-auto">
+            <button
+              type="button"
+              onClick={() => {
+                setShowRejectForm((v) => !v);
+                setActionError(null);
+              }}
+              disabled={isPending}
+              className="font-lato text-sm font-semibold px-4 py-2 rounded-md bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20 transition-colors disabled:opacity-50"
+            >
+              Reject
+            </button>
+            <button
+              type="button"
+              onClick={handleApprove}
+              disabled={isPending}
+              className="font-lato text-sm font-semibold px-4 py-2 rounded-md bg-success/10 text-success border border-success/20 hover:bg-success/20 transition-colors disabled:opacity-50"
+            >
+              {isPending ? "Processing…" : "✓ Approve"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Rejection reason form */}
+      {showRejectForm && application.approval_status === "pending" && (
+        <div className="mb-4 p-4 rounded-lg bg-danger/10 border border-danger/20">
+          <p className="font-lato text-sm font-semibold text-danger mb-3">
+            Rejection Reason
+          </p>
+          <textarea
+            value={rejectionReason}
+            onChange={(e) => setRejectionReason(e.target.value)}
+            placeholder="Explain why this application is being rejected. This will be communicated to the applicant."
+            rows={3}
+            className="w-full font-lato text-sm px-3 py-2 bg-bg-raised border border-border rounded-lg text-text-primary placeholder:text-text-muted focus:outline-none focus:border-danger resize-vertical mb-3"
+          />
+          {actionError && (
+            <p className="font-lato text-xs text-danger mb-2">{actionError}</p>
+          )}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setShowRejectForm(false);
+                setActionError(null);
+              }}
+              disabled={isPending}
+              className="font-lato text-sm font-semibold px-4 py-2 rounded-md bg-bg-raised border border-border text-text-primary hover:border-gold-dim transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleReject}
+              disabled={isPending}
+              className="font-lato text-sm font-semibold px-4 py-2 rounded-md bg-danger text-white hover:bg-danger/80 transition-colors disabled:opacity-50"
+            >
+              {isPending ? "Processing…" : "Confirm Rejection"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Action error (outside form, e.g. approve error) */}
+      {actionError && !showRejectForm && (
+        <p className="font-lato text-xs text-danger mb-4">{actionError}</p>
+      )}
+
+      {/* Rejection reason display (already rejected) */}
+      {application.approval_status === "rejected" &&
+        application.rejection_reason && (
+          <div className="mb-4 p-4 rounded-lg bg-danger/10 border border-danger/20">
+            <p className="font-lato text-xs font-semibold text-danger mb-1 uppercase tracking-wide">
+              Rejection Reason
+            </p>
+            <p className="font-lato text-sm text-text-primary">
+              {application.rejection_reason}
+            </p>
+          </div>
+        )}
+
+      {/* Organization details */}
+      <section className="card mb-4 overflow-hidden">
+        <div className="px-5 py-3 border-b border-border bg-bg-raised">
+          <h2 className="font-cinzel text-sm font-bold text-text-primary tracking-wide uppercase">
+            Organization Details
+          </h2>
+        </div>
+        <div className="px-5 py-4">
+          <DetailRow label="Name">{application.name}</DetailRow>
+          <DetailRow label="Description">
+            {application.description ?? (
+              <span className="text-text-muted">—</span>
+            )}
+          </DetailRow>
+          <DetailRow label="Links">
+            <LinksDisplay links={application.links} />
+          </DetailRow>
+          <DetailRow label="Email">
+            {application.email ?? <span className="text-text-muted">—</span>}
+          </DetailRow>
+          <DetailRow label="Phone">
+            {application.phone ?? <span className="text-text-muted">—</span>}
+          </DetailRow>
+        </div>
+      </section>
+
+      {/* Past tournament references */}
+      <section className="card mb-4 overflow-hidden">
+        <div className="px-5 py-3 border-b border-border bg-bg-raised">
+          <h2 className="font-cinzel text-sm font-bold text-text-primary tracking-wide uppercase">
+            Past Tournament References
+          </h2>
+        </div>
+        <div className="px-5 py-4">
+          {application.past_tournament_refs ? (
+            <p className="font-lato text-sm text-text-primary whitespace-pre-wrap leading-relaxed">
+              {application.past_tournament_refs}
+            </p>
+          ) : (
+            <p className="font-lato text-sm text-text-muted">
+              No tournament references provided.
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* Applicant account info */}
+      <section className="card mb-4 overflow-hidden">
+        <div className="px-5 py-3 border-b border-border bg-bg-raised">
+          <h2 className="font-cinzel text-sm font-bold text-text-primary tracking-wide uppercase">
+            Applicant Account
+          </h2>
+        </div>
+        <div className="px-5 py-4">
+          {applicant ? (
+            <>
+              <DetailRow label="Name">
+                {applicant.first_name} {applicant.last_name}
+              </DetailRow>
+              <DetailRow label="Email">{applicant.email}</DetailRow>
+              <DetailRow label="Account Created">
+                {new Date(applicant.created_at).toLocaleDateString("en-MY", {
+                  day: "numeric",
+                  month: "long",
+                  year: "numeric",
+                })}
+              </DetailRow>
+              <DetailRow label="Player Profile">
+                {profile ? (
+                  <span>
+                    {profile.title && (
+                      <span className="font-semibold">{profile.title} · </span>
+                    )}
+                    {profile.fide_id ? (
+                      <>FIDE ID: {profile.fide_id}</>
+                    ) : (
+                      "No FIDE ID"
+                    )}
+                    {profile.fide_rating?.rapid != null && (
+                      <> · Rapid {profile.fide_rating.rapid}</>
+                    )}
+                    {profile.fide_rating?.standard != null && (
+                      <> · Standard {profile.fide_rating.standard}</>
+                    )}
+                    {!profile.fide_id &&
+                      !profile.title &&
+                      !profile.fide_rating?.rapid &&
+                      !profile.fide_rating?.standard && (
+                        <span className="text-text-muted">
+                          No rating information
+                        </span>
+                      )}
+                  </span>
+                ) : (
+                  <span className="text-text-muted">No player profile</span>
+                )}
+              </DetailRow>
+            </>
+          ) : (
+            <p className="font-lato text-sm text-text-muted">
+              Applicant information not available.
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/applications/[id]/page.tsx
+++ b/src/app/admin/applications/[id]/page.tsx
@@ -15,12 +15,12 @@ const UUID_RE =
 
 export type ApprovalStatus = "pending" | "approved" | "rejected";
 
-export interface OrgLinks {
-  website?: string;
-  facebook?: string;
-  instagram?: string;
-  twitter?: string;
+export interface OrgLink {
+  label: string;
+  url: string;
 }
+
+export type OrgLinks = OrgLink[];
 
 export interface PlayerProfile {
   fide_id: number | null;

--- a/src/app/admin/applications/[id]/page.tsx
+++ b/src/app/admin/applications/[id]/page.tsx
@@ -1,0 +1,108 @@
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import { createClient } from "@/services/supabase/server";
+import { supabaseAdmin } from "@/services/supabase/admin";
+import ApplicationDetailClient from "./_components/ApplicationDetailClient";
+
+export const metadata: Metadata = {
+  title: "Application Review",
+  description: "Review organizer application details.",
+};
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ApprovalStatus = "pending" | "approved" | "rejected";
+
+export interface OrgLinks {
+  website?: string;
+  facebook?: string;
+  instagram?: string;
+  twitter?: string;
+}
+
+export interface PlayerProfile {
+  fide_id: number | null;
+  fide_rating: { standard?: number; rapid?: number; blitz?: number } | null;
+  title: string | null;
+}
+
+export interface Applicant {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  created_at: string;
+  player_profiles: PlayerProfile | PlayerProfile[] | null;
+}
+
+export interface ApplicationDetail {
+  id: string;
+  name: string;
+  description: string | null;
+  links: OrgLinks | null;
+  email: string | null;
+  phone: string | null;
+  past_tournament_refs: string | null;
+  approval_status: ApprovalStatus;
+  rejection_reason: string | null;
+  created_at: string;
+  reviewed_at: string | null;
+  applicant: Applicant | null;
+}
+
+export default async function AdminApplicationDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    redirect("/admin/applications");
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/login");
+  }
+
+  const { data: isAdmin, error: permissionError } = await supabase.rpc(
+    "has_global_permission",
+    { p_user_id: user.id, p_permission: "platform.manage" },
+  );
+
+  if (permissionError || !isAdmin) {
+    redirect("/");
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("organizations")
+    .select(
+      `id, name, description, links, email, phone, past_tournament_refs,
+       approval_status, rejection_reason, created_at, reviewed_at,
+       applicant:users!created_by(
+         id, first_name, last_name, email, created_at,
+         player_profiles(fide_id, fide_rating, title)
+       )`,
+    )
+    .eq("id", id)
+    .is("deleted_at", null)
+    .single();
+
+  if (error || !data) {
+    redirect("/admin/applications");
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <ApplicationDetailClient application={data as unknown as ApplicationDetail} />
+    </div>
+  );
+}

--- a/src/app/admin/applications/_components/ApplicationsClient.tsx
+++ b/src/app/admin/applications/_components/ApplicationsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import Link from "next/link";
 import type { Application, ApplicationCounts, ApprovalStatus } from "../page";
 
 type TabKey = "all" | ApprovalStatus;
@@ -52,7 +53,10 @@ function ApplicationRow({ app }: { app: Application }) {
   });
 
   return (
-    <div className="card px-5 py-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+    <Link
+      href={`/admin/applications/${app.id}`}
+      className="card px-5 py-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4 hover:border-gold-dim transition-colors"
+    >
       <div className="flex-1 min-w-0">
         <h3 className="font-lato text-sm font-semibold text-text-primary">
           {app.name}
@@ -76,7 +80,7 @@ function ApplicationRow({ app }: { app: Application }) {
         <span className="font-lato text-xs text-text-muted">{appliedDate}</span>
         <StatusBadge status={app.approval_status} />
       </div>
-    </div>
+    </Link>
   );
 }
 

--- a/src/app/api/v1/admin/applications/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/admin/applications/[id]/__tests__/route.test.ts
@@ -317,6 +317,16 @@ describe("PATCH /api/v1/admin/applications/:id", () => {
       );
       expect(res.status).toBe(400);
     });
+
+    it("returns 400 when rejection_reason is a non-string type", async () => {
+      const res = await PATCH(
+        makePatchRequest(APP_ID, { action: "reject", rejection_reason: {} as unknown as string }),
+        { params: Promise.resolve({ id: APP_ID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
   });
 
   // ── Authentication ────────────────────────────────────────────────────────

--- a/src/app/api/v1/admin/applications/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/admin/applications/[id]/__tests__/route.test.ts
@@ -1,0 +1,410 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockDetailBuilder,
+  mockUpdateBuilder,
+  mockFrom,
+  mockGetUser,
+  mockRpc,
+} = vi.hoisted(() => {
+  function makeBuilder(finalResult: {
+    data?: unknown;
+    error?: unknown;
+  }) {
+    const b: Record<string, unknown> = {};
+    for (const m of [
+      "select",
+      "eq",
+      "is",
+      "update",
+      "single",
+      "maybeSingle",
+    ]) {
+      b[m] = vi.fn(() => b);
+    }
+    b.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return b;
+  }
+
+  const mockDetailBuilder = makeBuilder({ data: null, error: null });
+  const mockUpdateBuilder = makeBuilder({ data: null, error: null });
+
+  const mockFrom = vi.fn((_table: string) => mockDetailBuilder);
+  const mockGetUser = vi.fn();
+  const mockRpc = vi.fn();
+
+  return {
+    mockDetailBuilder,
+    mockUpdateBuilder,
+    mockFrom,
+    mockGetUser,
+    mockRpc,
+  };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+    rpc: mockRpc,
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+import { GET, PATCH } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ADMIN_USER_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const APP_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+const NOT_UUID = "not-a-uuid";
+
+const FULL_APPLICATION = {
+  id: APP_ID,
+  name: "Penang Chess Club",
+  description: "Community club in Georgetown",
+  links: { website: "https://penangchess.org", facebook: "fb.com/penang" },
+  email: "penang@chess.my",
+  phone: "+60123456789",
+  past_tournament_refs: "Penang Open 2025 — 80 participants",
+  approval_status: "pending",
+  rejection_reason: null,
+  created_at: "2026-02-22T10:00:00Z",
+  reviewed_at: null,
+  applicant: {
+    id: "cccccccc-0000-0000-0000-000000000001",
+    first_name: "Lee",
+    last_name: "Wei Hao",
+    email: "weihao@gmail.com",
+    created_at: "2026-01-15T00:00:00Z",
+    player_profiles: {
+      fide_id: 5834567,
+      fide_rating: { standard: 1923, rapid: 1900 },
+      title: "FM",
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeGetRequest(id = APP_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/v1/admin/applications/${id}`);
+}
+
+function makePatchRequest(
+  id = APP_ID,
+  body: object = { action: "approve" },
+): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/admin/applications/${id}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function setUser(id = ADMIN_USER_ID) {
+  mockGetUser.mockResolvedValue({ data: { user: { id } }, error: null });
+}
+
+function setNoUser() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+function setAdminPermission(isAdmin: boolean) {
+  mockRpc.mockResolvedValue({ data: isAdmin, error: null });
+}
+
+function setBuilderResult(
+  builder: Record<string, unknown>,
+  result: { data?: unknown; error?: unknown },
+) {
+  builder.then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve(result).then(onfulfilled, onrejected);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/admin/applications/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setUser();
+    setAdminPermission(true);
+    setBuilderResult(mockDetailBuilder, { data: FULL_APPLICATION, error: null });
+    mockFrom.mockReturnValue(mockDetailBuilder);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  describe("validation", () => {
+    it("returns 400 for non-UUID id", async () => {
+      const res = await GET(makeGetRequest(NOT_UUID), {
+        params: Promise.resolve({ id: NOT_UUID }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  // ── Authentication ────────────────────────────────────────────────────────
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await GET(makeGetRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  // ── Authorization ─────────────────────────────────────────────────────────
+
+  describe("authorization", () => {
+    it("returns 403 when user is not admin", async () => {
+      setAdminPermission(false);
+      const res = await GET(makeGetRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+    });
+
+    it("returns 500 when permission check fails", async () => {
+      mockRpc.mockResolvedValue({ data: null, error: { message: "RPC error" } });
+      const res = await GET(makeGetRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ── Response ──────────────────────────────────────────────────────────────
+
+  describe("response", () => {
+    it("returns 200 with full application data", async () => {
+      const res = await GET(makeGetRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toHaveProperty("data");
+      expect(json.data.id).toBe(APP_ID);
+      expect(json.data.name).toBe("Penang Chess Club");
+      expect(json.data.links).toEqual({
+        website: "https://penangchess.org",
+        facebook: "fb.com/penang",
+      });
+      expect(json.data.applicant).toBeDefined();
+      expect(json.data.applicant.first_name).toBe("Lee");
+    });
+
+    it("returns 404 when application does not exist", async () => {
+      setBuilderResult(mockDetailBuilder, {
+        data: null,
+        error: { code: "PGRST116", message: "No rows found" },
+      });
+      const res = await GET(makeGetRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 500 on database error", async () => {
+      setBuilderResult(mockDetailBuilder, {
+        data: null,
+        error: { code: "500", message: "DB error" },
+      });
+      const res = await GET(makeGetRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: PATCH
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/v1/admin/applications/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setUser();
+    setAdminPermission(true);
+    setBuilderResult(mockUpdateBuilder, {
+      data: { id: APP_ID, name: "Penang Chess Club", approval_status: "approved", reviewed_at: "2026-05-01T00:00:00Z" },
+      error: null,
+    });
+    mockFrom.mockReturnValue(mockUpdateBuilder);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  describe("validation", () => {
+    it("returns 400 for non-UUID id", async () => {
+      const res = await PATCH(makePatchRequest(NOT_UUID), {
+        params: Promise.resolve({ id: NOT_UUID }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid action", async () => {
+      const res = await PATCH(
+        makePatchRequest(APP_ID, { action: "suspend" }),
+        { params: Promise.resolve({ id: APP_ID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 when rejecting without a reason", async () => {
+      const res = await PATCH(
+        makePatchRequest(APP_ID, { action: "reject" }),
+        { params: Promise.resolve({ id: APP_ID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 when rejection_reason is blank", async () => {
+      const res = await PATCH(
+        makePatchRequest(APP_ID, { action: "reject", rejection_reason: "   " }),
+        { params: Promise.resolve({ id: APP_ID }) },
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Authentication ────────────────────────────────────────────────────────
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ── Authorization ─────────────────────────────────────────────────────────
+
+  describe("authorization", () => {
+    it("returns 403 when user is not admin", async () => {
+      setAdminPermission(false);
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ── Approve ───────────────────────────────────────────────────────────────
+
+  describe("approve", () => {
+    it("returns 200 with updated application on approve", async () => {
+      const res = await PATCH(makePatchRequest(APP_ID, { action: "approve" }), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.data.approval_status).toBe("approved");
+    });
+  });
+
+  // ── Reject ────────────────────────────────────────────────────────────────
+
+  describe("reject", () => {
+    it("returns 200 with updated application on reject", async () => {
+      setBuilderResult(mockUpdateBuilder, {
+        data: {
+          id: APP_ID,
+          name: "Penang Chess Club",
+          approval_status: "rejected",
+          reviewed_at: "2026-05-01T00:00:00Z",
+        },
+        error: null,
+      });
+      const res = await PATCH(
+        makePatchRequest(APP_ID, {
+          action: "reject",
+          rejection_reason: "Insufficient information",
+        }),
+        { params: Promise.resolve({ id: APP_ID }) },
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.data.approval_status).toBe("rejected");
+    });
+  });
+
+  // ── Error handling ────────────────────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("returns 404 when application does not exist", async () => {
+      setBuilderResult(mockUpdateBuilder, {
+        data: null,
+        error: { code: "PGRST116", message: "No rows found" },
+      });
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 500 on database error", async () => {
+      setBuilderResult(mockUpdateBuilder, {
+        data: null,
+        error: { code: "500", message: "DB error" },
+      });
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ id: APP_ID }),
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/v1/admin/applications/[id]/route.ts
+++ b/src/app/api/v1/admin/applications/[id]/route.ts
@@ -1,0 +1,194 @@
+import { supabaseAdmin } from "@/services/supabase/admin";
+import { createClient } from "@/services/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+async function checkAdminAccess(supabase: Awaited<ReturnType<typeof createClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { user: null, isAdmin: false, error: null };
+  }
+
+  const { data: isAdmin, error } = await supabase.rpc("has_global_permission", {
+    p_user_id: user.id,
+    p_permission: "platform.manage",
+  });
+
+  return { user, isAdmin: !!isAdmin, error };
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid application ID" } },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+  const { user, isAdmin, error: permissionError } = await checkAdminAccess(supabase);
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  if (permissionError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: permissionError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (!isAdmin) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Admin access required" } },
+      { status: 403 },
+    );
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("organizations")
+    .select(
+      `id, name, description, links, email, phone, past_tournament_refs,
+       approval_status, rejection_reason, created_at, reviewed_at,
+       applicant:users!created_by(
+         id, first_name, last_name, email, created_at,
+         player_profiles(fide_id, fide_rating, title)
+       )`,
+    )
+    .eq("id", id)
+    .is("deleted_at", null)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Application not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ data }, { status: 200 });
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid application ID" } },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+  const { user, isAdmin, error: permissionError } = await checkAdminAccess(supabase);
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  if (permissionError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: permissionError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (!isAdmin) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Admin access required" } },
+      { status: 403 },
+    );
+  }
+
+  let body: { action: string; rejection_reason?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body" } },
+      { status: 400 },
+    );
+  }
+
+  const { action, rejection_reason } = body;
+
+  if (action !== "approve" && action !== "reject") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "action must be 'approve' or 'reject'",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  if (action === "reject" && (!rejection_reason || !rejection_reason.trim())) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "rejection_reason is required when rejecting",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const updates: Record<string, unknown> = {
+    approval_status: action === "approve" ? "approved" : "rejected",
+    reviewed_by: user.id,
+    reviewed_at: new Date().toISOString(),
+    rejection_reason: action === "reject" ? rejection_reason!.trim() : null,
+  };
+
+  const { data, error } = await supabaseAdmin
+    .from("organizations")
+    .update(updates)
+    .eq("id", id)
+    .is("deleted_at", null)
+    .select("id, name, approval_status, reviewed_at")
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Application not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ data }, { status: 200 });
+}

--- a/src/app/api/v1/admin/applications/[id]/route.ts
+++ b/src/app/api/v1/admin/applications/[id]/route.ts
@@ -150,12 +150,12 @@ export async function PATCH(
     );
   }
 
-  if (action === "reject" && (!rejection_reason || !rejection_reason.trim())) {
+  if (action === "reject" && (typeof rejection_reason !== "string" || !rejection_reason.trim())) {
     return NextResponse.json(
       {
         error: {
           code: "VALIDATION_ERROR",
-          message: "rejection_reason is required when rejecting",
+          message: "rejection_reason must be a non-empty string when rejecting",
         },
       },
       { status: 400 },


### PR DESCRIPTION
Implements issues #103 and #104 together.

## Changes

- `GET /api/v1/admin/applications/[id]` — full application detail joined with applicant user + player profile
- `PATCH /api/v1/admin/applications/[id]` — approve / reject action
- `/admin/applications/[id]` review page with org details, links, past refs, applicant account info, and action bar
- Applications list rows are now clickable links to the detail page

Closes #103, closes #104

Generated with [Claude Code](https://claude.ai/code)