### PR TITLE
feat: PATCH and DELETE routes for organizer member management

### DIFF
--- a/src/app/api/v1/organizer/[orgId]/members/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/[id]/__tests__/route.test.ts
@@ -1,0 +1,630 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockOrgBuilder,
+  mockCallerMembershipCheckBuilder,
+  mockTargetMembershipBuilder,
+  mockRoleBuilder,
+  mockMembershipUpdateBuilder,
+  mockMembershipDeleteBuilder,
+  mockFrom,
+  mockGetUser,
+  mockHasOrgPermission,
+} = vi.hoisted(() => {
+  function makeBuilder(finalResult: {
+    data?: unknown;
+    count?: unknown;
+    error?: unknown;
+  }) {
+    const b: Record<string, unknown> = {};
+    for (const m of [
+      "select",
+      "eq",
+      "in",
+      "is",
+      "order",
+      "limit",
+      "single",
+      "maybeSingle",
+      "update",
+      "delete",
+    ]) {
+      b[m] = vi.fn(() => b);
+    }
+    b.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return b;
+  }
+
+  const mockOrgBuilder = makeBuilder({ data: null, error: null });
+  const mockCallerMembershipCheckBuilder = makeBuilder({
+    count: 1,
+    error: null,
+  });
+  const mockTargetMembershipBuilder = makeBuilder({ data: null, error: null });
+  const mockRoleBuilder = makeBuilder({ data: null, error: null });
+  const mockMembershipUpdateBuilder = makeBuilder({ data: null, error: null });
+  const mockMembershipDeleteBuilder = makeBuilder({ data: null, error: null });
+
+  // membership table call index:
+  // 0 = caller membership check (count)
+  // 1 = target membership fetch (single)
+  // 2 = membership update/delete
+  let membershipCallIndex = 0;
+
+  const mockFrom = vi.fn((table: string) => {
+    if (table === "organizations") return mockOrgBuilder;
+    if (table === "roles") return mockRoleBuilder;
+    if (table === "organization_memberships") {
+      const idx = membershipCallIndex++;
+      if (idx === 0) return mockCallerMembershipCheckBuilder;
+      if (idx === 1) return mockTargetMembershipBuilder;
+      return mockMembershipUpdateBuilder;
+    }
+    return mockOrgBuilder;
+  });
+
+  (mockFrom as unknown as { _resetIndex: () => void })._resetIndex = () => {
+    membershipCallIndex = 0;
+  };
+
+  const mockGetUser = vi.fn();
+  const mockHasOrgPermission = vi.fn().mockResolvedValue(true);
+
+  return {
+    mockOrgBuilder,
+    mockCallerMembershipCheckBuilder,
+    mockTargetMembershipBuilder,
+    mockRoleBuilder,
+    mockMembershipUpdateBuilder,
+    mockMembershipDeleteBuilder,
+    mockFrom,
+    mockGetUser,
+    mockHasOrgPermission,
+  };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("@/services/supabase/permission", () => ({
+  hasOrgPermission: mockHasOrgPermission,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+import { PATCH, DELETE } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CALLER_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const TARGET_ID = "aaaaaaaa-0000-0000-0000-000000000002";
+const ORG_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+const ROLE_ID = "cccccccc-0000-0000-0000-000000000001";
+
+const APPROVED_ORG = {
+  id: ORG_ID,
+  approval_status: "approved",
+  created_by: CALLER_ID,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePatchRequest(
+  orgId: string = ORG_ID,
+  memberId: string = TARGET_ID,
+  body: unknown = { role: "admin" },
+): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/organizer/${orgId}/members/${memberId}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    },
+  );
+}
+
+function makeDeleteRequest(
+  orgId: string = ORG_ID,
+  memberId: string = TARGET_ID,
+): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/organizer/${orgId}/members/${memberId}`,
+    { method: "DELETE" },
+  );
+}
+
+function setUser(id = CALLER_ID) {
+  mockGetUser.mockResolvedValue({ data: { user: { id } }, error: null });
+}
+
+function setNoUser() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+}
+
+function setOrgResult(data: unknown, error: unknown = null) {
+  (mockOrgBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setCallerMembershipCheck(count: number | null, error: unknown = null) {
+  (mockCallerMembershipCheckBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ count, error }).then(onfulfilled, onrejected);
+}
+
+function setTargetMembership(data: unknown, error: unknown = null) {
+  (mockTargetMembershipBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setRoleResult(data: unknown, error: unknown = null) {
+  (mockRoleBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setMembershipUpdateResult(data: unknown, error: unknown = null) {
+  (mockMembershipUpdateBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function resetCallIndex() {
+  (mockFrom as unknown as { _resetIndex: () => void })._resetIndex();
+}
+
+// ---------------------------------------------------------------------------
+// PATCH Tests
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/v1/organizer/:orgId/members/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCallIndex();
+    setUser();
+    setOrgResult(APPROVED_ORG);
+    setCallerMembershipCheck(1);
+    setTargetMembership({ user_id: TARGET_ID });
+    setRoleResult({ id: ROLE_ID });
+    setMembershipUpdateResult(null);
+    mockHasOrgPermission.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  describe("validation", () => {
+    it("returns 400 for a non-UUID orgId", async () => {
+      const res = await PATCH(makePatchRequest("not-a-uuid"), {
+        params: Promise.resolve({ orgId: "not-a-uuid", id: TARGET_ID }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/invalid organization id/i);
+    });
+
+    it("returns 400 for a non-UUID member id", async () => {
+      const res = await PATCH(makePatchRequest(ORG_ID, "not-a-uuid"), {
+        params: Promise.resolve({ orgId: ORG_ID, id: "not-a-uuid" }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/invalid member id/i);
+    });
+
+    it("returns 400 for missing role", async () => {
+      const res = await PATCH(makePatchRequest(ORG_ID, TARGET_ID, {}), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/role must be/i);
+    });
+
+    it("returns 400 for invalid role value", async () => {
+      const res = await PATCH(
+        makePatchRequest(ORG_ID, TARGET_ID, { role: "owner" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }) },
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 for invalid JSON body", async () => {
+      const req = new NextRequest(
+        `http://localhost/api/v1/organizer/${ORG_ID}/members/${TARGET_ID}`,
+        {
+          method: "PATCH",
+          body: "not-json",
+          headers: { "content-type": "application/json" },
+        },
+      );
+      const res = await PATCH(req, {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------------
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorization
+  // -------------------------------------------------------------------------
+
+  describe("authorization", () => {
+    it("returns 403 when caller tries to change their own role", async () => {
+      const res = await PATCH(makePatchRequest(ORG_ID, CALLER_ID), {
+        params: Promise.resolve({ orgId: ORG_ID, id: CALLER_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/cannot change your own role/i);
+    });
+
+    it("returns 404 when organization does not exist", async () => {
+      setOrgResult(null, { code: "PGRST116", message: "No rows found" });
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 500 on org query error", async () => {
+      setOrgResult(null, { code: "500", message: "DB error" });
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(500);
+    });
+
+    it("returns 403 when org is not approved", async () => {
+      setOrgResult({ ...APPROVED_ORG, approval_status: "pending" });
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/not approved/i);
+    });
+
+    it("returns 403 when caller is not a member and not the creator", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: TARGET_ID });
+      setCallerMembershipCheck(0);
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/access denied/i);
+    });
+
+    it("returns 403 when caller lacks org.manage permission", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: TARGET_ID });
+      setCallerMembershipCheck(1);
+      mockHasOrgPermission.mockResolvedValue(false);
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/insufficient permissions/i);
+    });
+
+    it("skips permission check when caller is org creator", async () => {
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(200);
+      expect(mockHasOrgPermission).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when target member does not exist", async () => {
+      setTargetMembership(null, {
+        code: "PGRST116",
+        message: "No rows found",
+      });
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error.code).toBe("NOT_FOUND");
+      expect(json.error.message).toMatch(/member not found/i);
+    });
+
+    it("returns 500 on target membership query error", async () => {
+      setTargetMembership(null, { code: "500", message: "DB error" });
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Success
+  // -------------------------------------------------------------------------
+
+  describe("success", () => {
+    it("returns 200 with updated user_id and role", async () => {
+      const res = await PATCH(
+        makePatchRequest(ORG_ID, TARGET_ID, { role: "admin" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }) },
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.data).toMatchObject({ user_id: TARGET_ID, role: "admin" });
+    });
+
+    it("accepts 'member' as a valid role", async () => {
+      const res = await PATCH(
+        makePatchRequest(ORG_ID, TARGET_ID, { role: "member" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }) },
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.data.role).toBe("member");
+    });
+
+    it("returns 500 when role lookup fails", async () => {
+      setRoleResult(null, { message: "DB error" });
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+
+    it("returns 500 when membership update fails", async () => {
+      setMembershipUpdateResult(null, { message: "DB error" });
+      const res = await PATCH(makePatchRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE Tests
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/v1/organizer/:orgId/members/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCallIndex();
+    setUser();
+    setOrgResult(APPROVED_ORG);
+    setCallerMembershipCheck(1);
+    setTargetMembership({ user_id: TARGET_ID });
+    // For DELETE, the 3rd membership call (index 2) is the delete operation
+    // Route the delete builder to mockMembershipUpdateBuilder (reused as delete builder)
+    setMembershipUpdateResult(null);
+    mockHasOrgPermission.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  describe("validation", () => {
+    it("returns 400 for a non-UUID orgId", async () => {
+      const res = await DELETE(makeDeleteRequest("not-a-uuid"), {
+        params: Promise.resolve({ orgId: "not-a-uuid", id: TARGET_ID }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/invalid organization id/i);
+    });
+
+    it("returns 400 for a non-UUID member id", async () => {
+      const res = await DELETE(makeDeleteRequest(ORG_ID, "not-a-uuid"), {
+        params: Promise.resolve({ orgId: ORG_ID, id: "not-a-uuid" }),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/invalid member id/i);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------------
+
+  describe("authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      setNoUser();
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json.error.code).toBe("UNAUTHORIZED");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorization
+  // -------------------------------------------------------------------------
+
+  describe("authorization", () => {
+    it("returns 403 when caller tries to remove themselves", async () => {
+      const res = await DELETE(makeDeleteRequest(ORG_ID, CALLER_ID), {
+        params: Promise.resolve({ orgId: ORG_ID, id: CALLER_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/cannot remove yourself/i);
+    });
+
+    it("returns 404 when organization does not exist", async () => {
+      setOrgResult(null, { code: "PGRST116", message: "No rows found" });
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 403 when org is not approved", async () => {
+      setOrgResult({ ...APPROVED_ORG, approval_status: "pending" });
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 when caller is not a member and not the creator", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: TARGET_ID });
+      setCallerMembershipCheck(0);
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/access denied/i);
+    });
+
+    it("returns 403 when caller lacks org.manage permission", async () => {
+      setOrgResult({ ...APPROVED_ORG, created_by: TARGET_ID });
+      setCallerMembershipCheck(1);
+      mockHasOrgPermission.mockResolvedValue(false);
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(403);
+      const json = await res.json();
+      expect(json.error.code).toBe("FORBIDDEN");
+      expect(json.error.message).toMatch(/insufficient permissions/i);
+    });
+
+    it("skips permission check when caller is org creator", async () => {
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(204);
+      expect(mockHasOrgPermission).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when target member does not exist", async () => {
+      setTargetMembership(null, {
+        code: "PGRST116",
+        message: "No rows found",
+      });
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.error.code).toBe("NOT_FOUND");
+      expect(json.error.message).toMatch(/member not found/i);
+    });
+
+    it("returns 500 on target membership query error", async () => {
+      setTargetMembership(null, { code: "500", message: "DB error" });
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Success
+  // -------------------------------------------------------------------------
+
+  describe("success", () => {
+    it("returns 204 with no body on successful deletion", async () => {
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(204);
+    });
+
+    it("returns 500 when delete operation fails", async () => {
+      setMembershipUpdateResult(null, { message: "DB error" });
+      const res = await DELETE(makeDeleteRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID, id: TARGET_ID }),
+      });
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error.code).toBe("INTERNAL_ERROR");
+    });
+  });
+});

--- a/src/app/api/v1/organizer/[orgId]/members/[id]/route.ts
+++ b/src/app/api/v1/organizer/[orgId]/members/[id]/route.ts
@@ -1,0 +1,344 @@
+import { supabaseAdmin } from "@/services/supabase/admin";
+import { createClient } from "@/services/supabase/server";
+import { hasOrgPermission } from "@/services/supabase/permission";
+import { NextRequest, NextResponse } from "next/server";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const VALID_ROLES = ["admin", "member"] as const;
+type MemberRole = (typeof VALID_ROLES)[number];
+
+async function resolveOrgAccess(
+  orgId: string,
+  userId: string,
+): Promise<NextResponse | { isCreator: boolean }> {
+  const [
+    { data: org, error: orgError },
+    { count: memberCount, error: memberError },
+  ] = await Promise.all([
+    supabaseAdmin
+      .from("organizations")
+      .select("id, approval_status, created_by")
+      .eq("id", orgId)
+      .is("deleted_at", null)
+      .single(),
+    supabaseAdmin
+      .from("organization_memberships")
+      .select("*", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("user_id", userId),
+  ]);
+
+  if (orgError) {
+    if (orgError.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Organization not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: orgError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (memberError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: memberError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (org.approval_status !== "approved") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "Organization is not approved",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const isCreator = org.created_by === userId;
+  if (!isCreator && !memberCount) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied" } },
+      { status: 403 },
+    );
+  }
+
+  return { isCreator };
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgId: string; id: string }> },
+): Promise<NextResponse> {
+  const { orgId, id } = await params;
+
+  if (!UUID_RE.test(orgId)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid organization ID",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid member ID",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  if (user.id === id) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "Cannot change your own role",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const accessResult = await resolveOrgAccess(orgId, user.id);
+  if (accessResult instanceof NextResponse) return accessResult;
+  const { isCreator } = accessResult;
+
+  if (!isCreator) {
+    const allowed = await hasOrgPermission(user.id, orgId, "org.manage");
+    if (!allowed) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Insufficient permissions" } },
+        { status: 403 },
+      );
+    }
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body" } },
+      { status: 400 },
+    );
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body" } },
+      { status: 400 },
+    );
+  }
+
+  const b = body as Record<string, unknown>;
+  if (!b.role || !VALID_ROLES.includes(b.role as MemberRole)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Role must be 'admin' or 'member'",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const role = b.role as MemberRole;
+
+  const { data: membership, error: membershipError } = await supabaseAdmin
+    .from("organization_memberships")
+    .select("user_id")
+    .eq("organization_id", orgId)
+    .eq("user_id", id)
+    .single();
+
+  if (membershipError) {
+    if (membershipError.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Member not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: membershipError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (!membership) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Member not found" } },
+      { status: 404 },
+    );
+  }
+
+  const { data: roleData, error: roleError } = await supabaseAdmin
+    .from("roles")
+    .select("id")
+    .eq("name", role)
+    .single();
+
+  if (roleError || !roleData) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Role not found" } },
+      { status: 500 },
+    );
+  }
+
+  const { error: updateError } = await supabaseAdmin
+    .from("organization_memberships")
+    .update({ role_id: roleData.id })
+    .eq("organization_id", orgId)
+    .eq("user_id", id);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: updateError.message } },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(
+    { data: { user_id: id, role } },
+    { status: 200 },
+  );
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string; id: string }> },
+): Promise<NextResponse> {
+  const { orgId, id } = await params;
+
+  if (!UUID_RE.test(orgId)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid organization ID",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid member ID",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  if (user.id === id) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "Cannot remove yourself from the organization",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const accessResult = await resolveOrgAccess(orgId, user.id);
+  if (accessResult instanceof NextResponse) return accessResult;
+  const { isCreator } = accessResult;
+
+  if (!isCreator) {
+    const allowed = await hasOrgPermission(user.id, orgId, "org.manage");
+    if (!allowed) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Insufficient permissions" } },
+        { status: 403 },
+      );
+    }
+  }
+
+  const { data: membership, error: membershipError } = await supabaseAdmin
+    .from("organization_memberships")
+    .select("user_id")
+    .eq("organization_id", orgId)
+    .eq("user_id", id)
+    .single();
+
+  if (membershipError) {
+    if (membershipError.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Member not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: membershipError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (!membership) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Member not found" } },
+      { status: 404 },
+    );
+  }
+
+  const { error: deleteError } = await supabaseAdmin
+    .from("organization_memberships")
+    .delete()
+    .eq("organization_id", orgId)
+    .eq("user_id", id);
+
+  if (deleteError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: deleteError.message } },
+      { status: 500 },
+    );
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/organizer/[orgId]/members/_components/MembersClient.tsx
+++ b/src/app/organizer/[orgId]/members/_components/MembersClient.tsx
@@ -46,10 +46,19 @@ function getRoleConfig(role: string) {
 function MemberCard({
   member,
   isCurrentUser,
+  canManage,
+  onRoleChange,
+  onRemove,
 }: {
   member: Member;
   isCurrentUser: boolean;
+  canManage: boolean;
+  onRoleChange: (userId: string, newRole: "admin" | "member") => Promise<void>;
+  onRemove: (userId: string) => void;
 }) {
+  const [roleLoading, setRoleLoading] = useState(false);
+  const [roleError, setRoleError] = useState<string | null>(null);
+
   const fullName = [member.first_name, member.last_name].filter(Boolean).join(" ");
   const initials =
     `${member.first_name[0] ?? ""}${member.last_name[0] ?? ""}`.toUpperCase() ||
@@ -64,8 +73,21 @@ function MemberCard({
 
   const roleConfig = getRoleConfig(member.role);
 
+  async function handleRoleSelect(newRole: "admin" | "member") {
+    if (newRole === member.role) return;
+    setRoleLoading(true);
+    setRoleError(null);
+    try {
+      await onRoleChange(member.user_id, newRole);
+    } catch (err) {
+      setRoleError(err instanceof Error ? err.message : "Failed to update role");
+    } finally {
+      setRoleLoading(false);
+    }
+  }
+
   return (
-    <div className="card px-5 py-4 flex items-center gap-4">
+    <div className="card px-5 py-4 flex items-center gap-4 flex-wrap">
       <div className="bg-gold-ghost border-2 border-gold-dim font-cinzel text-gold-bright flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold">
         {initials}
       </div>
@@ -87,13 +109,37 @@ function MemberCard({
         <p className="font-lato text-xs text-text-disabled mt-0.5">
           Joined {joinedDate}
         </p>
+        {roleError && (
+          <p className="font-lato text-xs text-red-400 mt-1">{roleError}</p>
+        )}
       </div>
 
-      <span
-        className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${roleConfig.className}`}
-      >
-        {roleConfig.label}
-      </span>
+      {canManage ? (
+        <div className="flex items-center gap-2 shrink-0">
+          <select
+            value={member.role as "admin" | "member"}
+            onChange={(e) => handleRoleSelect(e.target.value as "admin" | "member")}
+            disabled={roleLoading}
+            className="rounded-md border border-border bg-bg-base px-2 py-1 font-cinzel text-xs font-bold tracking-widest uppercase text-text-secondary focus:outline-none focus:border-gold-dim disabled:opacity-50"
+          >
+            <option value="admin">Admin</option>
+            <option value="member">Member</option>
+          </select>
+          <button
+            onClick={() => onRemove(member.user_id)}
+            disabled={roleLoading}
+            className="font-lato text-xs text-red-400 hover:text-red-300 border border-red-900/40 hover:border-red-400/60 px-2 py-1 rounded-md transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Remove
+          </button>
+        </div>
+      ) : (
+        <span
+          className={`font-cinzel text-xs font-bold tracking-widest uppercase px-2.5 py-1 rounded-md whitespace-nowrap ${roleConfig.className}`}
+        >
+          {roleConfig.label}
+        </span>
+      )}
     </div>
   );
 }
@@ -208,8 +254,52 @@ export default function MembersClient({
   currentUserId,
   isOrgCreator,
 }: Props) {
-  const currentMember = members.find((m) => m.user_id === currentUserId);
+  const [memberList, setMemberList] = useState<Member[]>(members);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+
+  const currentMember = memberList.find((m) => m.user_id === currentUserId);
   const isOwner = isOrgCreator || currentMember?.role === "owner";
+
+  async function handleRoleChange(userId: string, newRole: "admin" | "member") {
+    const res = await fetch(`/api/v1/organizer/${orgId}/members/${userId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: newRole }),
+    });
+
+    const json = await res.json();
+    if (!res.ok) {
+      throw new Error(json.error?.message ?? "Failed to update role");
+    }
+
+    setMemberList((prev) =>
+      prev.map((m) => (m.user_id === userId ? { ...m, role: newRole } : m))
+    );
+  }
+
+  function handleRemove(userId: string) {
+    const member = memberList.find((m) => m.user_id === userId);
+    const name = member
+      ? [member.first_name, member.last_name].filter(Boolean).join(" ") || member.email
+      : "this member";
+
+    if (!confirm(`Remove ${name} from the organization?`)) return;
+
+    setRemoveError(null);
+    fetch(`/api/v1/organizer/${orgId}/members/${userId}`, { method: "DELETE" })
+      .then((res) => {
+        if (res.status === 204 || res.ok) {
+          setMemberList((prev) => prev.filter((m) => m.user_id !== userId));
+          return;
+        }
+        return res.json().then((j: { error?: { message?: string } }) => {
+          setRemoveError(j.error?.message ?? "Failed to remove member");
+        });
+      })
+      .catch(() => {
+        setRemoveError("An unexpected error occurred. Please try again.");
+      });
+  }
 
   return (
     <div className="max-w-3xl mx-auto px-6 py-8">
@@ -224,11 +314,17 @@ export default function MembersClient({
           {orgName}
         </h1>
         <p className="font-lato text-sm text-text-muted mt-1">
-          Members · {members.length} {members.length === 1 ? "person" : "people"}
+          Members · {memberList.length} {memberList.length === 1 ? "person" : "people"}
         </p>
       </div>
 
       {isOwner && <InviteBar orgId={orgId} />}
+
+      {removeError && (
+        <div className="mb-4 rounded-md bg-red-950/40 border border-red-900/40 px-4 py-2">
+          <p className="font-lato text-xs text-red-400">{removeError}</p>
+        </div>
+      )}
 
       {/* Role permissions reference */}
       <div className="rounded-lg bg-bg-raised border border-border px-5 py-4 mb-6">
@@ -260,7 +356,7 @@ export default function MembersClient({
       </div>
 
       {/* Members list */}
-      {members.length === 0 ? (
+      {memberList.length === 0 ? (
         <div className="text-center py-12 px-5">
           <div className="text-4xl mb-4 opacity-20">♟</div>
           <p className="font-lato text-sm text-text-muted leading-relaxed">
@@ -269,13 +365,20 @@ export default function MembersClient({
         </div>
       ) : (
         <div className="flex flex-col gap-3">
-          {members.map((member) => (
-            <MemberCard
-              key={member.user_id}
-              member={member}
-              isCurrentUser={member.user_id === currentUserId}
-            />
-          ))}
+          {memberList.map((member) => {
+            const isCurrentUser = member.user_id === currentUserId;
+            const canManage = isOwner && !isCurrentUser && member.role !== "owner";
+            return (
+              <MemberCard
+                key={member.user_id}
+                member={member}
+                isCurrentUser={isCurrentUser}
+                canManage={canManage}
+                onRoleChange={handleRoleChange}
+                onRemove={handleRemove}
+              />
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
Implements `PATCH /organizer/:orgId/members/:id` (change member role) and `DELETE /organizer/:orgId/members/:id` (remove member) with full auth, permission checks (`org.manage`), and 32 tests covering both handlers.

Closes #74, closes #75

Generated with [Claude Code](https://claude.ai/code)