### PR TITLE
fix: add aria-label to terms checkbox for correct accessible name

### DIFF
--- a/src/app/auth/signup/_components/SignUpForm.tsx
+++ b/src/app/auth/signup/_components/SignUpForm.tsx
@@ -363,6 +363,7 @@ export default function SignUpForm() {
                 onChange={(e) =>
                   setForm((f) => ({ ...f, termsAccepted: e.target.checked }))
                 }
+                aria-label="I agree to the Terms of Service and Privacy Policy"
                 aria-describedby={errors.terms ? "terms-error" : undefined}
               />
               <label


### PR DESCRIPTION
The terms checkbox label contained button elements whose text was excluded from the computed accessible name, causing screen readers to announce "I agree to the and" instead of the full text. Adding aria-label directly on the input overrides the computed name with the correct full string.

Fixes #254

Generated with [Claude Code](https://claude.ai/code)