### PR TITLE
feat: POST /organizer/:orgId/members/invite + invite UI (#72, #73)

### DIFF
--- a/src/app/api/v1/organizer/[orgId]/members/__tests__/route.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/__tests__/route.test.ts
@@ -310,7 +310,7 @@ describe("GET /api/v1/organizer/:orgId/members", () => {
   // -------------------------------------------------------------------------
 
   describe("response shape", () => {
-    it("returns 200 with data array", async () => {
+    it("returns 200 with data array and isOrgCreator flag", async () => {
       const res = await GET(makeRequest(), {
         params: Promise.resolve({ orgId: ORG_ID }),
       });
@@ -318,6 +318,7 @@ describe("GET /api/v1/organizer/:orgId/members", () => {
       const json = await res.json();
       expect(json).toHaveProperty("data");
       expect(Array.isArray(json.data)).toBe(true);
+      expect(json).toHaveProperty("isOrgCreator");
     });
 
     it("shapes each member entry correctly", async () => {

--- a/src/app/api/v1/organizer/[orgId]/members/invite/__tests__/route.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/invite/__tests__/route.test.ts
@@ -1,0 +1,544 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockOrgBuilder,
+  mockCallerMembershipBuilder,
+  mockRoleBuilder,
+  mockTargetUserBuilder,
+  mockTargetMembershipBuilder,
+  mockInsertBuilder,
+  mockFrom,
+  mockGetUser,
+  mockHasOrgPermission,
+  mockInviteUserByEmail,
+} = vi.hoisted(() => {
+  function makeBuilder(finalResult: {
+    data?: unknown;
+    count?: unknown;
+    error?: unknown;
+  }) {
+    const b: Record<string, unknown> = {};
+    for (const m of [
+      "select",
+      "eq",
+      "in",
+      "is",
+      "order",
+      "limit",
+      "single",
+      "maybeSingle",
+      "insert",
+    ]) {
+      b[m] = vi.fn(() => b);
+    }
+    b.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return b;
+  }
+
+  const mockInsertBuilder = makeBuilder({ data: null, error: null });
+  const mockOrgBuilder = makeBuilder({ data: null, error: null });
+  const mockCallerMembershipBuilder = makeBuilder({ count: 0, error: null });
+  const mockRoleBuilder = makeBuilder({ data: null, error: null });
+  const mockTargetUserBuilder = makeBuilder({ data: null, error: null });
+  const mockTargetMembershipBuilder = makeBuilder({ count: 0, error: null });
+
+  // Route insert() on all membership builders to mockInsertBuilder so that
+  // tests for insert failures work regardless of call index (new vs existing user).
+  (mockCallerMembershipBuilder as Record<string, unknown>).insert = vi.fn(
+    () => mockInsertBuilder,
+  );
+  (mockTargetMembershipBuilder as Record<string, unknown>).insert = vi.fn(
+    () => mockInsertBuilder,
+  );
+  // mockInsertBuilder.insert() already returns itself (b[m] = vi.fn(() => b))
+
+  let callIndex = 0;
+  const mockFrom = vi.fn((table: string) => {
+    if (table === "organizations") return mockOrgBuilder;
+    if (table === "roles") return mockRoleBuilder;
+    if (table === "organization_memberships") {
+      const idx = callIndex++;
+      if (idx === 0) return mockCallerMembershipBuilder;
+      if (idx === 1) return mockTargetMembershipBuilder;
+      return mockInsertBuilder;
+    }
+    if (table === "users") return mockTargetUserBuilder;
+    return mockOrgBuilder;
+  });
+
+  (mockFrom as unknown as { _resetIndex: () => void })._resetIndex = () => {
+    callIndex = 0;
+  };
+
+  const mockGetUser = vi.fn();
+  const mockHasOrgPermission = vi.fn().mockResolvedValue(true);
+  const mockInviteUserByEmail = vi.fn();
+
+  return {
+    mockOrgBuilder,
+    mockCallerMembershipBuilder,
+    mockRoleBuilder,
+    mockTargetUserBuilder,
+    mockTargetMembershipBuilder,
+    mockInsertBuilder,
+    mockFrom,
+    mockGetUser,
+    mockHasOrgPermission,
+    mockInviteUserByEmail,
+  };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: {
+    from: mockFrom,
+    auth: {
+      admin: {
+        inviteUserByEmail: mockInviteUserByEmail,
+      },
+    },
+  },
+}));
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("@/services/supabase/permission", () => ({
+  hasOrgPermission: mockHasOrgPermission,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+import { POST } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const USER_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const ORG_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+const TARGET_USER_ID = "cccccccc-0000-0000-0000-000000000001";
+const NEW_USER_ID = "dddddddd-0000-0000-0000-000000000001";
+const ROLE_ID = 2;
+
+const APPROVED_ORG = {
+  id: ORG_ID,
+  approval_status: "approved",
+  created_by: USER_ID,
+};
+
+function makeRequest(
+  orgId: string = ORG_ID,
+  body: unknown = { email: "new@example.com", role: "member" },
+): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/organizer/${orgId}/members/invite`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setUser(id = USER_ID) {
+  mockGetUser.mockResolvedValue({ data: { user: { id } }, error: null });
+}
+
+function setNoUser() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+function setOrgResult(data: unknown, error: unknown = null) {
+  (mockOrgBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setCallerMembershipResult(count: number | null, error: unknown = null) {
+  (mockCallerMembershipBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ count, error }).then(onfulfilled, onrejected);
+}
+
+function setRoleResult(data: unknown, error: unknown = null) {
+  (mockRoleBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setTargetUserResult(data: unknown, error: unknown = null) {
+  (mockTargetUserBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setTargetMembershipResult(count: number | null, error: unknown = null) {
+  (mockTargetMembershipBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ count, error }).then(onfulfilled, onrejected);
+}
+
+function setInsertResult(data: unknown, error: unknown = null) {
+  (mockInsertBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function resetCallIndex() {
+  (mockFrom as unknown as { _resetIndex: () => void })._resetIndex();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/organizer/:orgId/members/invite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCallIndex();
+    setUser();
+    setOrgResult(APPROVED_ORG);
+    setCallerMembershipResult(1);
+    setRoleResult({ id: ROLE_ID });
+    setTargetUserResult(null); // no existing user by default
+    setTargetMembershipResult(0);
+    setInsertResult(null);
+    mockHasOrgPermission.mockResolvedValue(true);
+    mockInviteUserByEmail.mockResolvedValue({
+      data: { user: { id: NEW_USER_ID } },
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  describe("validation", () => {
+    it("returns 400 for a non-UUID orgId", async () => {
+      const res = await POST(makeRequest("not-a-uuid"), {
+        params: Promise.resolve({ orgId: "not-a-uuid" }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/invalid organization id/i);
+    });
+
+    it("returns 400 when body is not JSON", async () => {
+      const req = new NextRequest(
+        `http://localhost/api/v1/organizer/${ORG_ID}/members/invite`,
+        { method: "POST", body: "not-json" },
+      );
+      const res = await POST(req, {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 when email is missing", async () => {
+      const res = await POST(makeRequest(ORG_ID, { role: "member" }), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/email/i);
+    });
+
+    it("returns 400 when email is invalid", async () => {
+      const res = await POST(
+        makeRequest(ORG_ID, { email: "not-an-email", role: "member" }),
+        { params: Promise.resolve({ orgId: ORG_ID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/invalid email/i);
+    });
+
+    it("returns 400 when role is missing", async () => {
+      const res = await POST(
+        makeRequest(ORG_ID, { email: "test@example.com" }),
+        { params: Promise.resolve({ orgId: ORG_ID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/role/i);
+    });
+
+    it("returns 400 when role is 'owner'", async () => {
+      const res = await POST(
+        makeRequest(ORG_ID, { email: "test@example.com", role: "owner" }),
+        { params: Promise.resolve({ orgId: ORG_ID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------------
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorization
+  // -------------------------------------------------------------------------
+
+  describe("authorization", () => {
+    it("returns 404 when organization does not exist", async () => {
+      setOrgResult(null, { code: "PGRST116", message: "No rows found" });
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 500 on org query error", async () => {
+      setOrgResult(null, { code: "500", message: "DB error" });
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 on membership check error", async () => {
+      setCallerMembershipResult(null, { message: "DB error" });
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 403 when organization is not approved", async () => {
+      setOrgResult({ ...APPROVED_ORG, approval_status: "pending" });
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+    });
+
+    it("returns 403 when user is not a member and not creator", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: "other-user-id" });
+      setCallerMembershipResult(0);
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/access denied/i);
+    });
+
+    it("returns 403 when member lacks org.invite permission", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: "other-user-id" });
+      setCallerMembershipResult(1);
+      mockHasOrgPermission.mockResolvedValue(false);
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/insufficient permissions/i);
+    });
+
+    it("allows creator without checking hasOrgPermission", async () => {
+      setCallerMembershipResult(0);
+      setInsertResult(null);
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(mockHasOrgPermission).not.toHaveBeenCalled();
+      expect(res.status).toBe(201);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Invite new user (no account)
+  // -------------------------------------------------------------------------
+
+  describe("invite new user", () => {
+    it("returns 201 with status pending for a new user", async () => {
+      const res = await POST(
+        makeRequest(ORG_ID, { email: "new@example.com", role: "member" }),
+        { params: Promise.resolve({ orgId: ORG_ID }) },
+      );
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json.data.status).toBe("pending");
+      expect(json.data.email).toBe("new@example.com");
+      expect(json.data.role).toBe("member");
+      expect(json.data.id).toBe(NEW_USER_ID);
+      expect(json.data).toHaveProperty("invited_at");
+    });
+
+    it("calls inviteUserByEmail with the target email", async () => {
+      await POST(
+        makeRequest(ORG_ID, { email: "NEW@Example.com", role: "admin" }),
+        { params: Promise.resolve({ orgId: ORG_ID }) },
+      );
+      expect(mockInviteUserByEmail).toHaveBeenCalledWith("new@example.com");
+    });
+
+    it("returns 500 when inviteUserByEmail fails", async () => {
+      mockInviteUserByEmail.mockResolvedValue({
+        data: { user: null },
+        error: { message: "Invite failed" },
+      });
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when membership insert fails for new user", async () => {
+      setInsertResult(null, { message: "Insert error" });
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Invite existing user
+  // -------------------------------------------------------------------------
+
+  describe("invite existing user", () => {
+    beforeEach(() => {
+      setTargetUserResult({ id: TARGET_USER_ID });
+    });
+
+    it("returns 201 with status active for existing user", async () => {
+      const res = await POST(
+        makeRequest(ORG_ID, { email: "existing@example.com", role: "admin" }),
+        { params: Promise.resolve({ orgId: ORG_ID }) },
+      );
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json.data.status).toBe("active");
+      expect(json.data.id).toBe(TARGET_USER_ID);
+      expect(json.data.role).toBe("admin");
+    });
+
+    it("does not call inviteUserByEmail for existing user", async () => {
+      await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(mockInviteUserByEmail).not.toHaveBeenCalled();
+    });
+
+    it("returns 409 when user is already a member", async () => {
+      setTargetMembershipResult(1);
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(409);
+      const json = await res.json();
+      expect(json.error.code).toBe("CONFLICT");
+      expect(json.error.message).toMatch(/already a member/i);
+    });
+
+    it("returns 500 on target membership check error", async () => {
+      setTargetMembershipResult(null, { message: "DB error" });
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when membership insert fails for existing user", async () => {
+      setInsertResult(null, { message: "Insert error" });
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Response shape
+  // -------------------------------------------------------------------------
+
+  describe("response shape", () => {
+    it("normalises email to lowercase", async () => {
+      const res = await POST(
+        makeRequest(ORG_ID, { email: "UPPER@EXAMPLE.COM", role: "member" }),
+        { params: Promise.resolve({ orgId: ORG_ID }) },
+      );
+      const json = await res.json();
+      expect(json.data.email).toBe("upper@example.com");
+    });
+
+    it("response contains all required fields", async () => {
+      const res = await POST(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const json = await res.json();
+      expect(json.data).toHaveProperty("id");
+      expect(json.data).toHaveProperty("email");
+      expect(json.data).toHaveProperty("role");
+      expect(json.data).toHaveProperty("status");
+      expect(json.data).toHaveProperty("invited_at");
+    });
+  });
+});

--- a/src/app/api/v1/organizer/[orgId]/members/invite/route.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/invite/route.ts
@@ -1,0 +1,245 @@
+import { supabaseAdmin } from "@/services/supabase/admin";
+import { createClient } from "@/services/supabase/server";
+import { hasOrgPermission } from "@/services/supabase/permission";
+import { NextRequest, NextResponse } from "next/server";
+import { validateInviteRequest } from "./validators";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+): Promise<NextResponse> {
+  const { orgId } = await params;
+
+  if (!UUID_RE.test(orgId)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid organization ID",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body" } },
+      { status: 400 },
+    );
+  }
+
+  const validation = validateInviteRequest(body);
+  if ("error" in validation) {
+    return validation.error;
+  }
+  const { email, role } = validation.data;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  const [
+    { data: org, error: orgError },
+    { count: memberCount, error: memberError },
+  ] = await Promise.all([
+    supabaseAdmin
+      .from("organizations")
+      .select("id, approval_status, created_by")
+      .eq("id", orgId)
+      .is("deleted_at", null)
+      .single(),
+    supabaseAdmin
+      .from("organization_memberships")
+      .select("*", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("user_id", user.id),
+  ]);
+
+  if (orgError) {
+    if (orgError.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Organization not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: orgError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (memberError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: memberError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (org.approval_status !== "approved") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "Organization is not approved",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const isCreator = org.created_by === user.id;
+  if (!isCreator && !memberCount) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied" } },
+      { status: 403 },
+    );
+  }
+
+  if (!isCreator) {
+    const allowed = await hasOrgPermission(user.id, orgId, "org.invite");
+    if (!allowed) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Insufficient permissions" } },
+        { status: 403 },
+      );
+    }
+  }
+
+  const { data: roleData, error: roleError } = await supabaseAdmin
+    .from("roles")
+    .select("id")
+    .eq("name", role)
+    .single();
+
+  if (roleError || !roleData) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Role not found" } },
+      { status: 500 },
+    );
+  }
+
+  const { data: existingUser } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("email", email)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  const invitedAt = new Date().toISOString();
+
+  if (existingUser) {
+    const { count: existingCount, error: existingCountError } =
+      await supabaseAdmin
+        .from("organization_memberships")
+        .select("*", { count: "exact", head: true })
+        .eq("organization_id", orgId)
+        .eq("user_id", existingUser.id);
+
+    if (existingCountError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "INTERNAL_ERROR",
+            message: existingCountError.message,
+          },
+        },
+        { status: 500 },
+      );
+    }
+
+    if (existingCount && existingCount > 0) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "CONFLICT",
+            message: "User is already a member of this organization",
+          },
+        },
+        { status: 409 },
+      );
+    }
+
+    const { error: insertError } = await supabaseAdmin
+      .from("organization_memberships")
+      .insert({
+        organization_id: orgId,
+        user_id: existingUser.id,
+        role_id: roleData.id,
+      });
+
+    if (insertError) {
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: insertError.message } },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        data: {
+          id: existingUser.id,
+          email,
+          role,
+          status: "active",
+          invited_at: invitedAt,
+        },
+      },
+      { status: 201 },
+    );
+  }
+
+  const { data: inviteData, error: inviteError } =
+    await supabaseAdmin.auth.admin.inviteUserByEmail(email);
+
+  if (inviteError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: inviteError.message } },
+      { status: 500 },
+    );
+  }
+
+  const newUserId = inviteData.user.id;
+
+  const { error: insertError } = await supabaseAdmin
+    .from("organization_memberships")
+    .insert({
+      organization_id: orgId,
+      user_id: newUserId,
+      role_id: roleData.id,
+    });
+
+  if (insertError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: insertError.message } },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      data: {
+        id: newUserId,
+        email,
+        role,
+        status: "pending",
+        invited_at: invitedAt,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/src/app/api/v1/organizer/[orgId]/members/invite/validators.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/invite/validators.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { validateEmail } from "@/services/auth/auth-validation";
 
 const VALID_ROLES = ["admin", "member"] as const;
-export type InviteRole = (typeof VALID_ROLES)[number];
+type InviteRole = (typeof VALID_ROLES)[number];
 
 export interface InviteRequest {
   email: string;

--- a/src/app/api/v1/organizer/[orgId]/members/invite/validators.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/invite/validators.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { validateEmail } from "@/services/auth/auth-validation";
+
+const VALID_ROLES = ["admin", "member"] as const;
+export type InviteRole = (typeof VALID_ROLES)[number];
+
+export interface InviteRequest {
+  email: string;
+  role: InviteRole;
+}
+
+export function validateInviteRequest(
+  body: unknown,
+): { data: InviteRequest } | { error: NextResponse } {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return {
+      error: NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Invalid request body" } },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const b = body as Record<string, unknown>;
+
+  if (!b.email || typeof b.email !== "string" || b.email.trim() === "") {
+    return {
+      error: NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Email is required" } },
+        { status: 400 },
+      ),
+    };
+  }
+
+  if (!validateEmail(b.email)) {
+    return {
+      error: NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Invalid email address" } },
+        { status: 400 },
+      ),
+    };
+  }
+
+  if (!b.role || !VALID_ROLES.includes(b.role as InviteRole)) {
+    return {
+      error: NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Role must be 'admin' or 'member'",
+          },
+        },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return {
+    data: {
+      email: (b.email as string).trim().toLowerCase(),
+      role: b.role as InviteRole,
+    },
+  };
+}

--- a/src/app/api/v1/organizer/[orgId]/members/route.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/route.ts
@@ -98,8 +98,8 @@ export async function GET(
     );
   }
 
-  const isCreator = org.created_by === user.id;
-  if (!isCreator && !memberCount) {
+  const isOrgCreator = org.created_by === user.id;
+  if (!isOrgCreator && !memberCount) {
     return NextResponse.json(
       { error: { code: "FORBIDDEN", message: "Access denied" } },
       { status: 403 },
@@ -132,7 +132,7 @@ export async function GET(
         role: m.roles.name,
         joined_at: m.joined_at,
       })),
-      isOrgCreator,
+      isOrgCreator: isOrgCreator,
     },
     { status: 200 },
   );

--- a/src/app/api/v1/organizer/[orgId]/members/route.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/route.ts
@@ -132,6 +132,7 @@ export async function GET(
         role: m.roles.name,
         joined_at: m.joined_at,
       })),
+      isOrgCreator,
     },
     { status: 200 },
   );

