### PR TITLE
fix: single column password criteria on mobile

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -497,7 +497,7 @@
     @apply font-cinzel text-text-muted mb-1 text-sm font-semibold tracking-widest uppercase;
   }
   .pw-req-grid {
-    @apply grid grid-cols-2 gap-x-3 gap-y-1;
+    @apply grid grid-cols-1 sm:grid-cols-2 gap-x-3 gap-y-1;
   }
   .pw-req {
     @apply font-lato text-text-muted flex items-center gap-1.25 text-sm;


### PR DESCRIPTION
Password criteria grid was using `grid-cols-2` at all viewport sizes. Changed to `grid-cols-1 sm:grid-cols-2` so it displays as a single column on mobile and two columns on larger screens.

Closes #189

Generated with [Claude Code](https://claude.ai/code)