### PR TITLE
feat: organizer dashboard tournament table with status badges and manage buttons

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "typescript": "6.0.3",
-        "vite-tsconfig-paths": "^6.1.1",
         "vitest": "4.1.6"
       }
     },
@@ -5693,12 +5692,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -8884,9 +8877,9 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9055,42 +9048,6 @@
           "optional": true
         },
         "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
-      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      }
-    },
-    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "deprecated": "unmaintained",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "typescript": "6.0.3",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "4.1.6"
   }
 }

--- a/src/app/api/v1/organizer/[orgId]/tournaments/[id]/__tests__/route.get.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/tournaments/[id]/__tests__/route.get.test.ts
@@ -1,0 +1,649 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockOrgBuilder,
+  mockMembershipBuilder,
+  mockTournamentBuilder,
+  mockRegistrationsBuilder,
+  mockUsersBuilder,
+  mockProfilesBuilder,
+  mockFrom,
+  mockGetUser,
+} = vi.hoisted(() => {
+  function makeBuilder(finalResult: {
+    data?: unknown;
+    count?: unknown;
+    error?: unknown;
+  }) {
+    const b: Record<string, unknown> = {};
+    for (const m of [
+      "select",
+      "eq",
+      "in",
+      "is",
+      "order",
+      "limit",
+      "single",
+      "maybeSingle",
+      "insert",
+      "update",
+    ]) {
+      b[m] = vi.fn(() => b);
+    }
+    b.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return b;
+  }
+
+  const mockOrgBuilder = makeBuilder({ data: null, error: null });
+  const mockMembershipBuilder = makeBuilder({ data: null, error: null });
+  const mockTournamentBuilder = makeBuilder({ data: null, error: null });
+  const mockRegistrationsBuilder = makeBuilder({ data: null, error: null });
+  const mockUsersBuilder = makeBuilder({ data: null, error: null });
+  const mockProfilesBuilder = makeBuilder({ data: null, error: null });
+
+  const mockFrom = vi.fn((table: string) => {
+    switch (table) {
+      case "organizations":
+        return mockOrgBuilder;
+      case "organization_memberships":
+        return mockMembershipBuilder;
+      case "tournaments":
+        return mockTournamentBuilder;
+      case "registrations":
+        return mockRegistrationsBuilder;
+      case "users":
+        return mockUsersBuilder;
+      case "player_profiles":
+        return mockProfilesBuilder;
+      default:
+        return mockOrgBuilder;
+    }
+  });
+
+  const mockGetUser = vi.fn();
+
+  return {
+    mockOrgBuilder,
+    mockMembershipBuilder,
+    mockTournamentBuilder,
+    mockRegistrationsBuilder,
+    mockUsersBuilder,
+    mockProfilesBuilder,
+    mockFrom,
+    mockGetUser,
+  };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+import { GET } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const USER_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const ORG_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+const TOUR_ID = "cccccccc-0000-0000-0000-000000000001";
+const MEMBER_USER_ID = "aaaaaaaa-0000-0000-0000-000000000002";
+
+const APPROVED_ORG = {
+  id: ORG_ID,
+  approval_status: "approved",
+  created_by: USER_ID,
+};
+
+const TOURNAMENT_DATA = {
+  id: TOUR_ID,
+  name: "Test Tournament",
+  description: null,
+  status: "published",
+  start_date: "2026-09-01",
+  end_date: "2026-09-02",
+  registration_deadline: "2026-08-25T23:59:59Z",
+  venue_name: "KL Convention Centre",
+  venue_state: "W.P. Kuala Lumpur",
+  venue_address: "Jalan Pinang",
+  format: { type: "rapid", system: "swiss", rounds: 7 },
+  time_control: { base_minutes: 15, increment_seconds: 10, delay_seconds: 0 },
+  is_fide_rated: true,
+  is_mcf_rated: false,
+  max_participants: 64,
+  entry_fees: { standard: { amount_cents: 5000 } },
+  prizes: null,
+  restrictions: null,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setResult(
+  builder: Record<string, unknown>,
+  data: unknown,
+  error: unknown = null,
+) {
+  builder.then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setUser(id = USER_ID) {
+  mockGetUser.mockResolvedValue({ data: { user: { id } }, error: null });
+}
+
+function setNoUser() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+function makeRequest(orgId = ORG_ID, id = TOUR_ID): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/organizer/${orgId}/tournaments/${id}`,
+    { method: "GET" },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setUser();
+  setResult(mockOrgBuilder, APPROVED_ORG);
+  setResult(mockMembershipBuilder, { roles: { name: "owner" } });
+  setResult(mockTournamentBuilder, TOURNAMENT_DATA);
+  setResult(mockRegistrationsBuilder, []);
+  setResult(mockUsersBuilder, []);
+  setResult(mockProfilesBuilder, []);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/v1/organizer/[orgId]/tournaments/[id]", () => {
+  describe("input validation", () => {
+    it("returns 400 for invalid orgId format", async () => {
+      const res = await GET(makeRequest("not-a-uuid"), {
+        params: Promise.resolve({ orgId: "not-a-uuid", id: TOUR_ID }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 for invalid tournament ID format", async () => {
+      const res = await GET(makeRequest(ORG_ID, "not-a-uuid"), {
+        params: Promise.resolve({ orgId: ORG_ID, id: "not-a-uuid" }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("authentication", () => {
+    it("returns 401 when not authenticated", async () => {
+      setNoUser();
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  describe("organization checks", () => {
+    it("returns 404 when organization does not exist", async () => {
+      setResult(mockOrgBuilder, null, {
+        code: "PGRST116",
+        message: "Not found",
+      });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 500 when org query fails with a generic DB error", async () => {
+      setResult(mockOrgBuilder, null, {
+        code: "DB_ERROR",
+        message: "Connection failed",
+      });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 403 when organization is not approved", async () => {
+      setResult(mockOrgBuilder, { ...APPROVED_ORG, approval_status: "pending" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error.code).toBe("FORBIDDEN");
+    });
+  });
+
+  describe("permission checks", () => {
+    it("allows the org creator to view a tournament", async () => {
+      setUser(USER_ID);
+      setResult(mockOrgBuilder, { ...APPROVED_ORG, created_by: USER_ID });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("allows an org admin member to view a tournament", async () => {
+      setUser(MEMBER_USER_ID);
+      setResult(mockOrgBuilder, { ...APPROVED_ORG, created_by: USER_ID });
+      setResult(mockMembershipBuilder, { roles: { name: "admin" } });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 403 for a non-member user", async () => {
+      setUser(MEMBER_USER_ID);
+      setResult(mockOrgBuilder, { ...APPROVED_ORG, created_by: USER_ID });
+      setResult(mockMembershipBuilder, null, {
+        code: "PGRST116",
+        message: "Not found",
+      });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 for a member-role user", async () => {
+      setUser(MEMBER_USER_ID);
+      setResult(mockOrgBuilder, { ...APPROVED_ORG, created_by: USER_ID });
+      setResult(mockMembershipBuilder, { roles: { name: "member" } });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("tournament fetch", () => {
+    it("returns 404 when tournament does not exist", async () => {
+      setResult(mockTournamentBuilder, null, {
+        code: "PGRST116",
+        message: "Not found",
+      });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 500 when tournament query fails with a generic DB error", async () => {
+      setResult(mockTournamentBuilder, null, {
+        code: "DB_ERROR",
+        message: "Connection timeout",
+      });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error.code).toBe("INTERNAL_ERROR");
+    });
+  });
+
+  describe("registrations query", () => {
+    it("returns 500 when registrations query fails", async () => {
+      setResult(mockRegistrationsBuilder, null, { message: "DB error" });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 200 with empty participants and zero stats when no registrations", async () => {
+      setResult(mockRegistrationsBuilder, []);
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.participants).toEqual([]);
+      expect(body.data.stats.total).toBe(0);
+      expect(body.data.stats.confirmed).toBe(0);
+      expect(body.data.stats.pending).toBe(0);
+    });
+  });
+
+  describe("successful response", () => {
+    it("returns correct tournament structure with venue and format", async () => {
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const t = body.data.tournament;
+      expect(t.id).toBe(TOUR_ID);
+      expect(t.name).toBe("Test Tournament");
+      expect(t.venue.name).toBe("KL Convention Centre");
+      expect(t.venue.state).toBe("W.P. Kuala Lumpur");
+      expect(t.venue.address).toBe("Jalan Pinang");
+      expect(t.is_fide_rated).toBe(true);
+      expect(t.prizes).toBeNull();
+    });
+
+    it("returns participants with resolved user names and ratings", async () => {
+      setResult(mockRegistrationsBuilder, [
+        {
+          id: "reg-1",
+          user_id: "u1",
+          fee_tier: "standard",
+          status: "confirmed",
+          registered_at: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "reg-2",
+          user_id: "u2",
+          fee_tier: "early_bird",
+          status: "pending_payment",
+          registered_at: "2026-01-02T00:00:00Z",
+        },
+      ]);
+      setResult(mockUsersBuilder, [
+        { id: "u1", first_name: "Alice", last_name: "Wong" },
+        { id: "u2", first_name: "Bob", last_name: "Lee" },
+      ]);
+      setResult(mockProfilesBuilder, [
+        {
+          user_id: "u1",
+          fide_id: 1234567,
+          fide_rating: { rapid: 1800 },
+          national_rating: null,
+        },
+        {
+          user_id: "u2",
+          fide_id: null,
+          fide_rating: null,
+          national_rating: 1400,
+        },
+      ]);
+
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.participants).toHaveLength(2);
+      expect(body.data.participants[0].name).toBe("Alice Wong");
+      expect(body.data.participants[0].rating).toBe(1800);
+      expect(body.data.participants[1].name).toBe("Bob Lee");
+      expect(body.data.stats.total).toBe(2);
+      expect(body.data.stats.confirmed).toBe(1);
+      expect(body.data.stats.pending).toBe(1);
+    });
+
+    it("uses blitz rating when tournament format is blitz", async () => {
+      setResult(mockTournamentBuilder, {
+        ...TOURNAMENT_DATA,
+        format: { type: "blitz", system: "swiss", rounds: 9 },
+      });
+      setResult(mockRegistrationsBuilder, [
+        {
+          id: "reg-1",
+          user_id: "u1",
+          fee_tier: "standard",
+          status: "confirmed",
+          registered_at: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      setResult(mockUsersBuilder, [
+        { id: "u1", first_name: "Alice", last_name: "Wong" },
+      ]);
+      setResult(mockProfilesBuilder, [
+        {
+          user_id: "u1",
+          fide_id: null,
+          fide_rating: { blitz: 1600, rapid: 1700, standard: 1750 },
+          national_rating: null,
+        },
+      ]);
+
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.participants[0].rating).toBe(1600);
+    });
+
+    it("falls back to rapid when blitz format has no blitz rating", async () => {
+      setResult(mockTournamentBuilder, {
+        ...TOURNAMENT_DATA,
+        format: { type: "blitz", system: "swiss", rounds: 9 },
+      });
+      setResult(mockRegistrationsBuilder, [
+        {
+          id: "reg-1",
+          user_id: "u1",
+          fee_tier: "standard",
+          status: "confirmed",
+          registered_at: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      setResult(mockUsersBuilder, [
+        { id: "u1", first_name: "Alice", last_name: "Wong" },
+      ]);
+      setResult(mockProfilesBuilder, [
+        {
+          user_id: "u1",
+          fide_id: null,
+          fide_rating: { rapid: 1700 },
+          national_rating: null,
+        },
+      ]);
+
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.participants[0].rating).toBe(1700);
+    });
+
+    it("uses standard rating when tournament format is classical", async () => {
+      setResult(mockTournamentBuilder, {
+        ...TOURNAMENT_DATA,
+        format: { type: "classical", system: "swiss", rounds: 9 },
+      });
+      setResult(mockRegistrationsBuilder, [
+        {
+          id: "reg-1",
+          user_id: "u1",
+          fee_tier: "standard",
+          status: "confirmed",
+          registered_at: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      setResult(mockUsersBuilder, [
+        { id: "u1", first_name: "Alice", last_name: "Wong" },
+      ]);
+      setResult(mockProfilesBuilder, [
+        {
+          user_id: "u1",
+          fide_id: 9876543,
+          fide_rating: { standard: 2000 },
+          national_rating: null,
+        },
+      ]);
+
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.participants[0].rating).toBe(2000);
+    });
+
+    it("falls back to rapid when rapid format has no rapid rating", async () => {
+      setResult(mockRegistrationsBuilder, [
+        {
+          id: "reg-1",
+          user_id: "u1",
+          fee_tier: "standard",
+          status: "confirmed",
+          registered_at: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      setResult(mockUsersBuilder, [
+        { id: "u1", first_name: "Alice", last_name: "Wong" },
+      ]);
+      setResult(mockProfilesBuilder, [
+        {
+          user_id: "u1",
+          fide_id: null,
+          fide_rating: { standard: 1900 },
+          national_rating: null,
+        },
+      ]);
+
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.participants[0].rating).toBe(1900);
+    });
+
+    it("returns null rating when player has no fide_rating", async () => {
+      setResult(mockRegistrationsBuilder, [
+        {
+          id: "reg-1",
+          user_id: "u1",
+          fee_tier: "standard",
+          status: "confirmed",
+          registered_at: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      setResult(mockUsersBuilder, [
+        { id: "u1", first_name: "Alice", last_name: "Wong" },
+      ]);
+      setResult(mockProfilesBuilder, [
+        {
+          user_id: "u1",
+          fide_id: null,
+          fide_rating: null,
+          national_rating: null,
+        },
+      ]);
+
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.participants[0].rating).toBeNull();
+    });
+
+    it("shows 'Unknown' name when user is not found in users table", async () => {
+      setResult(mockRegistrationsBuilder, [
+        {
+          id: "reg-1",
+          user_id: "missing-user",
+          fee_tier: "standard",
+          status: "confirmed",
+          registered_at: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      setResult(mockUsersBuilder, []);
+      setResult(mockProfilesBuilder, []);
+
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.participants[0].name).toBe("Unknown");
+    });
+
+    it("handles tournament with null format gracefully", async () => {
+      setResult(mockTournamentBuilder, { ...TOURNAMENT_DATA, format: null });
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.tournament.format).toBeNull();
+    });
+
+    it("includes correct participant index ordering", async () => {
+      setResult(mockRegistrationsBuilder, [
+        {
+          id: "reg-1",
+          user_id: "u1",
+          fee_tier: "standard",
+          status: "confirmed",
+          registered_at: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "reg-2",
+          user_id: "u2",
+          fee_tier: "standard",
+          status: "confirmed",
+          registered_at: "2026-01-02T00:00:00Z",
+        },
+      ]);
+      setResult(mockUsersBuilder, [
+        { id: "u1", first_name: "Alice", last_name: "Wong" },
+        { id: "u2", first_name: "Bob", last_name: "Lee" },
+      ]);
+      setResult(mockProfilesBuilder, []);
+
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.participants[0].index).toBe(1);
+      expect(body.data.participants[1].index).toBe(2);
+    });
+  });
+});

--- a/src/app/api/v1/organizer/[orgId]/tournaments/[id]/__tests__/route.get.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/tournaments/[id]/__tests__/route.get.test.ts
@@ -247,7 +247,10 @@ describe("GET /api/v1/organizer/[orgId]/tournaments/[id]", () => {
     });
 
     it("returns 403 when organization is not approved", async () => {
-      setResult(mockOrgBuilder, { ...APPROVED_ORG, approval_status: "pending" });
+      setResult(mockOrgBuilder, {
+        ...APPROVED_ORG,
+        approval_status: "pending",
+      });
       const res = await GET(makeRequest(), {
         params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
       });

--- a/src/app/api/v1/organizer/[orgId]/tournaments/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/tournaments/[id]/__tests__/route.test.ts
@@ -62,8 +62,9 @@ const {
     return mockOrgBuilder;
   });
 
-  (mockFrom as unknown as { _resetTournamentCallIndex: () => void })
-    ._resetTournamentCallIndex = () => {
+  (
+    mockFrom as unknown as { _resetTournamentCallIndex: () => void }
+  )._resetTournamentCallIndex = () => {
     tournamentCallIndex = 0;
   };
 
@@ -370,7 +371,10 @@ describe("PATCH /api/v1/organizer/[orgId]/tournaments/[id]", () => {
   describe("tournament checks", () => {
     it("returns 404 when tournament does not exist", async () => {
       setUser();
-      setTournamentFetchResult(null, { code: "PGRST116", message: "Not found" });
+      setTournamentFetchResult(null, {
+        code: "PGRST116",
+        message: "Not found",
+      });
       const res = await PATCH(makeRequest(), {
         params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
       });
@@ -381,7 +385,10 @@ describe("PATCH /api/v1/organizer/[orgId]/tournaments/[id]", () => {
 
     it("returns 404 when tournament belongs to a different org", async () => {
       setUser();
-      setTournamentFetchResult(null, { code: "PGRST116", message: "Not found" });
+      setTournamentFetchResult(null, {
+        code: "PGRST116",
+        message: "Not found",
+      });
       const res = await PATCH(makeRequest(), {
         params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
       });
@@ -412,10 +419,9 @@ describe("PATCH /api/v1/organizer/[orgId]/tournaments/[id]", () => {
 
     it("allows updating prizes to null", async () => {
       setUser();
-      const res = await PATCH(
-        makeRequest(ORG_ID, TOUR_ID, { prizes: null }),
-        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
-      );
+      const res = await PATCH(makeRequest(ORG_ID, TOUR_ID, { prizes: null }), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
       expect(res.status).toBe(200);
     });
 
@@ -480,7 +486,10 @@ describe("PATCH /api/v1/organizer/[orgId]/tournaments/[id]", () => {
 
     it("returns 500 when the tournament fetch fails with a generic DB error", async () => {
       setUser();
-      setTournamentFetchResult(null, { code: "DB_ERROR", message: "Query timeout" });
+      setTournamentFetchResult(null, {
+        code: "DB_ERROR",
+        message: "Query timeout",
+      });
       const res = await PATCH(makeRequest(), {
         params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
       });

--- a/src/app/api/v1/organizer/[orgId]/tournaments/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/tournaments/[id]/__tests__/route.test.ts
@@ -466,5 +466,91 @@ describe("PATCH /api/v1/organizer/[orgId]/tournaments/[id]", () => {
       const body = await res.json();
       expect(body.error.code).toBe("INTERNAL_ERROR");
     });
+
+    it("returns 500 when the org query fails with a generic DB error", async () => {
+      setUser();
+      setOrgResult(null, { code: "DB_ERROR", message: "Connection timeout" });
+      const res = await PATCH(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when the tournament fetch fails with a generic DB error", async () => {
+      setUser();
+      setTournamentFetchResult(null, { code: "DB_ERROR", message: "Query timeout" });
+      const res = await PATCH(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
+      });
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error.code).toBe("INTERNAL_ERROR");
+    });
+  });
+
+  describe("field-level patch branches", () => {
+    it("patches description with a non-empty string", async () => {
+      setUser();
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, { description: "Updated description." }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("sets description to null when provided as empty string", async () => {
+      setUser();
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, { description: "" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("patches prizes with non-null categories and special prizes", async () => {
+      setUser();
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          prizes: {
+            categories: [
+              {
+                name: "Open",
+                entries: [{ placement: "1st", amount_cents: 100000 }],
+              },
+            ],
+            special: [{ name: "Best Game", amount_cents: 20000 }],
+          },
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("patches restrictions with a non-empty array", async () => {
+      setUser();
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          restrictions: [{ type: "Max Rating", value: "2000" }],
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("patches entry_fees with additional tiers", async () => {
+      setUser();
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          entry_fees: {
+            standard: { amount_cents: 5000 },
+            additional: [{ type: "early_bird", amount_cents: 4000 }],
+          },
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/src/app/api/v1/organizer/[orgId]/tournaments/[id]/route.ts
+++ b/src/app/api/v1/organizer/[orgId]/tournaments/[id]/route.ts
@@ -5,6 +5,179 @@ import { NextRequest, NextResponse } from "next/server";
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string; id: string }> },
+): Promise<NextResponse> {
+  const { orgId, id } = await params;
+
+  if (!UUID_RE.test(orgId)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid organization ID" } },
+      { status: 400 },
+    );
+  }
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid tournament ID" } },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  const permissionError = await resolvePermission(orgId, user.id);
+  if (permissionError) return permissionError;
+
+  const { data: tournament, error: tErr } = await supabaseAdmin
+    .from("tournaments")
+    .select(
+      "id, name, description, status, start_date, end_date, registration_deadline, venue_name, venue_state, venue_address, format, time_control, is_fide_rated, is_mcf_rated, max_participants, entry_fees, prizes, restrictions",
+    )
+    .eq("id", id)
+    .eq("organization_id", orgId)
+    .single();
+
+  if (tErr) {
+    if (tErr.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Tournament not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: tErr.message } },
+      { status: 500 },
+    );
+  }
+
+  const { data: regs, error: regErr } = await supabaseAdmin
+    .from("registrations")
+    .select("id, user_id, fee_tier, status, registered_at")
+    .eq("tournament_id", id)
+    .in("status", ["confirmed", "pending_payment"])
+    .order("registered_at", { ascending: true });
+
+  if (regErr) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: regErr.message } },
+      { status: 500 },
+    );
+  }
+
+  const registrations = (regs ?? []) as Array<{
+    id: string;
+    user_id: string;
+    fee_tier: string;
+    status: string;
+    registered_at: string;
+  }>;
+
+  const userIds = registrations.map((r) => r.user_id).filter(Boolean);
+
+  type UserRow = { id: string; first_name: string; last_name: string };
+  type ProfileRow = {
+    user_id: string;
+    fide_id: number | null;
+    fide_rating: Record<string, number> | null;
+    national_rating: number | null;
+  };
+
+  let userMap = new Map<string, UserRow>();
+  let profileMap = new Map<string, ProfileRow>();
+
+  if (userIds.length > 0) {
+    const [{ data: users }, { data: profiles }] = await Promise.all([
+      supabaseAdmin
+        .from("users")
+        .select("id, first_name, last_name")
+        .in("id", userIds),
+      supabaseAdmin
+        .from("player_profiles")
+        .select("user_id, fide_id, fide_rating, national_rating")
+        .in("user_id", userIds),
+    ]);
+
+    userMap = new Map((users as UserRow[] ?? []).map((u) => [u.id, u]));
+    profileMap = new Map((profiles as ProfileRow[] ?? []).map((p) => [p.user_id, p]));
+  }
+
+  const formatType =
+    (tournament.format as { type?: string } | null)?.type ?? "";
+
+  const participants = registrations.map((reg, idx) => {
+    const u = userMap.get(reg.user_id);
+    const p = profileMap.get(reg.user_id);
+
+    let rating: number | null = null;
+    if (p?.fide_rating) {
+      const r = p.fide_rating;
+      if (formatType === "blitz") {
+        rating = r.blitz ?? r.rapid ?? r.standard ?? null;
+      } else if (formatType === "rapid") {
+        rating = r.rapid ?? r.standard ?? null;
+      } else {
+        rating = r.standard ?? null;
+      }
+    }
+
+    return {
+      index: idx + 1,
+      id: reg.id,
+      user_id: reg.user_id,
+      name: u ? `${u.first_name} ${u.last_name}` : "Unknown",
+      fide_id: p?.fide_id ?? null,
+      rating,
+      fee_tier: reg.fee_tier,
+      status: reg.status,
+      registered_at: reg.registered_at,
+    };
+  });
+
+  const total = registrations.length;
+  const confirmed = registrations.filter((r) => r.status === "confirmed").length;
+  const pending = registrations.filter((r) => r.status === "pending_payment").length;
+
+  return NextResponse.json({
+    data: {
+      tournament: {
+        id: tournament.id,
+        name: tournament.name,
+        description: tournament.description ?? null,
+        status: tournament.status,
+        start_date: tournament.start_date,
+        end_date: tournament.end_date,
+        registration_deadline: tournament.registration_deadline,
+        venue: {
+          name: tournament.venue_name,
+          state: tournament.venue_state,
+          address: tournament.venue_address,
+        },
+        format: tournament.format,
+        time_control: tournament.time_control,
+        is_fide_rated: tournament.is_fide_rated,
+        is_mcf_rated: tournament.is_mcf_rated,
+        max_participants: tournament.max_participants,
+        entry_fees: tournament.entry_fees,
+        prizes: tournament.prizes ?? null,
+        restrictions: tournament.restrictions ?? null,
+      },
+      stats: { total, confirmed, pending },
+      participants,
+    },
+  });
+}
+
 interface FormatInput {
   type?: string;
   system?: string;

--- a/src/app/api/v1/tournaments/name-check/route.ts
+++ b/src/app/api/v1/tournaments/name-check/route.ts
@@ -1,8 +1,12 @@
 import { supabaseAdmin } from "@/services/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const name = request.nextUrl.searchParams.get("name")?.trim();
+  const excludeId = request.nextUrl.searchParams.get("excludeId")?.trim();
 
   if (!name) {
     return NextResponse.json(
@@ -11,10 +15,16 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const { count, error } = await supabaseAdmin
+  let query = supabaseAdmin
     .from("tournaments")
     .select("id", { count: "exact", head: true })
     .ilike("name", name);
+
+  if (excludeId && UUID_RE.test(excludeId)) {
+    query = query.neq("id", excludeId);
+  }
+
+  const { count, error } = await query;
 
   if (error) {
     return NextResponse.json(

--- a/src/app/auth/signup/_components/__tests__/PrivacyModal.test.tsx
+++ b/src/app/auth/signup/_components/__tests__/PrivacyModal.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import PrivacyModal from "../PrivacyModal";
+
+afterEach(cleanup);
+
+describe("PrivacyModal", () => {
+  it("renders the modal with dialog role and aria-modal attribute", () => {
+    render(<PrivacyModal onClose={vi.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeDefined();
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBe("privacy-modal-title");
+  });
+
+  it("renders the Privacy Policy heading", () => {
+    render(<PrivacyModal onClose={vi.fn()} />);
+    expect(screen.getByText("Privacy Policy")).toBeDefined();
+  });
+
+  it("locks body scroll on mount and restores it on unmount", () => {
+    document.body.style.overflow = "";
+    const { unmount } = render(<PrivacyModal onClose={vi.fn()} />);
+    expect(document.body.style.overflow).toBe("hidden");
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<PrivacyModal onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /close privacy policy/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Escape key is pressed", () => {
+    const onClose = vi.fn();
+    render(<PrivacyModal onClose={onClose} />);
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClose for non-Escape key presses", () => {
+    const onClose = vi.fn();
+    render(<PrivacyModal onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when clicking directly on the overlay backdrop", () => {
+    const onClose = vi.fn();
+    const { container } = render(<PrivacyModal onClose={onClose} />);
+    const overlay = container.querySelector(".modal-overlay") as HTMLElement;
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClose when clicking inside the modal content area", () => {
+    const onClose = vi.fn();
+    const { container } = render(<PrivacyModal onClose={onClose} />);
+    const modal = container.querySelector(".modal") as HTMLElement;
+    fireEvent.click(modal);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("removes the keydown listener when unmounted", () => {
+    const onClose = vi.fn();
+    const { unmount } = render(<PrivacyModal onClose={onClose} />);
+    unmount();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/auth/signup/_components/__tests__/PrivacyModal.test.tsx
+++ b/src/app/auth/signup/_components/__tests__/PrivacyModal.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import PrivacyModal from "../PrivacyModal";
 
 afterEach(cleanup);
@@ -30,7 +36,9 @@ describe("PrivacyModal", () => {
   it("calls onClose when the close button is clicked", () => {
     const onClose = vi.fn();
     render(<PrivacyModal onClose={onClose} />);
-    fireEvent.click(screen.getByRole("button", { name: /close privacy policy/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /close privacy policy/i }),
+    );
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/src/app/auth/signup/_components/__tests__/TermsModal.test.tsx
+++ b/src/app/auth/signup/_components/__tests__/TermsModal.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import TermsModal from "../TermsModal";
 
 afterEach(cleanup);
@@ -30,7 +36,9 @@ describe("TermsModal", () => {
   it("calls onClose when the close button is clicked", () => {
     const onClose = vi.fn();
     render(<TermsModal onClose={onClose} />);
-    fireEvent.click(screen.getByRole("button", { name: /close terms of service/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /close terms of service/i }),
+    );
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/src/app/auth/signup/_components/__tests__/TermsModal.test.tsx
+++ b/src/app/auth/signup/_components/__tests__/TermsModal.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import TermsModal from "../TermsModal";
+
+afterEach(cleanup);
+
+describe("TermsModal", () => {
+  it("renders the modal with dialog role and aria-modal attribute", () => {
+    render(<TermsModal onClose={vi.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeDefined();
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBe("terms-modal-title");
+  });
+
+  it("renders the Terms of Service heading", () => {
+    render(<TermsModal onClose={vi.fn()} />);
+    expect(screen.getByText("Terms of Service")).toBeDefined();
+  });
+
+  it("locks body scroll on mount and restores it on unmount", () => {
+    document.body.style.overflow = "";
+    const { unmount } = render(<TermsModal onClose={vi.fn()} />);
+    expect(document.body.style.overflow).toBe("hidden");
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<TermsModal onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /close terms of service/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Escape key is pressed", () => {
+    const onClose = vi.fn();
+    render(<TermsModal onClose={onClose} />);
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClose for non-Escape key presses", () => {
+    const onClose = vi.fn();
+    render(<TermsModal onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when clicking directly on the overlay backdrop", () => {
+    const onClose = vi.fn();
+    const { container } = render(<TermsModal onClose={onClose} />);
+    const overlay = container.querySelector(".modal-overlay") as HTMLElement;
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClose when clicking inside the modal content area", () => {
+    const onClose = vi.fn();
+    const { container } = render(<TermsModal onClose={onClose} />);
+    const modal = container.querySelector(".modal") as HTMLElement;
+    fireEvent.click(modal);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("removes the keydown listener when unmounted", () => {
+    const onClose = vi.fn();
+    const { unmount } = render(<TermsModal onClose={onClose} />);
+    unmount();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/components/__tests__/Icons.test.tsx
+++ b/src/app/components/__tests__/Icons.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  BrowseIcon,
+  CloseIcon,
+  FacebookIcon,
+  InstagramIcon,
+  LinkedInIcon,
+  LogoutIcon,
+  MenuIcon,
+  MoonIcon,
+  PayIcon,
+  SunIcon,
+  TrophyIcon,
+} from "../Icons";
+
+describe("Icons", () => {
+  it("renders BrowseIcon as an SVG element", () => {
+    const html = renderToStaticMarkup(<BrowseIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain("viewBox");
+  });
+
+  it("renders PayIcon as an SVG element", () => {
+    const html = renderToStaticMarkup(<PayIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain("viewBox");
+  });
+
+  it("renders TrophyIcon as an SVG element", () => {
+    const html = renderToStaticMarkup(<TrophyIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain("viewBox");
+  });
+
+  it("renders FacebookIcon as an SVG with correct dimensions", () => {
+    const html = renderToStaticMarkup(<FacebookIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain('width="16"');
+    expect(html).toContain('height="16"');
+  });
+
+  it("renders InstagramIcon as an SVG with stroke", () => {
+    const html = renderToStaticMarkup(<InstagramIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain("stroke");
+  });
+
+  it("renders LinkedInIcon as an SVG element", () => {
+    const html = renderToStaticMarkup(<LinkedInIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain('aria-hidden="true"');
+  });
+
+  it("renders LogoutIcon as an SVG element", () => {
+    const html = renderToStaticMarkup(<LogoutIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain('aria-hidden="true"');
+  });
+
+  it("renders MenuIcon as an SVG with three lines", () => {
+    const html = renderToStaticMarkup(<MenuIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain("<line");
+  });
+
+  it("renders CloseIcon as an SVG with cross lines", () => {
+    const html = renderToStaticMarkup(<CloseIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain("<line");
+  });
+
+  it("renders SunIcon as an SVG with a circle", () => {
+    const html = renderToStaticMarkup(<SunIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain("<circle");
+  });
+
+  it("renders MoonIcon as an SVG with a path", () => {
+    const html = renderToStaticMarkup(<MoonIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain("<path");
+  });
+});

--- a/src/app/organizer/[orgId]/dashboard/_components/DashboardClient.tsx
+++ b/src/app/organizer/[orgId]/dashboard/_components/DashboardClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 type TournamentStatus = "draft" | "published" | "ongoing" | "completed" | "cancelled";
 
@@ -32,92 +31,160 @@ interface Props {
 }
 
 const STATUS_CONFIG: Record<TournamentStatus, { label: string; className: string }> = {
-  draft: { label: "Draft", className: "bg-bg-raised text-text-muted border border-border" },
-  published: { label: "Open", className: "bg-success/10 text-success border border-success/20" },
-  ongoing: { label: "Ongoing", className: "bg-warning/15 text-warning border border-warning/20" },
-  completed: { label: "Completed", className: "bg-bg-raised text-text-muted border border-border" },
-  cancelled: { label: "Cancelled", className: "bg-danger/15 text-danger border border-danger/20" },
+  draft: {
+    label: "Draft",
+    className: "bg-bg-raised text-text-muted border border-border",
+  },
+  published: {
+    label: "Published",
+    className: "bg-success/10 text-success border border-success/20",
+  },
+  ongoing: {
+    label: "Ongoing",
+    className: "bg-warning/15 text-warning border border-warning/20",
+  },
+  completed: {
+    label: "Completed",
+    className: "bg-bg-raised text-text-muted border border-border",
+  },
+  cancelled: {
+    label: "Cancelled",
+    className: "bg-danger/15 text-danger border border-danger/20",
+  },
 };
 
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-MY", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
 function formatCents(cents: number): string {
-  return `MYR ${(cents / 100).toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  return `MYR ${(cents / 100).toLocaleString("en-MY", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function getActionConfig(
+  status: TournamentStatus,
+): { label: string; pathSuffix: string } {
+  switch (status) {
+    case "draft":
+      return { label: "Edit", pathSuffix: "/edit" };
+    case "published":
+    case "ongoing":
+      return { label: "Manage", pathSuffix: "" };
+    case "completed":
+    case "cancelled":
+    default:
+      return { label: "View", pathSuffix: "" };
+  }
 }
 
 function StatCard({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="card px-5 py-4 flex flex-col gap-1">
-      <p className="font-lato text-xs text-text-muted uppercase tracking-widest">{label}</p>
+      <p className="font-lato text-xs text-text-muted uppercase tracking-widest">
+        {label}
+      </p>
       <p className="font-cinzel text-2xl font-bold text-text-primary">{value}</p>
     </div>
   );
 }
 
-function TournamentRow({ tournament }: { tournament: RecentTournament }) {
-  const startDate = new Date(tournament.start_date + "T00:00:00");
-  const month = startDate.toLocaleString("en-MY", { month: "short" }).toUpperCase();
-  const day = startDate.getDate();
-  const statusConfig = STATUS_CONFIG[tournament.status] ?? STATUS_CONFIG.draft;
+interface TournamentRowProps {
+  tournament: RecentTournament;
+  orgId: string;
+}
+
+function TournamentRow({ tournament: t, orgId }: TournamentRowProps) {
+  const statusConfig = STATUS_CONFIG[t.status] ?? STATUS_CONFIG.draft;
+  const actionConfig = getActionConfig(t.status);
+  const basePath = `/organizer/${orgId}/tournaments/${t.id}`;
+  const isDimmed = t.status === "completed" || t.status === "cancelled";
 
   return (
-    <Link
-      href={`/tournaments/${tournament.id}`}
-      className="flex items-center gap-4 card px-5 py-4 no-underline transition-shadow duration-150 hover:shadow-[0_4px_20px_var(--color-grandiose-hover)]"
-    >
-      <div className="text-center min-w-12 shrink-0">
-        <div className="font-cinzel text-xs font-bold tracking-widest text-gold-bright">{month}</div>
-        <div className="font-cinzel text-2xl font-bold text-text-primary leading-tight">{day}</div>
-      </div>
-
-      <div className="flex-1 min-w-0">
-        <h4 className="font-lato text-sm font-semibold text-text-primary truncate">{tournament.name}</h4>
-        <p className="font-lato text-xs text-text-muted mt-0.5">
-          {tournament.current_participants} / {tournament.max_participants} participants
-        </p>
-      </div>
-
-      <span
-        className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${statusConfig.className}`}
-      >
-        {statusConfig.label}
-      </span>
-    </Link>
+    <tr className={`border-b border-border last:border-b-0 hover:bg-bg-raised transition-colors duration-100${isDimmed ? " opacity-60" : ""}`}>
+      <td className="px-5 py-3.5">
+        <span className="font-lato text-sm font-semibold text-text-primary">
+          {t.name}
+        </span>
+      </td>
+      <td className="px-5 py-3.5 whitespace-nowrap">
+        <span className="font-lato text-sm text-text-secondary">
+          {formatDate(t.start_date)}
+        </span>
+      </td>
+      <td className="px-5 py-3.5 whitespace-nowrap">
+        <span className="font-lato text-sm text-text-secondary">
+          {t.current_participants} / {t.max_participants}
+        </span>
+      </td>
+      <td className="px-5 py-3.5">
+        <span
+          className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${statusConfig.className}`}
+        >
+          {statusConfig.label}
+        </span>
+      </td>
+      <td className="px-5 py-3.5 text-right">
+        <Link
+          href={`${basePath}${actionConfig.pathSuffix}`}
+          className="font-cinzel text-gold-bright border-gold-bright/40 hover:border-gold-bright hover:bg-int-gold-bg inline-flex cursor-pointer items-center rounded-md border bg-transparent px-3 py-1.5 text-xs font-bold tracking-widest uppercase transition duration-150"
+        >
+          {actionConfig.label}
+        </Link>
+      </td>
+    </tr>
   );
 }
 
 export default function DashboardClient({ data }: Props) {
   const { organization, stats, recent_tournaments } = data;
-  const router = useRouter();
 
   return (
-    <div className="max-w-3xl mx-auto px-6 py-8">
+    <div className="max-w-4xl mx-auto px-6 py-8">
+      {/* Header */}
       <div className="mb-6 flex items-start justify-between gap-4">
         <div>
           <h1 className="font-cinzel text-2xl font-bold text-text-primary tracking-wide">
             {organization.name}
           </h1>
-          <p className="font-lato text-sm text-text-muted mt-1">Organizer Dashboard</p>
+          <p className="font-lato text-sm text-text-muted mt-1">
+            Organizer Dashboard
+          </p>
         </div>
-        <button
-          type="button"
+        <Link
+          href={`/organizer/${organization.id}/tournaments/create`}
           className="font-cinzel text-bg-base shrink-0 cursor-pointer rounded-md border-0 px-4 py-2 text-xs font-bold tracking-widest uppercase transition duration-200 hover:opacity-90"
           style={{
             background:
               "linear-gradient(135deg, var(--color-gold-bright), var(--color-gold-deep))",
           }}
-          onClick={() =>
-            router.push(`/organizer/${organization.id}/tournaments/create`)
-          }
         >
           + Create
-        </button>
+        </Link>
       </div>
 
       {/* Stats */}
       <div className="grid grid-cols-2 gap-3 mb-8">
         <StatCard label="Active Tournaments" value={stats.active_tournaments} />
-        <StatCard label="Total Registrations" value={stats.total_registrations} />
-        <StatCard label="Total Revenue" value={formatCents(stats.total_revenue_cents)} />
-        <StatCard label="Pending Payout" value={formatCents(stats.pending_payout_cents)} />
+        <StatCard
+          label="Total Registrations"
+          value={stats.total_registrations}
+        />
+        <StatCard
+          label="Total Revenue"
+          value={formatCents(stats.total_revenue_cents)}
+        />
+        <StatCard
+          label="Pending Payout"
+          value={formatCents(stats.pending_payout_cents)}
+        />
       </div>
 
       {/* Quick Links */}
@@ -132,32 +199,61 @@ export default function DashboardClient({ data }: Props) {
           <div className="flex items-center gap-3">
             <span className="text-xl text-gold-bright">♟</span>
             <div>
-              <p className="font-lato text-sm font-semibold text-text-primary">Members</p>
-              <p className="font-lato text-xs text-text-muted mt-0.5">View and manage organization members</p>
+              <p className="font-lato text-sm font-semibold text-text-primary">
+                Members
+              </p>
+              <p className="font-lato text-xs text-text-muted mt-0.5">
+                View and manage organization members
+              </p>
             </div>
           </div>
           <span className="text-text-muted text-lg">›</span>
         </Link>
       </div>
 
-      {/* Recent Tournaments */}
+      {/* Tournament Table */}
       <div>
         <h2 className="font-cinzel text-base font-bold text-text-primary tracking-wide mb-3">
-          Recent Tournaments
+          Your Tournaments
         </h2>
 
         {recent_tournaments.length === 0 ? (
-          <div className="text-center py-12 px-5">
+          <div className="card text-center py-12 px-5">
             <div className="text-4xl mb-4 opacity-20">♟</div>
             <p className="font-lato text-sm text-text-muted leading-relaxed">
               No tournaments yet. Create your first tournament to get started.
             </p>
           </div>
         ) : (
-          <div className="flex flex-col gap-3">
-            {recent_tournaments.map((t) => (
-              <TournamentRow key={t.id} tournament={t} />
-            ))}
+          <div className="card overflow-hidden overflow-x-auto">
+            <table className="w-full border-collapse min-w-[600px]">
+              <thead>
+                <tr className="border-b border-border bg-bg-raised">
+                  <th className="font-cinzel text-left px-5 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted">
+                    Tournament
+                  </th>
+                  <th className="font-cinzel text-left px-5 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted whitespace-nowrap">
+                    Date
+                  </th>
+                  <th className="font-cinzel text-left px-5 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted whitespace-nowrap">
+                    Registrations
+                  </th>
+                  <th className="font-cinzel text-left px-5 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted">
+                    Status
+                  </th>
+                  <th className="px-5 py-3" />
+                </tr>
+              </thead>
+              <tbody>
+                {recent_tournaments.map((t) => (
+                  <TournamentRow
+                    key={t.id}
+                    tournament={t}
+                    orgId={organization.id}
+                  />
+                ))}
+              </tbody>
+            </table>
           </div>
         )}
       </div>

--- a/src/app/organizer/[orgId]/tournaments/[id]/_components/TournamentManageClient.tsx
+++ b/src/app/organizer/[orgId]/tournaments/[id]/_components/TournamentManageClient.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+type TournamentStatus = "draft" | "published" | "ongoing" | "completed" | "cancelled";
+
+interface Venue {
+  name: string;
+  state: string;
+  address?: string | null;
+}
+
+interface Format {
+  type?: string;
+  system?: string;
+  rounds?: number;
+}
+
+interface Tournament {
+  id: string;
+  name: string;
+  status: TournamentStatus;
+  start_date: string;
+  end_date: string;
+  venue: Venue;
+  format: Format | null;
+  max_participants: number;
+}
+
+interface Stats {
+  total: number;
+  confirmed: number;
+  pending: number;
+}
+
+interface Participant {
+  index: number;
+  id: string;
+  user_id: string;
+  name: string;
+  fide_id: number | null;
+  rating: number | null;
+  fee_tier: string;
+  status: string;
+  registered_at: string;
+}
+
+interface Props {
+  orgId: string;
+  tournament: Tournament;
+  stats: Stats;
+  participants: Participant[];
+}
+
+const STATUS_CONFIG: Record<TournamentStatus, { label: string; className: string }> = {
+  draft: {
+    label: "Draft",
+    className: "bg-bg-raised text-text-muted border border-border",
+  },
+  published: {
+    label: "Published",
+    className: "bg-success/10 text-success border border-success/20",
+  },
+  ongoing: {
+    label: "Ongoing",
+    className: "bg-warning/15 text-warning border border-warning/20",
+  },
+  completed: {
+    label: "Completed",
+    className: "bg-bg-raised text-text-muted border border-border",
+  },
+  cancelled: {
+    label: "Cancelled",
+    className: "bg-danger/15 text-danger border border-danger/20",
+  },
+};
+
+const REG_STATUS_CONFIG: Record<string, { label: string; className: string }> = {
+  confirmed: {
+    label: "Confirmed",
+    className: "bg-success/10 text-success border border-success/20",
+  },
+  pending_payment: {
+    label: "Pending",
+    className: "bg-warning/15 text-warning border border-warning/20",
+  },
+};
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-MY", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function formatDateTime(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-MY", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function toTitleCase(str: string): string {
+  return str
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function StatCard({ label, value, note }: { label: string; value: string | number; note?: string }) {
+  return (
+    <div className="card px-5 py-4 flex flex-col gap-1">
+      <p className="font-lato text-xs text-text-muted uppercase tracking-widest">{label}</p>
+      <p className="font-cinzel text-2xl font-bold text-text-primary">{value}</p>
+      {note && <p className="font-lato text-xs text-text-muted">{note}</p>}
+    </div>
+  );
+}
+
+export default function TournamentManageClient({ orgId, tournament, stats, participants }: Props) {
+  const [search, setSearch] = useState("");
+  const statusConfig = STATUS_CONFIG[tournament.status] ?? STATUS_CONFIG.draft;
+  const isEditable = tournament.status === "draft" || tournament.status === "published" || tournament.status === "ongoing";
+
+  const filtered = participants.filter((p) =>
+    p.name.toLowerCase().includes(search.toLowerCase()) ||
+    (p.fide_id?.toString() ?? "").includes(search),
+  );
+
+  return (
+    <div className="max-w-5xl mx-auto px-6 py-8">
+      {/* Back link */}
+      <div className="mb-4">
+        <Link
+          href={`/organizer/${orgId}/dashboard`}
+          className="font-lato text-sm text-text-muted hover:text-text-primary transition-colors"
+        >
+          ← Back to Dashboard
+        </Link>
+      </div>
+
+      {/* Header */}
+      <div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="font-cinzel text-2xl font-bold text-text-primary tracking-wide">
+            {tournament.name}
+          </h1>
+          <p className="font-lato text-sm text-text-muted mt-1">
+            {formatDate(tournament.start_date)}
+            {tournament.start_date !== tournament.end_date && ` – ${formatDate(tournament.end_date)}`}
+            {" · "}
+            {tournament.venue.name}, {tournament.venue.state}
+            {" · "}
+            <span
+              className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2 py-0.5 rounded-md ${statusConfig.className}`}
+            >
+              {statusConfig.label}
+            </span>
+          </p>
+        </div>
+        {isEditable && (
+          <Link
+            href={`/organizer/${orgId}/tournaments/${tournament.id}/edit`}
+            className="font-cinzel text-gold-bright border-gold-bright/40 hover:border-gold-bright hover:bg-int-gold-bg inline-flex cursor-pointer items-center rounded-md border bg-transparent px-4 py-2 text-xs font-bold tracking-widest uppercase transition duration-150 shrink-0"
+          >
+            Edit Tournament
+          </Link>
+        )}
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-8">
+        <StatCard
+          label="Registered"
+          value={stats.total}
+          note={`of ${tournament.max_participants} capacity`}
+        />
+        <StatCard
+          label="Confirmed"
+          value={stats.confirmed}
+          note="Paid"
+        />
+        <StatCard
+          label="Pending"
+          value={stats.pending}
+          note="Awaiting payment"
+        />
+      </div>
+
+      {/* Participants table */}
+      <div>
+        <div className="flex items-center justify-between mb-3 gap-3 flex-wrap">
+          <h2 className="font-cinzel text-base font-bold text-text-primary tracking-wide">
+            Participants ({stats.total})
+          </h2>
+          {participants.length > 0 && (
+            <input
+              type="text"
+              placeholder="Search by name or FIDE ID…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="input text-sm w-56"
+            />
+          )}
+        </div>
+
+        {participants.length === 0 ? (
+          <div className="card text-center py-10 px-5">
+            <p className="font-lato text-sm text-text-muted">
+              No registrations yet.
+            </p>
+          </div>
+        ) : (
+          <div className="card overflow-hidden overflow-x-auto">
+            <table className="w-full border-collapse min-w-[640px]">
+              <thead>
+                <tr className="border-b border-border bg-bg-raised">
+                  <th className="font-cinzel text-left px-4 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted w-10">
+                    #
+                  </th>
+                  <th className="font-cinzel text-left px-4 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted">
+                    Player
+                  </th>
+                  <th className="font-cinzel text-left px-4 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted whitespace-nowrap">
+                    FIDE ID
+                  </th>
+                  <th className="font-cinzel text-left px-4 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted">
+                    Rating
+                  </th>
+                  <th className="font-cinzel text-left px-4 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted whitespace-nowrap">
+                    Fee Tier
+                  </th>
+                  <th className="font-cinzel text-left px-4 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted">
+                    Status
+                  </th>
+                  <th className="font-cinzel text-left px-4 py-3 text-xs font-semibold tracking-widest uppercase text-text-muted whitespace-nowrap">
+                    Registered
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center font-lato text-sm text-text-muted">
+                      No participants match your search.
+                    </td>
+                  </tr>
+                ) : (
+                  filtered.map((p) => {
+                    const regStatus = REG_STATUS_CONFIG[p.status] ?? {
+                      label: toTitleCase(p.status),
+                      className: "bg-bg-raised text-text-muted border border-border",
+                    };
+                    return (
+                      <tr
+                        key={p.id}
+                        className="border-b border-border last:border-b-0 hover:bg-bg-raised transition-colors duration-100"
+                      >
+                        <td className="px-4 py-3">
+                          <span className="font-lato text-sm text-text-muted">{p.index}</span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className="font-lato text-sm font-semibold text-text-primary">
+                            {p.name}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className="font-lato text-sm text-text-secondary font-mono">
+                            {p.fide_id ?? "—"}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className="font-lato text-sm text-text-secondary">
+                            {p.rating ?? "—"}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className="font-lato text-sm text-text-secondary">
+                            {toTitleCase(p.fee_tier)}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2 py-0.5 rounded-md ${regStatus.className}`}
+                          >
+                            {regStatus.label}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className="font-lato text-sm text-text-secondary">
+                            {formatDateTime(p.registered_at)}
+                          </span>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/organizer/[orgId]/tournaments/[id]/edit/page.tsx
+++ b/src/app/organizer/[orgId]/tournaments/[id]/edit/page.tsx
@@ -1,0 +1,244 @@
+import { headers } from "next/headers";
+import { redirect, notFound } from "next/navigation";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import { createClient } from "@/services/supabase/server";
+import { TournamentWizardProvider } from "@/app/organizer/[orgId]/tournaments/create/_components/TournamentWizardContext";
+import type { PersistedState } from "@/app/organizer/[orgId]/tournaments/create/_components/TournamentWizardContext";
+import WizardShell from "@/app/organizer/[orgId]/tournaments/create/_components/WizardShell";
+
+export const metadata: Metadata = {
+  title: "Edit Tournament",
+  description: "Edit your tournament details.",
+};
+
+type ApiTierType = "early_bird" | "titled_players" | "rating_based" | "age_based" | "standard";
+
+interface AdditionalTier {
+  type: ApiTierType;
+  amount_cents: number;
+  valid_until?: string;
+  titles?: string[];
+  rating_from?: number;
+  rating_to?: number;
+  age_from?: number;
+  age_to?: number;
+}
+
+interface TournamentForEdit {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  start_date: string;
+  end_date: string;
+  registration_deadline: string;
+  venue: { name: string; state: string; address?: string | null };
+  format: { type?: string; system?: string; rounds?: number } | null;
+  time_control: { base_minutes?: number; increment_seconds?: number; delay_seconds?: number } | null;
+  is_fide_rated: boolean;
+  is_mcf_rated: boolean;
+  max_participants: number;
+  entry_fees: {
+    standard: { amount_cents: number };
+    additional?: AdditionalTier[];
+  } | null;
+  prizes: {
+    categories?: Array<{ name: string; entries: Array<{ placement: string; amount_cents: number }> }>;
+    special?: Array<{ name: string; amount_cents: number }>;
+  } | null;
+  restrictions: Array<{ type: string; value: string }> | null;
+}
+
+async function fetchTournamentForEdit(
+  orgId: string,
+  id: string,
+  cookieHeader: string,
+): Promise<TournamentForEdit | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+
+  try {
+    const res = await fetch(
+      `${baseUrl}/api/v1/organizer/${orgId}/tournaments/${id}`,
+      { cache: "no-store", headers: { cookie: cookieHeader } },
+    );
+    if (!res.ok) return null;
+    const json = await res.json();
+    return (json.data?.tournament as TournamentForEdit) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function toLocalDatetimeString(isoString: string): string {
+  const d = new Date(isoString);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function mapApiTierType(type: ApiTierType): "early-bird" | "titled" | "rating-based" | "age-based" {
+  switch (type) {
+    case "early_bird": return "early-bird";
+    case "titled_players": return "titled";
+    case "rating_based": return "rating-based";
+    case "age_based": return "age-based";
+    default: return "early-bird";
+  }
+}
+
+function buildInitialData(t: TournamentForEdit, orgId: string): PersistedState {
+  const basicInfoData = {
+    name: t.name,
+    description: t.description ?? "",
+    venueName: t.venue.name,
+    venueState: t.venue.state,
+    venueAddress: t.venue.address ?? "",
+  };
+
+  const restrictions = (t.restrictions ?? []).map((r, idx) => ({
+    id: `r-${idx}`,
+    type: r.type,
+    value: r.value,
+  }));
+
+  const formatData = {
+    formatType: t.format?.type
+      ? t.format.type.charAt(0).toUpperCase() + t.format.type.slice(1)
+      : "",
+    system: t.format?.system
+      ? t.format.system.charAt(0).toUpperCase() + t.format.system.slice(1)
+      : "",
+    rounds: t.format?.rounds ?? ("" as const),
+    baseTime: t.time_control?.base_minutes ?? ("" as const),
+    increment: t.time_control?.increment_seconds ?? 0,
+    delay: t.time_control?.delay_seconds ?? 0,
+    startDate: t.start_date,
+    endDate: t.end_date,
+    registrationDeadline: toLocalDatetimeString(t.registration_deadline),
+    maxParticipants: t.max_participants,
+    fideRated: t.is_fide_rated,
+    mcfRated: t.is_mcf_rated,
+    restrictions,
+  };
+
+  const additionalTiers = (t.entry_fees?.additional ?? [])
+    .filter((tier) => tier.type !== "standard")
+    .map((tier, idx) => ({
+      id: `tier-${idx}`,
+      type: mapApiTierType(tier.type),
+      amount: tier.amount_cents / 100,
+      validUntil: tier.valid_until ?? "",
+      titles: tier.titles ?? [],
+      ratingFrom: tier.rating_from ?? ("" as const),
+      ratingTo: tier.rating_to ?? ("" as const),
+      ageFrom: tier.age_from ?? ("" as const),
+      ageTo: tier.age_to ?? ("" as const),
+    }));
+
+  const feesData = {
+    standardFee: t.entry_fees?.standard
+      ? t.entry_fees.standard.amount_cents / 100
+      : ("" as const),
+    tiers: additionalTiers,
+  };
+
+  const prizeCategories = (t.prizes?.categories ?? []).map((cat, ci) => ({
+    id: `cat-${ci}`,
+    name: cat.name,
+    prizes: cat.entries.map((e, ei) => ({
+      id: `prize-${ci}-${ei}`,
+      placement: e.placement,
+      amount: e.amount_cents / 100,
+    })),
+  }));
+
+  const specialPrizes = (t.prizes?.special ?? []).map((sp, si) => ({
+    id: `sp-${si}`,
+    name: sp.name,
+    amount: sp.amount_cents / 100,
+  }));
+
+  const prizesData = {
+    categories: prizeCategories,
+    specialPrizes,
+  };
+
+  return {
+    basicInfoData,
+    formatData,
+    feesData,
+    prizesData,
+    tournamentId: t.id,
+    currentStepIndex: 0,
+    completedSteps: [],
+  };
+}
+
+async function fetchOrgName(
+  orgId: string,
+  cookieHeader: string,
+): Promise<string> {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/organizer/${orgId}/dashboard`, {
+      cache: "no-store",
+      headers: { cookie: cookieHeader },
+    });
+    if (!res.ok) return "Organization";
+    const json = await res.json();
+    return (json.data?.organization?.name as string) ?? "Organization";
+  } catch {
+    return "Organization";
+  }
+}
+
+export default async function EditTournamentPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; id: string }>;
+}) {
+  const { orgId, id } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/login");
+  }
+
+  const headersList = await headers();
+  const cookieHeader = headersList.get("cookie") ?? "";
+
+  const [tournament, orgName] = await Promise.all([
+    fetchTournamentForEdit(orgId, id, cookieHeader),
+    fetchOrgName(orgId, cookieHeader),
+  ]);
+
+  if (!tournament) {
+    notFound();
+  }
+
+  const initialData = buildInitialData(tournament, orgId);
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <TournamentWizardProvider
+        orgId={orgId}
+        initialData={initialData}
+        storageKeySuffix={`edit-${id}`}
+        excludeId={id}
+      >
+        <WizardShell
+          orgId={orgId}
+          orgName={orgName}
+          title="Edit Tournament"
+          redirectPath={`/organizer/${orgId}/tournaments/${id}`}
+          mode="edit"
+        />
+      </TournamentWizardProvider>
+    </div>
+  );
+}