--- a/src/app/organizer/[orgId]/members/_components/MembersClient.tsx
+++ b/src/app/organizer/[orgId]/members/_components/MembersClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState, type FormEvent } from "react";
 
 interface Member {
   user_id: string;
@@ -96,12 +97,118 @@ function MemberCard({
   );
 }
 
+function InviteBar({ orgId }: { orgId: string }) {
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<"admin" | "member">("member");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setSuccessMsg(null);
+
+    try {
+      const res = await fetch(`/api/v1/organizer/${orgId}/members/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, role }),
+      });
+
+      const json = await res.json();
+
+      if (!res.ok) {
+        setError(json.error?.message ?? "Failed to send invitation");
+      } else {
+        const msg =
+          json.data.status === "pending"
+            ? `Invitation sent to ${json.data.email}`
+            : `${json.data.email} has been added as a member`;
+        setSuccessMsg(msg);
+        setEmail("");
+        setRole("member");
+      }
+    } catch {
+      setError("An unexpected error occurred. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg bg-bg-raised border border-border px-5 py-4 mb-6">
+      <p className="font-cinzel text-xs font-bold tracking-widest uppercase text-gold-muted mb-3">
+        Invite Member
+      </p>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <div className="flex-1 min-w-0">
+          <label
+            htmlFor="invite-email"
+            className="font-lato text-xs text-text-muted mb-1 block"
+          >
+            Email address
+          </label>
+          <input
+            id="invite-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="colleague@example.com"
+            required
+            disabled={loading}
+            className="w-full rounded-md border border-border bg-bg-base px-3 py-2 font-lato text-sm text-text-primary placeholder:text-text-disabled focus:outline-none focus:border-gold-dim disabled:opacity-50"
+          />
+        </div>
+
+        <div className="sm:w-36">
+          <label
+            htmlFor="invite-role"
+            className="font-lato text-xs text-text-muted mb-1 block"
+          >
+            Role
+          </label>
+          <select
+            id="invite-role"
+            value={role}
+            onChange={(e) => setRole(e.target.value as "admin" | "member")}
+            disabled={loading}
+            className="w-full rounded-md border border-border bg-bg-base px-3 py-2 font-lato text-sm text-text-primary focus:outline-none focus:border-gold-dim disabled:opacity-50"
+          >
+            <option value="admin">Admin</option>
+            <option value="member">Member</option>
+          </select>
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading || !email.trim()}
+          className="font-cinzel text-xs font-bold tracking-widest uppercase px-4 py-2 rounded-md bg-gold-ghost border border-gold-dim text-gold-bright hover:bg-gold-dim hover:text-bg-base transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+        >
+          {loading ? "Sending…" : "Send Invite"}
+        </button>
+      </form>
+
+      {error && (
+        <p className="font-lato text-xs text-red-400 mt-2">{error}</p>
+      )}
+      {successMsg && (
+        <p className="font-lato text-xs text-green-400 mt-2">{successMsg}</p>
+      )}
+    </div>
+  );
+}
+
 export default function MembersClient({
   orgId,
   orgName,
   members,
   currentUserId,
 }: Props) {
+  const currentMember = members.find((m) => m.user_id === currentUserId);
+  const isOwner = currentMember?.role === "owner";
+
   return (
     <div className="max-w-3xl mx-auto px-6 py-8">
       <div className="mb-6">
@@ -118,6 +225,8 @@ export default function MembersClient({
           Members · {members.length} {members.length === 1 ? "person" : "people"}
         </p>
       </div>
+
+      {isOwner && <InviteBar orgId={orgId} />}
 
       {/* Role permissions reference */}
       <div className="rounded-lg bg-bg-raised border border-border px-5 py-4 mb-6">

--- a/src/app/organizer/[orgId]/members/_components/MembersClient.tsx
+++ b/src/app/organizer/[orgId]/members/_components/MembersClient.tsx
@@ -18,6 +18,7 @@ interface Props {
   orgName: string;
   members: Member[];
   currentUserId: string;
+  isOrgCreator: boolean;
 }
 
 type Role = "owner" | "admin" | "member";
@@ -205,9 +206,10 @@ export default function MembersClient({
   orgName,
   members,
   currentUserId,
+  isOrgCreator,
 }: Props) {
   const currentMember = members.find((m) => m.user_id === currentUserId);
-  const isOwner = currentMember?.role === "owner";
+  const isOwner = isOrgCreator || currentMember?.role === "owner";
 
   return (
     <div className="max-w-3xl mx-auto px-6 py-8">

--- a/src/app/organizer/[orgId]/members/page.tsx
+++ b/src/app/organizer/[orgId]/members/page.tsx
@@ -23,6 +23,7 @@ interface Member {
 interface MembersData {
   members: Member[];
   orgName: string;
+  isOrgCreator: boolean;
 }
 
 async function fetchMembers(
@@ -58,6 +59,7 @@ async function fetchMembers(
 
     const membersJson = await membersRes.json();
     const members: Member[] = membersJson.data ?? [];
+    const isOrgCreator: boolean = membersJson.isOrgCreator ?? false;
 
     let orgName = "Organization";
     if (dashboardRes.ok) {
@@ -65,7 +67,7 @@ async function fetchMembers(
       orgName = dashJson.data?.organization?.name ?? orgName;
     }
 
-    return { members, orgName };
+    return { members, orgName, isOrgCreator };
   } catch {
     return null;
   }
@@ -105,6 +107,7 @@ export default async function OrganizerMembersPage({
         orgName={data.orgName}
         members={data.members}
         currentUserId={user.id}
+        isOrgCreator={data.isOrgCreator}
       />
     </div>
   );


### PR DESCRIPTION
Implements #72 and #73.

## Changes

- **Backend #72**: `POST /api/v1/organizer/:orgId/members/invite` with validators and 25 unit tests. Handles existing users (direct add, status: active) and new users (Supabase invite, status: pending).
- **Frontend #73**: `InviteBar` component added to the Members page (visible to owners only) with email input, role selector, and send invite button.

Generated with [Claude Code](https://claude.ai/code)