--- a/src/app/organizer/[orgId]/tournaments/[id]/page.tsx
+++ b/src/app/organizer/[orgId]/tournaments/[id]/page.tsx
@@ -1,0 +1,110 @@
+import { headers } from "next/headers";
+import { redirect, notFound } from "next/navigation";
+import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import { createClient } from "@/services/supabase/server";
+import TournamentManageClient from "./_components/TournamentManageClient";
+
+interface Participant {
+  index: number;
+  id: string;
+  user_id: string;
+  name: string;
+  fide_id: number | null;
+  rating: number | null;
+  fee_tier: string;
+  status: string;
+  registered_at: string;
+}
+
+interface TournamentManageData {
+  tournament: {
+    id: string;
+    name: string;
+    status: "draft" | "published" | "ongoing" | "completed" | "cancelled";
+    start_date: string;
+    end_date: string;
+    venue: { name: string; state: string; address?: string | null };
+    format: { type?: string; system?: string; rounds?: number } | null;
+    max_participants: number;
+  };
+  stats: { total: number; confirmed: number; pending: number };
+  participants: Participant[];
+}
+
+async function fetchTournamentManage(
+  orgId: string,
+  id: string,
+  cookieHeader: string,
+): Promise<TournamentManageData | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+
+  try {
+    const res = await fetch(
+      `${baseUrl}/api/v1/organizer/${orgId}/tournaments/${id}`,
+      {
+        cache: "no-store",
+        headers: { cookie: cookieHeader },
+      },
+    );
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ orgId: string; id: string }>;
+}): Promise<Metadata> {
+  const { orgId, id } = await params;
+  const headersList = await headers();
+  const cookieHeader = headersList.get("cookie") ?? "";
+  const data = await fetchTournamentManage(orgId, id, cookieHeader);
+
+  return {
+    title: data ? `Manage: ${data.tournament.name}` : "Tournament",
+    description: "Manage your tournament registrations and participants.",
+  };
+}
+
+export default async function TournamentManagePage({
+  params,
+}: {
+  params: Promise<{ orgId: string; id: string }>;
+}) {
+  const { orgId, id } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/login");
+  }
+
+  const headersList = await headers();
+  const cookieHeader = headersList.get("cookie") ?? "";
+
+  const data = await fetchTournamentManage(orgId, id, cookieHeader);
+
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-base">
+      <NavBar />
+      <TournamentManageClient
+        orgId={orgId}
+        tournament={data.tournament}
+        stats={data.stats}
+        participants={data.participants}
+      />
+    </div>
+  );
+}

--- a/src/app/organizer/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
@@ -9,12 +9,7 @@ import {
   useState,
 } from "react";
 
-type WizardStepId =
-  | "basic-info"
-  | "format"
-  | "fees"
-  | "prizes"
-  | "review";
+type WizardStepId = "basic-info" | "format" | "fees" | "prizes" | "review";
 
 export interface WizardStep {
   id: WizardStepId;
@@ -149,7 +144,10 @@ function storageKey(orgId: string, suffix?: string) {
   return `tournament-wizard-${orgId}${suffix ? `-${suffix}` : ""}`;
 }
 
-function loadFromStorage(orgId: string, suffix?: string): PersistedState | null {
+function loadFromStorage(
+  orgId: string,
+  suffix?: string,
+): PersistedState | null {
   try {
     const raw = sessionStorage.getItem(storageKey(orgId, suffix));
     if (!raw) return null;
@@ -159,7 +157,11 @@ function loadFromStorage(orgId: string, suffix?: string): PersistedState | null 
   }
 }
 
-function saveToStorage(orgId: string, state: PersistedState, suffix?: string): void {
+function saveToStorage(
+  orgId: string,
+  state: PersistedState,
+  suffix?: string,
+): void {
   try {
     sessionStorage.setItem(storageKey(orgId, suffix), JSON.stringify(state));
   } catch {}
@@ -206,17 +208,12 @@ export function TournamentWizardProvider({
   excludeId?: string | null;
 }) {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState<Set<number>>(
-    new Set(),
-  );
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
   const [basicInfoData, setBasicInfoData] =
     useState<BasicInfoData>(initialBasicInfo);
-  const [formatData, setFormatData] =
-    useState<FormatData>(initialFormatData);
-  const [feesData, setFeesData] =
-    useState<FeesData>(initialFeesData);
-  const [prizesData, setPrizesData] =
-    useState<PrizesData>(initialPrizesData);
+  const [formatData, setFormatData] = useState<FormatData>(initialFormatData);
+  const [feesData, setFeesData] = useState<FeesData>(initialFeesData);
+  const [prizesData, setPrizesData] = useState<PrizesData>(initialPrizesData);
   const [tournamentId, setTournamentId] = useState<string | null>(null);
 
   // isHydrated gates the persist effect so it never runs before the load
@@ -230,7 +227,10 @@ export function TournamentWizardProvider({
 
   // Restore persisted state once on mount (client-only, no SSR sessionStorage).
   useEffect(() => {
-    const saved = loadFromStorage(orgIdRef.current, storageKeySuffixRef.current) ?? initialDataRef.current ?? null;
+    const saved =
+      loadFromStorage(orgIdRef.current, storageKeySuffixRef.current) ??
+      initialDataRef.current ??
+      null;
     if (saved) {
       setBasicInfoData(saved.basicInfoData ?? initialBasicInfo);
       setFormatData(saved.formatData ?? initialFormatData);
@@ -249,15 +249,19 @@ export function TournamentWizardProvider({
   // but only after the initial load has completed.
   useEffect(() => {
     if (!isHydrated) return;
-    saveToStorage(orgId, {
-      basicInfoData,
-      formatData,
-      feesData,
-      prizesData,
-      tournamentId,
-      currentStepIndex,
-      completedSteps: [...completedSteps],
-    }, storageKeySuffix);
+    saveToStorage(
+      orgId,
+      {
+        basicInfoData,
+        formatData,
+        feesData,
+        prizesData,
+        tournamentId,
+        currentStepIndex,
+        completedSteps: [...completedSteps],
+      },
+      storageKeySuffix,
+    );
   }, [
     isHydrated,
     orgId,
@@ -284,21 +288,18 @@ export function TournamentWizardProvider({
     [],
   );
 
-  const triggerStepHandler = useCallback(
-    async (index: number) => {
-      const handler = stepHandlers.current[index];
-      if (handler) {
-        await handler();
-      } else {
-        setCurrentStepIndex((prev) => {
-          const next = Math.min(prev + 1, WIZARD_STEPS.length - 1);
-          setCompletedSteps((done) => new Set(done).add(prev));
-          return next;
-        });
-      }
-    },
-    [],
-  );
+  const triggerStepHandler = useCallback(async (index: number) => {
+    const handler = stepHandlers.current[index];
+    if (handler) {
+      await handler();
+    } else {
+      setCurrentStepIndex((prev) => {
+        const next = Math.min(prev + 1, WIZARD_STEPS.length - 1);
+        setCompletedSteps((done) => new Set(done).add(prev));
+        return next;
+      });
+    }
+  }, []);
 
   const markStepDone = useCallback((index: number) => {
     setCompletedSteps((prev) => new Set(prev).add(index));

--- a/src/app/organizer/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
@@ -135,7 +135,7 @@ const initialFormatData: FormatData = {
   restrictions: [],
 };
 
-interface PersistedState {
+export interface PersistedState {
   basicInfoData: BasicInfoData;
   formatData: FormatData;
   feesData: FeesData;
@@ -145,13 +145,13 @@ interface PersistedState {
   completedSteps: number[];
 }
 
-function storageKey(orgId: string) {
-  return `tournament-wizard-${orgId}`;
+function storageKey(orgId: string, suffix?: string) {
+  return `tournament-wizard-${orgId}${suffix ? `-${suffix}` : ""}`;
 }
 
-function loadFromStorage(orgId: string): PersistedState | null {
+function loadFromStorage(orgId: string, suffix?: string): PersistedState | null {
   try {
-    const raw = sessionStorage.getItem(storageKey(orgId));
+    const raw = sessionStorage.getItem(storageKey(orgId, suffix));
     if (!raw) return null;
     return JSON.parse(raw) as PersistedState;
   } catch {
@@ -159,9 +159,9 @@ function loadFromStorage(orgId: string): PersistedState | null {
   }
 }
 
-function saveToStorage(orgId: string, state: PersistedState): void {
+function saveToStorage(orgId: string, state: PersistedState, suffix?: string): void {
   try {
-    sessionStorage.setItem(storageKey(orgId), JSON.stringify(state));
+    sessionStorage.setItem(storageKey(orgId, suffix), JSON.stringify(state));
   } catch {}
 }
 
@@ -185,6 +185,7 @@ interface TournamentWizardContextType {
   registerStepHandler: (index: number, handler: () => Promise<void>) => void;
   triggerStepHandler: (index: number) => Promise<void>;
   clearWizardStorage: () => void;
+  excludeId: string | null;
 }
 
 const TournamentWizardContext =
@@ -193,9 +194,15 @@ const TournamentWizardContext =
 export function TournamentWizardProvider({
   orgId,
   children,
+  initialData,
+  storageKeySuffix,
+  excludeId = null,
 }: {
   orgId: string;
   children: React.ReactNode;
+  initialData?: PersistedState;
+  storageKeySuffix?: string;
+  excludeId?: string | null;
 }) {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(
@@ -216,11 +223,13 @@ export function TournamentWizardProvider({
   const [isHydrated, setIsHydrated] = useState(false);
 
   const orgIdRef = useRef(orgId);
+  const storageKeySuffixRef = useRef(storageKeySuffix);
+  const initialDataRef = useRef(initialData);
   const stepHandlers = useRef<Record<number, () => Promise<void>>>({});
 
   // Restore persisted state once on mount (client-only, no SSR sessionStorage).
   useEffect(() => {
-    const saved = loadFromStorage(orgIdRef.current);
+    const saved = loadFromStorage(orgIdRef.current, storageKeySuffixRef.current) ?? initialDataRef.current ?? null;
     if (saved) {
       setBasicInfoData(saved.basicInfoData ?? initialBasicInfo);
       setFormatData(saved.formatData ?? initialFormatData);
@@ -247,10 +256,11 @@ export function TournamentWizardProvider({
       tournamentId,
       currentStepIndex,
       completedSteps: [...completedSteps],
-    });
+    }, storageKeySuffix);
   }, [
     isHydrated,
     orgId,
+    storageKeySuffix,
     basicInfoData,
     formatData,
     feesData,
@@ -262,9 +272,9 @@ export function TournamentWizardProvider({
 
   const clearWizardStorage = useCallback(() => {
     try {
-      sessionStorage.removeItem(storageKey(orgId));
+      sessionStorage.removeItem(storageKey(orgId, storageKeySuffix));
     } catch {}
-  }, [orgId]);
+  }, [orgId, storageKeySuffix]);
 
   const registerStepHandler = useCallback(
     (index: number, handler: () => Promise<void>) => {
@@ -336,6 +346,7 @@ export function TournamentWizardProvider({
         registerStepHandler,
         triggerStepHandler,
         clearWizardStorage,
+        excludeId,
       }}
     >
       {children}

--- a/src/app/organizer/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
@@ -186,6 +186,7 @@ interface TournamentWizardContextType {
   triggerStepHandler: (index: number) => Promise<void>;
   clearWizardStorage: () => void;
   excludeId: string | null;
+  isHydrated: boolean;
 }
 
 const TournamentWizardContext =
@@ -347,6 +348,7 @@ export function TournamentWizardProvider({
         triggerStepHandler,
         clearWizardStorage,
         excludeId,
+        isHydrated,
       }}
     >
       {children}

--- a/src/app/organizer/[orgId]/tournaments/create/_components/WizardShell.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/WizardShell.tsx
@@ -25,6 +25,9 @@ const STEP_COMPONENTS = [
 interface WizardShellProps {
   orgId: string;
   orgName: string;
+  title?: string;
+  redirectPath?: string;
+  mode?: "create" | "edit";
 }
 
 function mapTierType(t: FeeTier["type"]): string {
@@ -40,7 +43,7 @@ function mapTierType(t: FeeTier["type"]): string {
   }
 }
 
-export default function WizardShell({ orgId, orgName }: WizardShellProps) {
+export default function WizardShell({ orgId, orgName, title = "Create Tournament", redirectPath, mode = "create" }: WizardShellProps) {
   const router = useRouter();
   const {
     currentStepIndex,
@@ -183,10 +186,12 @@ export default function WizardShell({ orgId, orgName }: WizardShellProps) {
     return json.data.id;
   }
 
+  const afterSaveRedirect = redirectPath ?? `/organizer/${orgId}/dashboard`;
+
   async function handleSaveDraft() {
     if (!basicInfoData.name.trim()) {
       clearWizardStorage();
-      router.push(`/organizer/${orgId}/dashboard`);
+      router.push(afterSaveRedirect);
       return;
     }
     setIsSaving(true);
@@ -196,7 +201,7 @@ export default function WizardShell({ orgId, orgName }: WizardShellProps) {
     } finally {
       setIsSaving(false);
       clearWizardStorage();
-      router.push(`/organizer/${orgId}/dashboard`);
+      router.push(afterSaveRedirect);
     }
   }
 
@@ -205,7 +210,7 @@ export default function WizardShell({ orgId, orgName }: WizardShellProps) {
     setIsPublishing(true);
     try {
       if (!basicInfoData.name.trim()) {
-        router.push(`/organizer/${orgId}/dashboard`);
+        router.push(afterSaveRedirect);
         return;
       }
       const draftId = await saveDraftToApi();
@@ -231,7 +236,7 @@ export default function WizardShell({ orgId, orgName }: WizardShellProps) {
         return;
       }
       clearWizardStorage();
-      router.push(`/organizer/${orgId}/dashboard`);
+      router.push(afterSaveRedirect);
     } finally {
       setIsPublishing(false);
     }
@@ -248,7 +253,7 @@ export default function WizardShell({ orgId, orgName }: WizardShellProps) {
           {orgName}
         </p>
         <h1 className="font-cinzel text-xl font-bold text-text-primary tracking-wide">
-          Create Tournament
+          {title}
         </h1>
       </div>
 
@@ -287,7 +292,20 @@ export default function WizardShell({ orgId, orgName }: WizardShellProps) {
               {isSaving ? "Saving…" : "Save Draft"}
             </button>
 
-            {isLastStep ? (
+            {isLastStep && mode === "edit" ? (
+              <button
+                type="button"
+                className="font-cinzel text-bg-base cursor-pointer rounded-md border-0 px-5 py-2 text-xs font-bold tracking-widest uppercase transition duration-200 hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{
+                  background:
+                    "linear-gradient(135deg, var(--color-gold-bright), var(--color-gold-deep))",
+                }}
+                onClick={handleSaveDraft}
+                disabled={isSaving}
+              >
+                {isSaving ? "Saving…" : "Save Changes"}
+              </button>
+            ) : isLastStep ? (
               <button
                 type="button"
                 className="font-cinzel text-bg-base cursor-pointer rounded-md border-0 px-5 py-2 text-xs font-bold tracking-widest uppercase transition duration-200 hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"

--- a/src/app/organizer/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
@@ -74,10 +74,16 @@ function validate(
 }
 
 export default function BasicInfoStep() {
-  const { setBasicInfoData, basicInfoData, goNext, registerStepHandler, excludeId } =
+  const { setBasicInfoData, basicInfoData, goNext, registerStepHandler, excludeId, isHydrated } =
     useTournamentWizard();
 
   const [form, setForm] = useState<BasicInfoData>(basicInfoData);
+
+  useEffect(() => {
+    if (isHydrated) setForm(basicInfoData);
+    // intentionally runs once when context finishes hydrating
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHydrated]);
   const [nameStatus, setNameStatus] = useState<NameStatus>("idle");
   const [errors, setErrors] = useState<FieldErrors>({});
   const [showErrors, setShowErrors] = useState(false);

--- a/src/app/organizer/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
@@ -32,9 +32,15 @@ type FieldErrors = {
   venueAddress?: string;
 };
 
-async function checkNameAvailability(name: string, excludeId?: string | null): Promise<NameStatus> {
+async function checkNameAvailability(
+  name: string,
+  excludeId?: string | null,
+): Promise<NameStatus> {
   try {
-    const url = new URL("/api/v1/tournaments/name-check", window.location.origin);
+    const url = new URL(
+      "/api/v1/tournaments/name-check",
+      window.location.origin,
+    );
     url.searchParams.set("name", name);
     if (excludeId) url.searchParams.set("excludeId", excludeId);
     const res = await fetch(url.toString());
@@ -46,10 +52,7 @@ async function checkNameAvailability(name: string, excludeId?: string | null): P
   }
 }
 
-function validate(
-  data: BasicInfoData,
-  nameStatus: NameStatus,
-): FieldErrors {
+function validate(data: BasicInfoData, nameStatus: NameStatus): FieldErrors {
   const errors: FieldErrors = {};
 
   if (!data.name.trim()) {
@@ -74,8 +77,14 @@ function validate(
 }
 
 export default function BasicInfoStep() {
-  const { setBasicInfoData, basicInfoData, goNext, registerStepHandler, excludeId, isHydrated } =
-    useTournamentWizard();
+  const {
+    setBasicInfoData,
+    basicInfoData,
+    goNext,
+    registerStepHandler,
+    excludeId,
+    isHydrated,
+  } = useTournamentWizard();
 
   const [form, setForm] = useState<BasicInfoData>(basicInfoData);
 
@@ -109,9 +118,15 @@ export default function BasicInfoStep() {
 
     let currentNameStatus = nameStatus;
 
-    if (form.name.trim() && (nameStatus === "idle" || nameStatus === "checking")) {
+    if (
+      form.name.trim() &&
+      (nameStatus === "idle" || nameStatus === "checking")
+    ) {
       setNameStatus("checking");
-      currentNameStatus = await checkNameAvailability(form.name.trim(), excludeId);
+      currentNameStatus = await checkNameAvailability(
+        form.name.trim(),
+        excludeId,
+      );
       setNameStatus(currentNameStatus);
     }
 
@@ -140,10 +155,10 @@ export default function BasicInfoStep() {
 
   return (
     <div>
-      <h2 className="font-cinzel mb-1 text-lg font-bold text-text-primary tracking-wide">
+      <h2 className="font-cinzel text-text-primary mb-1 text-lg font-bold tracking-wide">
         Basic Information
       </h2>
-      <p className="font-lato mb-6 text-sm text-text-muted">
+      <p className="font-lato text-text-muted mb-6 text-sm">
         Tell players what your tournament is about and where it&apos;s held.
       </p>
 
@@ -153,7 +168,9 @@ export default function BasicInfoStep() {
           <label htmlFor="tournament-name" className="input-label">
             Tournament Name
           </label>
-          <span aria-hidden="true" className="text-danger text-sm ml-0.5">*</span>
+          <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
+            *
+          </span>
         </div>
         <div className="relative">
           <input
@@ -167,12 +184,12 @@ export default function BasicInfoStep() {
             autoComplete="off"
           />
           {nameStatus === "checking" && (
-            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted text-xs">
+            <span className="text-text-muted absolute top-1/2 right-3 -translate-y-1/2 text-xs">
               …
             </span>
           )}
           {nameStatus === "available" && form.name.trim() && (
-            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-success text-sm">
+            <span className="text-success absolute top-1/2 right-3 -translate-y-1/2 text-sm">
               ✓
             </span>
           )}
@@ -212,7 +229,9 @@ export default function BasicInfoStep() {
             <label htmlFor="venue-name" className="input-label">
               Venue Name
             </label>
-            <span aria-hidden="true" className="text-danger text-sm ml-0.5">*</span>
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
+              *
+            </span>
           </div>
           <input
             id="venue-name"
@@ -233,7 +252,9 @@ export default function BasicInfoStep() {
             <label htmlFor="venue-state" className="input-label">
               State
             </label>
-            <span aria-hidden="true" className="text-danger text-sm ml-0.5">*</span>
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
+              *
+            </span>
           </div>
           <select
             id="venue-state"
@@ -260,7 +281,9 @@ export default function BasicInfoStep() {
           <label htmlFor="venue-address" className="input-label">
             Venue Address
           </label>
-          <span aria-hidden="true" className="text-danger text-sm ml-0.5">*</span>
+          <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
+            *
+          </span>
         </div>
         <input
           id="venue-address"

--- a/src/app/organizer/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
@@ -32,11 +32,12 @@ type FieldErrors = {
   venueAddress?: string;
 };
 
-async function checkNameAvailability(name: string): Promise<NameStatus> {
+async function checkNameAvailability(name: string, excludeId?: string | null): Promise<NameStatus> {
   try {
-    const res = await fetch(
-      `/api/v1/tournaments/name-check?name=${encodeURIComponent(name)}`,
-    );
+    const url = new URL("/api/v1/tournaments/name-check", window.location.origin);
+    url.searchParams.set("name", name);
+    if (excludeId) url.searchParams.set("excludeId", excludeId);
+    const res = await fetch(url.toString());
     if (!res.ok) return "error";
     const json = await res.json();
     return json.available ? "available" : "taken";
@@ -73,7 +74,7 @@ function validate(
 }
 
 export default function BasicInfoStep() {
-  const { setBasicInfoData, basicInfoData, goNext, registerStepHandler } =
+  const { setBasicInfoData, basicInfoData, goNext, registerStepHandler, excludeId } =
     useTournamentWizard();
 
   const [form, setForm] = useState<BasicInfoData>(basicInfoData);
@@ -92,7 +93,7 @@ export default function BasicInfoStep() {
 
     nameCheckTimer.current = setTimeout(async () => {
       setNameStatus("checking");
-      const status = await checkNameAvailability(value.trim());
+      const status = await checkNameAvailability(value.trim(), excludeId);
       setNameStatus(status);
     }, 600);
   };
@@ -104,7 +105,7 @@ export default function BasicInfoStep() {
 
     if (form.name.trim() && (nameStatus === "idle" || nameStatus === "checking")) {
       setNameStatus("checking");
-      currentNameStatus = await checkNameAvailability(form.name.trim());
+      currentNameStatus = await checkNameAvailability(form.name.trim(), excludeId);
       setNameStatus(currentNameStatus);
     }
 

--- a/src/app/organizer/[orgId]/tournaments/create/_components/steps/FeesStep.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/steps/FeesStep.tsx
@@ -114,9 +114,9 @@ function NetBreakdown({ amount }: { amount: number | "" }) {
   const isFree = revenue === 0;
 
   return (
-    <div className="flex flex-wrap gap-5 items-center mt-3 px-3.5 py-2.5 bg-bg-base border border-border rounded-md">
+    <div className="bg-bg-base border-border mt-3 flex flex-wrap items-center gap-5 rounded-md border px-3.5 py-2.5">
       <div className="flex flex-col gap-0.5">
-        <span className="font-cinzel text-text-muted text-[10px] uppercase tracking-widest">
+        <span className="font-cinzel text-text-muted text-[10px] tracking-widest uppercase">
           Your revenue
         </span>
         <span className="font-lato text-text-body text-sm tabular-nums">
@@ -125,7 +125,7 @@ function NetBreakdown({ amount }: { amount: number | "" }) {
       </div>
       <span className="text-text-disabled text-sm">+</span>
       <div className="flex flex-col gap-0.5">
-        <span className="font-cinzel text-text-muted text-[10px] uppercase tracking-widest">
+        <span className="font-cinzel text-text-muted text-[10px] tracking-widest uppercase">
           Commission (10%)
         </span>
         <span className="font-lato text-text-body text-sm tabular-nums">
@@ -134,7 +134,7 @@ function NetBreakdown({ amount }: { amount: number | "" }) {
       </div>
       <span className="text-text-disabled text-sm">=</span>
       <div className="flex flex-col gap-0.5">
-        <span className="font-cinzel text-text-muted text-[10px] uppercase tracking-widest">
+        <span className="font-cinzel text-text-muted text-[10px] tracking-widest uppercase">
           Player pays
         </span>
         <span
@@ -194,15 +194,15 @@ function TierCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="bg-bg-raised border border-border rounded-lg p-4">
-      <div className="flex justify-between items-center mb-3">
+    <div className="bg-bg-raised border-border rounded-lg border p-4">
+      <div className="mb-3 flex items-center justify-between">
         <span className="font-cinzel text-text-primary text-sm font-semibold">
           {label}
         </span>
         <button
           type="button"
           aria-label={`Remove ${label} tier`}
-          className="border-border text-text-muted hover:text-danger hover:border-danger-border flex items-center justify-center rounded-md border bg-transparent transition duration-200 cursor-pointer"
+          className="border-border text-text-muted hover:text-danger hover:border-danger-border flex cursor-pointer items-center justify-center rounded-md border bg-transparent transition duration-200"
           style={{ width: "28px", height: "28px", flexShrink: 0 }}
           onClick={onRemove}
         >
@@ -216,7 +216,7 @@ function TierCard({
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
   return (
-    <h3 className="font-cinzel text-gold-muted text-xs font-bold tracking-widest uppercase mt-0 mb-1 pt-4 border-t border-border">
+    <h3 className="font-cinzel text-gold-muted border-border mt-0 mb-1 border-t pt-4 text-xs font-bold tracking-widest uppercase">
       {children}
     </h3>
   );
@@ -285,8 +285,7 @@ export default function FeesStep() {
     const fieldErrors = validate(form);
     setErrors(fieldErrors);
     const hasErrors =
-      !!fieldErrors.standardFee ||
-      Object.keys(fieldErrors.tiers).length > 0;
+      !!fieldErrors.standardFee || Object.keys(fieldErrors.tiers).length > 0;
     if (hasErrors) return;
     setFeesData(form);
     goNext();
@@ -304,17 +303,17 @@ export default function FeesStep() {
 
   return (
     <div>
-      <h2 className="font-cinzel mb-1 text-lg font-bold text-text-primary tracking-wide">
+      <h2 className="font-cinzel text-text-primary mb-1 text-lg font-bold tracking-wide">
         Entry Fees
       </h2>
-      <p className="font-lato mb-6 text-sm text-text-muted">
+      <p className="font-lato text-text-muted mb-6 text-sm">
         Set the standard fee, then add optional tiers for early bird, titled
         players, rating-based, or age-based discounts.
       </p>
 
       {/* Commission info banner */}
-      <div className="flex items-start gap-2.5 mb-5 px-3.5 py-3 bg-bg-raised border border-border rounded-md">
-        <span className="text-base shrink-0 leading-snug">ℹ️</span>
+      <div className="bg-bg-raised border-border mb-5 flex items-start gap-2.5 rounded-md border px-3.5 py-3">
+        <span className="shrink-0 text-base leading-snug">ℹ️</span>
         <p className="font-lato text-text-muted text-xs leading-relaxed">
           A{" "}
           <strong className="text-text-secondary font-semibold">
@@ -326,11 +325,11 @@ export default function FeesStep() {
       </div>
 
       {/* Standard Fee */}
-      <h3 className="font-cinzel text-gold-muted text-xs font-bold tracking-widest uppercase mb-3">
+      <h3 className="font-cinzel text-gold-muted mb-3 text-xs font-bold tracking-widest uppercase">
         Standard Fee
       </h3>
-      <div className="bg-bg-raised border border-border rounded-lg p-4 mb-6">
-        <div className="flex flex-wrap items-center gap-3 mb-1.5">
+      <div className="bg-bg-raised border-border mb-6 rounded-lg border p-4">
+        <div className="mb-1.5 flex flex-wrap items-center gap-3">
           <span
             className="font-cinzel text-text-secondary text-sm font-semibold"
             style={{ minWidth: "90px" }}
@@ -353,12 +352,13 @@ export default function FeesStep() {
 
       {/* Additional Fee Tiers */}
       <SectionHeader>Additional Fee Tiers</SectionHeader>
-      <p className="font-lato text-text-muted text-xs mb-4">
-        Optional. Players who qualify will see these options during registration.
+      <p className="font-lato text-text-muted mb-4 text-xs">
+        Optional. Players who qualify will see these options during
+        registration.
       </p>
 
       {form.tiers.length > 0 && (
-        <div className="flex flex-col gap-3 mb-4">
+        <div className="mb-4 flex flex-col gap-3">
           {form.tiers.map((tier) => {
             const te = errors.tiers[tier.id] ?? {};
 
@@ -369,7 +369,7 @@ export default function FeesStep() {
                   label={TIER_LABELS[tier.type]}
                   onRemove={() => removeTier(tier.id)}
                 >
-                  <div className="flex flex-wrap gap-3 items-start mb-1.5">
+                  <div className="mb-1.5 flex flex-wrap items-start gap-3">
                     <AmountField
                       id={`${tier.id}-amount`}
                       value={tier.amount}
@@ -411,26 +411,26 @@ export default function FeesStep() {
                   label={TIER_LABELS[tier.type]}
                   onRemove={() => removeTier(tier.id)}
                 >
-                  <div className="flex flex-wrap gap-3 items-start mb-3">
+                  <div className="mb-3 flex flex-wrap items-start gap-3">
                     <AmountField
                       id={`${tier.id}-amount`}
                       value={tier.amount}
                       onChange={(v) => updateTier(tier.id, { amount: v })}
                       error={showErrors ? te.amount : undefined}
                     />
-                    <div className="flex-1 min-w-[220px]">
-                      <p className="font-lato text-text-muted text-xs mb-2">
+                    <div className="min-w-[220px] flex-1">
+                      <p className="font-lato text-text-muted mb-2 text-xs">
                         Applies to titles:
                       </p>
                       <div className="flex flex-wrap gap-x-4 gap-y-2">
                         {CHESS_TITLES.map((title) => (
                           <label
                             key={title}
-                            className="flex items-center gap-1.5 cursor-pointer select-none"
+                            className="flex cursor-pointer items-center gap-1.5 select-none"
                           >
                             <input
                               type="checkbox"
-                              className="accent-gold-bright w-3.5 h-3.5 cursor-pointer"
+                              className="accent-gold-bright h-3.5 w-3.5 cursor-pointer"
                               checked={tier.titles.includes(title)}
                               onChange={(e) => {
                                 const next = e.target.checked
@@ -462,7 +462,7 @@ export default function FeesStep() {
                   label={TIER_LABELS[tier.type]}
                   onRemove={() => removeTier(tier.id)}
                 >
-                  <div className="flex flex-wrap gap-3 items-start mb-1.5">
+                  <div className="mb-1.5 flex flex-wrap items-start gap-3">
                     <AmountField
                       id={`${tier.id}-amount`}
                       value={tier.amount}
@@ -479,7 +479,9 @@ export default function FeesStep() {
                           className={`input text-center tabular-nums ${showErrors && te.ratingFrom ? "input-error" : ""}`}
                           style={{ width: "80px" }}
                           value={
-                            tier.ratingFrom === "" ? "" : String(tier.ratingFrom)
+                            tier.ratingFrom === ""
+                              ? ""
+                              : String(tier.ratingFrom)
                           }
                           min={0}
                           onChange={(e) => {
@@ -531,7 +533,7 @@ export default function FeesStep() {
                   label={TIER_LABELS[tier.type]}
                   onRemove={() => removeTier(tier.id)}
                 >
-                  <div className="flex flex-wrap gap-3 items-start mb-1.5">
+                  <div className="mb-1.5 flex flex-wrap items-start gap-3">
                     <AmountField
                       id={`${tier.id}-amount`}
                       value={tier.amount}
@@ -547,7 +549,9 @@ export default function FeesStep() {
                           type="number"
                           className={`input text-center tabular-nums ${showErrors && te.ageFrom ? "input-error" : ""}`}
                           style={{ width: "70px" }}
-                          value={tier.ageFrom === "" ? "" : String(tier.ageFrom)}
+                          value={
+                            tier.ageFrom === "" ? "" : String(tier.ageFrom)
+                          }
                           min={0}
                           onChange={(e) => {
                             const raw = e.target.value;
@@ -608,14 +612,14 @@ export default function FeesStep() {
           </button>
           {dropdownOpen && (
             <div
-              className="absolute top-[calc(100%+4px)] left-0 bg-bg-surface border border-border rounded-lg py-1.5 min-w-44 z-10"
+              className="bg-bg-surface border-border absolute top-[calc(100%+4px)] left-0 z-10 min-w-44 rounded-lg border py-1.5"
               style={{ boxShadow: "0 4px 16px rgba(0,0,0,0.4)" }}
             >
               {availableTypes.map((t) => (
                 <button
                   key={t}
                   type="button"
-                  className="font-lato w-full text-left px-3.5 py-2 text-sm text-text-body hover:bg-int-gold-bg transition duration-100 cursor-pointer border-0 bg-transparent"
+                  className="font-lato text-text-body hover:bg-int-gold-bg w-full cursor-pointer border-0 bg-transparent px-3.5 py-2 text-left text-sm transition duration-100"
                   onClick={() => addTier(t)}
                 >
                   {TIER_LABELS[t]}
@@ -627,7 +631,7 @@ export default function FeesStep() {
       )}
 
       {/* Tip */}
-      <div className="mt-5 px-3.5 py-3 bg-int-gold-bg border border-gold-ghost rounded-md">
+      <div className="bg-int-gold-bg border-gold-ghost mt-5 rounded-md border px-3.5 py-3">
         <p className="font-lato text-gold-muted text-xs leading-relaxed">
           💡 Players will see the fee tiers they qualify for during
           registration. The breakdown updates automatically as you change

--- a/src/app/organizer/[orgId]/tournaments/create/_components/steps/FeesStep.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/steps/FeesStep.tsx
@@ -223,10 +223,15 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 }
 
 export default function FeesStep() {
-  const { feesData, setFeesData, goNext, registerStepHandler } =
+  const { feesData, setFeesData, goNext, registerStepHandler, isHydrated } =
     useTournamentWizard();
 
   const [form, setForm] = useState<FeesData>(feesData);
+
+  useEffect(() => {
+    if (isHydrated) setForm(feesData);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHydrated]);
   const [errors, setErrors] = useState<FeesErrors>({ tiers: {} });
   const [showErrors, setShowErrors] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);

--- a/src/app/organizer/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
@@ -93,10 +93,15 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 }
 
 export default function FormatStep() {
-  const { formatData, setFormatData, goNext, registerStepHandler } =
+  const { formatData, setFormatData, goNext, registerStepHandler, isHydrated } =
     useTournamentWizard();
 
   const [form, setForm] = useState<FormatData>(formatData);
+
+  useEffect(() => {
+    if (isHydrated) setForm(formatData);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHydrated]);
   const [errors, setErrors] = useState<FieldErrors>({});
   const [showErrors, setShowErrors] = useState(false);
   const uid = useId();

--- a/src/app/organizer/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
@@ -86,7 +86,7 @@ function validate(data: FormatData): FieldErrors {
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
   return (
-    <h3 className="font-cinzel text-gold-muted text-xs font-bold tracking-widest uppercase mt-6 mb-3 pt-5 border-t border-border">
+    <h3 className="font-cinzel text-gold-muted border-border mt-6 mb-3 border-t pt-5 text-xs font-bold tracking-widest uppercase">
       {children}
     </h3>
   );
@@ -163,10 +163,10 @@ export default function FormatStep() {
 
   return (
     <div>
-      <h2 className="font-cinzel mb-1 text-lg font-bold text-text-primary tracking-wide">
+      <h2 className="font-cinzel text-text-primary mb-1 text-lg font-bold tracking-wide">
         Format &amp; Schedule
       </h2>
-      <p className="font-lato mb-6 text-sm text-text-muted">
+      <p className="font-lato text-text-muted mb-6 text-sm">
         Define the tournament format, time control, and schedule.
       </p>
 
@@ -177,7 +177,7 @@ export default function FormatStep() {
             <label htmlFor={`${uid}-format-type`} className="input-label">
               Format Type
             </label>
-            <span aria-hidden="true" className="text-danger text-sm ml-0.5">
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
               *
             </span>
           </div>
@@ -204,7 +204,7 @@ export default function FormatStep() {
             <label htmlFor={`${uid}-system`} className="input-label">
               System
             </label>
-            <span aria-hidden="true" className="text-danger text-sm ml-0.5">
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
               *
             </span>
           </div>
@@ -233,7 +233,7 @@ export default function FormatStep() {
           <label htmlFor={`${uid}-rounds`} className="input-label">
             Number of Rounds
           </label>
-          <span aria-hidden="true" className="text-danger text-sm ml-0.5">
+          <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
             *
           </span>
         </div>
@@ -262,7 +262,7 @@ export default function FormatStep() {
             <label htmlFor={`${uid}-base-time`} className="input-label">
               Base Time (min)
             </label>
-            <span aria-hidden="true" className="text-danger text-sm ml-0.5">
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
               *
             </span>
           </div>
@@ -332,7 +332,7 @@ export default function FormatStep() {
             <label htmlFor={`${uid}-start-date`} className="input-label">
               Start Date
             </label>
-            <span aria-hidden="true" className="text-danger text-sm ml-0.5">
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
               *
             </span>
           </div>
@@ -353,7 +353,7 @@ export default function FormatStep() {
             <label htmlFor={`${uid}-end-date`} className="input-label">
               End Date
             </label>
-            <span aria-hidden="true" className="text-danger text-sm ml-0.5">
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
               *
             </span>
           </div>
@@ -376,7 +376,7 @@ export default function FormatStep() {
             <label htmlFor={`${uid}-reg-deadline`} className="input-label">
               Registration Deadline
             </label>
-            <span aria-hidden="true" className="text-danger text-sm ml-0.5">
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
               *
             </span>
           </div>
@@ -397,7 +397,7 @@ export default function FormatStep() {
             <label htmlFor={`${uid}-max-participants`} className="input-label">
               Max Participants
             </label>
-            <span aria-hidden="true" className="text-danger text-sm ml-0.5">
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
               *
             </span>
           </div>
@@ -422,20 +422,20 @@ export default function FormatStep() {
 
       <SectionHeader>Rating</SectionHeader>
 
-      <div className="flex gap-6 mb-2">
-        <label className="font-lato flex items-center gap-2 cursor-pointer text-sm text-text-body select-none">
+      <div className="mb-2 flex gap-6">
+        <label className="font-lato text-text-body flex cursor-pointer items-center gap-2 text-sm select-none">
           <input
             type="checkbox"
-            className="accent-gold-bright w-4 h-4 cursor-pointer"
+            className="accent-gold-bright h-4 w-4 cursor-pointer"
             checked={form.fideRated}
             onChange={(e) => field("fideRated", e.target.checked)}
           />
           FIDE Rated
         </label>
-        <label className="font-lato flex items-center gap-2 cursor-pointer text-sm text-text-body select-none">
+        <label className="font-lato text-text-body flex cursor-pointer items-center gap-2 text-sm select-none">
           <input
             type="checkbox"
-            className="accent-gold-bright w-4 h-4 cursor-pointer"
+            className="accent-gold-bright h-4 w-4 cursor-pointer"
             checked={form.mcfRated}
             onChange={(e) => field("mcfRated", e.target.checked)}
           />
@@ -445,19 +445,21 @@ export default function FormatStep() {
 
       <SectionHeader>Restrictions</SectionHeader>
 
-      <p className="font-lato text-xs text-text-muted mb-3 -mt-1">
+      <p className="font-lato text-text-muted -mt-1 mb-3 text-xs">
         Optional. Leave empty if the tournament is open to all players.
       </p>
 
       {form.restrictions.length > 0 && (
-        <div className="flex flex-col gap-2 mb-3">
+        <div className="mb-3 flex flex-col gap-2">
           {form.restrictions.map((r) => (
-            <div key={r.id} className="flex gap-2 items-start">
+            <div key={r.id} className="flex items-start gap-2">
               <select
                 className="input"
                 style={{ width: "175px", flexShrink: 0 }}
                 value={r.type}
-                onChange={(e) => updateRestriction(r.id, "type", e.target.value)}
+                onChange={(e) =>
+                  updateRestriction(r.id, "type", e.target.value)
+                }
                 aria-label="Restriction type"
               >
                 {RESTRICTION_TYPES.map((t) => (
@@ -466,7 +468,7 @@ export default function FormatStep() {
                   </option>
                 ))}
               </select>
-              <div className="flex-1 min-w-0">
+              <div className="min-w-0 flex-1">
                 <input
                   type="text"
                   className={`input ${
@@ -490,7 +492,7 @@ export default function FormatStep() {
               <button
                 type="button"
                 aria-label="Remove restriction"
-                className="font-lato border-border text-text-muted hover:text-danger hover:border-danger-border flex items-center justify-center rounded-md border bg-transparent transition duration-200 cursor-pointer"
+                className="font-lato border-border text-text-muted hover:text-danger hover:border-danger-border flex cursor-pointer items-center justify-center rounded-md border bg-transparent transition duration-200"
                 style={{ width: "36px", height: "38px", flexShrink: 0 }}
                 onClick={() => removeRestriction(r.id)}
               >

--- a/src/app/organizer/[orgId]/tournaments/create/_components/steps/PrizesStep.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/steps/PrizesStep.tsx
@@ -10,7 +10,10 @@ import type {
 import { useTournamentWizard } from "../TournamentWizardContext";
 
 type PrizeRowErrors = Partial<{ placement: string; amount: string }>;
-type CategoryErrors = Partial<{ name: string; prizes: Record<string, PrizeRowErrors> }>;
+type CategoryErrors = Partial<{
+  name: string;
+  prizes: Record<string, PrizeRowErrors>;
+}>;
 type SpecialPrizeErrors = Partial<{ name: string; amount: string }>;
 
 type PrizesErrors = {
@@ -59,12 +62,18 @@ function hasErrors(errors: PrizesErrors): boolean {
   );
 }
 
-function RemoveButton({ onClick, label }: { onClick: () => void; label: string }) {
+function RemoveButton({
+  onClick,
+  label,
+}: {
+  onClick: () => void;
+  label: string;
+}) {
   return (
     <button
       type="button"
       aria-label={label}
-      className="border-border text-text-muted hover:text-danger hover:border-danger-border flex items-center justify-center rounded-md border bg-transparent transition duration-200 cursor-pointer shrink-0"
+      className="border-border text-text-muted hover:text-danger hover:border-danger-border flex shrink-0 cursor-pointer items-center justify-center rounded-md border bg-transparent transition duration-200"
       style={{ width: "32px", height: "32px", fontSize: "16px" }}
       onClick={onClick}
     >
@@ -73,7 +82,13 @@ function RemoveButton({ onClick, label }: { onClick: () => void; label: string }
   );
 }
 
-function AddRowButton({ onClick, children }: { onClick: () => void; children: React.ReactNode }) {
+function AddRowButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
   return (
     <button
       type="button"
@@ -107,9 +122,9 @@ function PrizeCategoryBlock({
   const prizeErrors = catErrors.prizes ?? {};
 
   return (
-    <div className="bg-bg-base border border-border rounded-lg p-4 mb-3">
-      <div className="flex justify-between items-center mb-3 gap-2">
-        <div className="flex-1 min-w-0">
+    <div className="bg-bg-base border-border mb-3 rounded-lg border p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="min-w-0 flex-1">
           <input
             type="text"
             className={`input font-semibold ${showErrors && catErrors.name ? "input-error" : ""}`}
@@ -124,25 +139,27 @@ function PrizeCategoryBlock({
         </div>
         <button
           type="button"
-          className="font-lato border-border text-text-muted hover:text-danger hover:border-danger-border cursor-pointer rounded-md border bg-transparent px-3 py-1 text-xs transition duration-200 shrink-0"
+          className="font-lato border-border text-text-muted hover:text-danger hover:border-danger-border shrink-0 cursor-pointer rounded-md border bg-transparent px-3 py-1 text-xs transition duration-200"
           onClick={onRemoveCategory}
         >
           Remove
         </button>
       </div>
 
-      <div className="flex flex-col gap-2 mb-3">
+      <div className="mb-3 flex flex-col gap-2">
         {category.prizes.map((row) => {
           const re = prizeErrors[row.id] ?? {};
           return (
-            <div key={row.id} className="flex gap-2 items-start">
-              <div className="flex-1 min-w-0">
+            <div key={row.id} className="flex items-start gap-2">
+              <div className="min-w-0 flex-1">
                 <input
                   type="text"
                   className={`input w-full ${showErrors && re.placement ? "input-error" : ""}`}
                   placeholder="Placement (e.g. 1st Place)"
                   value={row.placement}
-                  onChange={(e) => onUpdatePrize(row.id, { placement: e.target.value })}
+                  onChange={(e) =>
+                    onUpdatePrize(row.id, { placement: e.target.value })
+                  }
                 />
                 {showErrors && re.placement && (
                   <p className="input-hint error mt-0.5">{re.placement}</p>
@@ -150,16 +167,20 @@ function PrizeCategoryBlock({
               </div>
               <div style={{ width: "130px", flexShrink: 0 }}>
                 <div className="flex items-center gap-1.5">
-                  <span className="font-lato text-text-muted text-sm shrink-0">RM</span>
+                  <span className="font-lato text-text-muted shrink-0 text-sm">
+                    RM
+                  </span>
                   <input
                     type="number"
-                    className={`input text-right tabular-nums w-full ${showErrors && re.amount ? "input-error" : ""}`}
+                    className={`input w-full text-right tabular-nums ${showErrors && re.amount ? "input-error" : ""}`}
                     placeholder="0"
                     min={0}
                     value={row.amount === "" ? "" : String(row.amount)}
                     onChange={(e) => {
                       const raw = e.target.value;
-                      onUpdatePrize(row.id, { amount: raw === "" ? "" : Number(raw) });
+                      onUpdatePrize(row.id, {
+                        amount: raw === "" ? "" : Number(raw),
+                      });
                     }}
                   />
                 </div>
@@ -245,7 +266,11 @@ export default function PrizesStep() {
     }));
   };
 
-  const updatePrize = (catId: string, rowId: string, changes: Partial<PrizeRow>) => {
+  const updatePrize = (
+    catId: string,
+    rowId: string,
+    changes: Partial<PrizeRow>,
+  ) => {
     setForm((f) => ({
       ...f,
       categories: f.categories.map((c) =>
@@ -307,10 +332,10 @@ export default function PrizesStep() {
 
   return (
     <div>
-      <h2 className="font-cinzel mb-1 text-lg font-bold text-text-primary tracking-wide">
+      <h2 className="font-cinzel text-text-primary mb-1 text-lg font-bold tracking-wide">
         Prizes
       </h2>
-      <p className="font-lato mb-6 text-sm text-text-muted">
+      <p className="font-lato text-text-muted mb-6 text-sm">
         Define prize categories and amounts. Add as many categories and
         placements as needed.
       </p>
@@ -327,7 +352,9 @@ export default function PrizesStep() {
             onUpdateName={(name) => updateCategoryName(cat.id, name)}
             onRemoveCategory={() => removeCategory(cat.id)}
             onAddPrize={() => addPrize(cat.id)}
-            onUpdatePrize={(rowId, changes) => updatePrize(cat.id, rowId, changes)}
+            onUpdatePrize={(rowId, changes) =>
+              updatePrize(cat.id, rowId, changes)
+            }
             onRemovePrize={(rowId) => removePrize(cat.id, rowId)}
           />
         );
@@ -336,21 +363,21 @@ export default function PrizesStep() {
       <AddRowButton onClick={addCategory}>+ Add Prize Category</AddRowButton>
 
       {/* Special Prizes */}
-      <h3 className="font-cinzel text-gold-muted text-xs font-bold tracking-widest uppercase mt-6 mb-3 pt-4 border-t border-border">
+      <h3 className="font-cinzel text-gold-muted border-border mt-6 mb-3 border-t pt-4 text-xs font-bold tracking-widest uppercase">
         Special Prizes
       </h3>
-      <p className="font-lato text-text-muted text-xs mb-4">
+      <p className="font-lato text-text-muted mb-4 text-xs">
         Optional. Awards for specific achievements (e.g. Best Female Player,
         Best Veteran).
       </p>
 
       {form.specialPrizes.length > 0 && (
-        <div className="flex flex-col gap-2 mb-4">
+        <div className="mb-4 flex flex-col gap-2">
           {form.specialPrizes.map((sp) => {
             const se = errors.specialPrizes[sp.id] ?? {};
             return (
-              <div key={sp.id} className="flex gap-2 items-start">
-                <div className="flex-1 min-w-0">
+              <div key={sp.id} className="flex items-start gap-2">
+                <div className="min-w-0 flex-1">
                   <input
                     type="text"
                     className={`input w-full ${showErrors && se.name ? "input-error" : ""}`}
@@ -366,10 +393,12 @@ export default function PrizesStep() {
                 </div>
                 <div style={{ width: "130px", flexShrink: 0 }}>
                   <div className="flex items-center gap-1.5">
-                    <span className="font-lato text-text-muted text-sm shrink-0">RM</span>
+                    <span className="font-lato text-text-muted shrink-0 text-sm">
+                      RM
+                    </span>
                     <input
                       type="number"
-                      className={`input text-right tabular-nums w-full ${showErrors && se.amount ? "input-error" : ""}`}
+                      className={`input w-full text-right tabular-nums ${showErrors && se.amount ? "input-error" : ""}`}
                       placeholder="0"
                       min={0}
                       value={sp.amount === "" ? "" : String(sp.amount)}

--- a/src/app/organizer/[orgId]/tournaments/create/_components/steps/PrizesStep.tsx
+++ b/src/app/organizer/[orgId]/tournaments/create/_components/steps/PrizesStep.tsx
@@ -182,10 +182,15 @@ function PrizeCategoryBlock({
 }
 
 export default function PrizesStep() {
-  const { prizesData, setPrizesData, goNext, registerStepHandler } =
+  const { prizesData, setPrizesData, goNext, registerStepHandler, isHydrated } =
     useTournamentWizard();
 
   const [form, setForm] = useState<PrizesData>(prizesData);
+
+  useEffect(() => {
+    if (isHydrated) setForm(prizesData);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHydrated]);
   const [errors, setErrors] = useState<PrizesErrors>({
     categories: {},
     specialPrizes: {},

--- a/src/app/tournaments/[id]/__tests__/page.test.ts
+++ b/src/app/tournaments/[id]/__tests__/page.test.ts
@@ -579,6 +579,38 @@ describe("fetchStartingRank coverage", () => {
     expect(await TournamentDetailData({ id: "t1" })).toBeDefined();
   });
 
+  it("covers classical format with fide_rating object: uses standard field", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () =>
+        makeTournamentPayload({
+          start_date: "2020-01-01",
+          end_date: "2020-01-02",
+          format: { type: "classical", system: "swiss", rounds: 9 },
+        }),
+    });
+    mockFrom.mockImplementation(
+      makeFromMock(
+        { data: [{ user_id: "u1" }], error: null },
+        [{ id: "u1", first_name: "Diana", last_name: "Tan" }],
+        [
+          {
+            user_id: "u1",
+            title: "IM",
+            fide_id: 5551234,
+            fide_rating: { standard: 2250 },
+            national_rating: null,
+            nationality: "Malaysia",
+            mcf_id: null,
+            gender: "female",
+          },
+        ],
+      ),
+    );
+    const { TournamentDetailData } = await import("../page");
+    expect(await TournamentDetailData({ id: "t1" })).toBeDefined();
+  });
+
   it("sorts MCF-only player above unrated player", async () => {
     mockFrom.mockImplementation(
       makeFromMock(
@@ -607,6 +639,100 @@ describe("fetchStartingRank coverage", () => {
             nationality: "Malaysia",
             mcf_id: 9999,
             gender: "female",
+          },
+        ],
+      ),
+    );
+    const { TournamentDetailData } = await import("../page");
+    expect(await TournamentDetailData({ id: "t1" })).toBeDefined();
+  });
+
+  it("covers sort branch: unrated player compared against MCF-rated player", async () => {
+    // Array order [FIDE, unrated, MCF] forces the sort to compare (unrated, MCF),
+    // which hits the `if (hasMcfB) return 1` branch (line 141).
+    mockFrom.mockImplementation(
+      makeFromMock(
+        {
+          data: [
+            { user_id: "u1" },
+            { user_id: "u2" },
+            { user_id: "u3" },
+          ],
+          error: null,
+        },
+        [
+          { id: "u1", first_name: "FIDE", last_name: "Player" },
+          { id: "u2", first_name: "Unrated", last_name: "Player" },
+          { id: "u3", first_name: "MCF", last_name: "Player" },
+        ],
+        [
+          {
+            user_id: "u1",
+            title: null,
+            fide_id: 111,
+            fide_rating: { rapid: 1800 },
+            national_rating: null,
+            nationality: "Malaysia",
+            mcf_id: null,
+            gender: null,
+          },
+          {
+            user_id: "u2",
+            title: null,
+            fide_id: null,
+            fide_rating: null,
+            national_rating: null,
+            nationality: null,
+            mcf_id: null,
+            gender: null,
+          },
+          {
+            user_id: "u3",
+            title: null,
+            fide_id: null,
+            fide_rating: null,
+            national_rating: 1300,
+            nationality: "Malaysia",
+            mcf_id: 8888,
+            gender: null,
+          },
+        ],
+      ),
+    );
+    const { TournamentDetailData } = await import("../page");
+    expect(await TournamentDetailData({ id: "t1" })).toBeDefined();
+  });
+
+  it("covers sort branch: two unrated players sorted alphabetically", async () => {
+    // Both players have no FIDE or MCF rating, so they are sorted alphabetically,
+    // hitting the `return a.name.localeCompare(b.name)` branch (line 142).
+    mockFrom.mockImplementation(
+      makeFromMock(
+        { data: [{ user_id: "u1" }, { user_id: "u2" }], error: null },
+        [
+          { id: "u1", first_name: "Zara", last_name: "Ahmad" },
+          { id: "u2", first_name: "Aaron", last_name: "Lim" },
+        ],
+        [
+          {
+            user_id: "u1",
+            title: null,
+            fide_id: null,
+            fide_rating: null,
+            national_rating: null,
+            nationality: null,
+            mcf_id: null,
+            gender: null,
+          },
+          {
+            user_id: "u2",
+            title: null,
+            fide_id: null,
+            fide_rating: null,
+            national_rating: null,
+            nationality: null,
+            mcf_id: null,
+            gender: null,
           },
         ],
       ),

--- a/src/app/tournaments/[id]/__tests__/page.test.ts
+++ b/src/app/tournaments/[id]/__tests__/page.test.ts
@@ -356,8 +356,9 @@ function makeChain(resolveWith: unknown) {
       Promise.resolve(resolveWith).catch(r),
     select: vi.fn(() => chain),
     eq: vi.fn(() => chain),
-    in: vi.fn<() => Promise<{ count?: number; data: unknown; error: unknown }>>(() =>
-      Promise.resolve({ count: 0, data: null, error: null })),
+    in: vi.fn<() => Promise<{ count?: number; data: unknown; error: unknown }>>(
+      () => Promise.resolve({ count: 0, data: null, error: null }),
+    ),
   };
   return chain;
 }
@@ -653,11 +654,7 @@ describe("fetchStartingRank coverage", () => {
     mockFrom.mockImplementation(
       makeFromMock(
         {
-          data: [
-            { user_id: "u1" },
-            { user_id: "u2" },
-            { user_id: "u3" },
-          ],
+          data: [{ user_id: "u1" }, { user_id: "u2" }, { user_id: "u3" }],
           error: null,
         },
         [
@@ -771,7 +768,9 @@ describe("fetchStartingRank coverage", () => {
         regCallIdx++;
         if (regCallIdx === 1) {
           const c = makeChain({ count: 0 });
-          c.in = vi.fn(() => Promise.resolve({ count: 0, data: null, error: null }));
+          c.in = vi.fn(() =>
+            Promise.resolve({ count: 0, data: null, error: null }),
+          );
           return { select: vi.fn(() => c) };
         }
         return { select: vi.fn(() => makeChain({ data: [], error: null })) };

--- a/src/services/redis/__tests__/redis.test.ts
+++ b/src/services/redis/__tests__/redis.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — use vi.hoisted so references are available inside vi.mock factory
+// ---------------------------------------------------------------------------
+
+const { mockSet, mockGet } = vi.hoisted(() => ({
+  mockSet: vi.fn(),
+  mockGet: vi.fn(),
+}));
+
+vi.mock("@upstash/redis", () => ({
+  Redis: function (this: unknown) {
+    return { set: mockSet, get: mockGet };
+  },
+}));
+
+import {
+  getVerificationCode,
+  storeVerificationCode,
+  verifyKey,
+} from "../redis";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("verifyKey", () => {
+  it("returns the prefixed lowercase email", () => {
+    expect(verifyKey("user@example.com")).toBe("verify:user@example.com");
+  });
+
+  it("lowercases the email before adding the prefix", () => {
+    expect(verifyKey("User@Example.COM")).toBe("verify:user@example.com");
+  });
+
+  it("handles already-lowercase emails without modification", () => {
+    expect(verifyKey("test@test.com")).toBe("verify:test@test.com");
+  });
+});
+
+describe("storeVerificationCode", () => {
+  it("calls redis.set with the correct key, code, and 15-minute TTL", async () => {
+    await storeVerificationCode("test@example.com", "123456");
+    expect(mockSet).toHaveBeenCalledOnce();
+    expect(mockSet).toHaveBeenCalledWith(
+      "verify:test@example.com",
+      "123456",
+      { ex: 900 },
+    );
+  });
+
+  it("lowercases the email in the stored key", async () => {
+    await storeVerificationCode("CAPS@EXAMPLE.COM", "789012");
+    expect(mockSet).toHaveBeenCalledWith(
+      "verify:caps@example.com",
+      "789012",
+      { ex: 900 },
+    );
+  });
+});
+
+describe("getVerificationCode", () => {
+  it("calls redis.get with the correct prefixed key", async () => {
+    mockGet.mockResolvedValue("654321");
+    const result = await getVerificationCode("test@example.com");
+    expect(mockGet).toHaveBeenCalledOnce();
+    expect(mockGet).toHaveBeenCalledWith("verify:test@example.com");
+    expect(result).toBe("654321");
+  });
+
+  it("returns null when no verification code is stored", async () => {
+    mockGet.mockResolvedValue(null);
+    const result = await getVerificationCode("notfound@example.com");
+    expect(result).toBeNull();
+  });
+
+  it("lowercases the email when building the lookup key", async () => {
+    mockGet.mockResolvedValue("111222");
+    await getVerificationCode("UPPER@CASE.COM");
+    expect(mockGet).toHaveBeenCalledWith("verify:upper@case.com");
+  });
+});
+
+describe("module initialization", () => {
+  it("throws when UPSTASH_REDIS_REST_URL environment variable is missing", async () => {
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    vi.resetModules();
+
+    await expect(import("../redis")).rejects.toThrow(
+      /Missing UPSTASH_REDIS_REST_URL/,
+    );
+
+    process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+    vi.resetModules();
+  });
+
+  it("throws when UPSTASH_REDIS_REST_TOKEN environment variable is missing", async () => {
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    vi.resetModules();
+
+    await expect(import("../redis")).rejects.toThrow(
+      /Missing UPSTASH_REDIS_REST_URL/,
+    );
+
+    process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    vi.resetModules();
+  });
+});

--- a/src/services/redis/__tests__/redis.test.ts
+++ b/src/services/redis/__tests__/redis.test.ts
@@ -51,20 +51,16 @@ describe("storeVerificationCode", () => {
   it("calls redis.set with the correct key, code, and 15-minute TTL", async () => {
     await storeVerificationCode("test@example.com", "123456");
     expect(mockSet).toHaveBeenCalledOnce();
-    expect(mockSet).toHaveBeenCalledWith(
-      "verify:test@example.com",
-      "123456",
-      { ex: 900 },
-    );
+    expect(mockSet).toHaveBeenCalledWith("verify:test@example.com", "123456", {
+      ex: 900,
+    });
   });
 
   it("lowercases the email in the stored key", async () => {
     await storeVerificationCode("CAPS@EXAMPLE.COM", "789012");
-    expect(mockSet).toHaveBeenCalledWith(
-      "verify:caps@example.com",
-      "789012",
-      { ex: 900 },
-    );
+    expect(mockSet).toHaveBeenCalledWith("verify:caps@example.com", "789012", {
+      ex: 900,
+    });
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     environment: "node",
     env: {


### PR DESCRIPTION
Fixes the organizer dashboard (`/organizer/[orgId]/dashboard`) so it no longer redirects to the player view (`/tournaments/[id]`) when a tournament is clicked.

Implements the tournament list table per `wireframes/organizer.html`:
- Proper `<table>` with columns: Tournament · Date · Registrations · Status · Action
- Status badges (Draft, Published, Ongoing, Completed, Cancelled)
- Per-status action buttons (Edit / Manage / View) all routing to organizer paths
- Dimmed rows for completed / cancelled tournaments

Closes #67

Generated with [Claude Code](https://claude.ai/code)