### PR TITLE
Payout Phase 1 — Data-integrity foundations

### DIFF
--- a/.claude/skills/chip-collect/SKILL.md
+++ b/.claude/skills/chip-collect/SKILL.md
@@ -1,0 +1,433 @@
+---
+name: chip-collect
+description: Use this skill whenever the user wants to integrate CHIP (chip-in.asia) payment gateway into their application. Trigger this skill for any task involving CHIP API setup, creating purchases, handling payment callbacks, configuring webhooks, verifying signatures, going live, or troubleshooting CHIP payment flows — even if the user just says "add payments", "accept FPX/eWallet/card payments", or "integrate CHIP". This skill covers backend API integration in a language-agnostic way.
+---
+
+# CHIP Payment Gateway — Backend Integration Skill
+
+CHIP (chip-in.asia) is a Malaysian digital finance platform supporting FPX, credit/debit cards, e-wallets (Touch 'n Go, GrabPay, Boost), and DuitNow QR. This skill covers end-to-end backend API integration.
+
+> **Always integrate from the server side.** CHIP does not enable CORS — never expose your secret key to the browser/client.
+
+---
+
+## 📐 API Schema — Fetch, Don't Remember
+
+The authoritative source of truth for every endpoint is the CHIP
+Collect OpenAPI spec:
+
+- **OpenAPI YAML:** https://docs.chip-in.asia/openapi/chip-collect.yaml
+- **Rendered reference:** https://docs.chip-in.asia/chip-collect/api-reference/purchases/create
+
+**Do not hardcode endpoint paths in your integration code.** When
+you need an endpoint:
+
+1. Fetch the spec (or the rendered reference) and copy the path
+   verbatim.
+2. If a path you "remember" isn't in the spec, the spec wins —
+   your memory is wrong.
+3. If you build a client library, generate it from the spec (e.g.
+   with `openapi-generator` or `orval`) rather than writing paths
+   by hand.
+
+The endpoints referenced in this file (Create Purchase, Retrieve
+Purchase, Refund, etc.) are kept here as **worked examples**, not
+as the canonical list. Always cross-check the spec.
+
+---
+
+## ⚡ Before You Begin — Clarify Intent
+
+**Always ask the user this before writing any code:**
+
+> "Are you looking to:
+> 1. **Integrate CHIP into your actual system** (real backend endpoint, production/staging setup), or
+> 2. **Generate a dummy/test checkout link** to quickly verify the API works before building anything?
+>
+> 💡 If you're just exploring or haven't set up a backend yet, I recommend starting with **sandbox testing** — you can generate a real CHIP checkout link with test credentials in minutes, no backend needed."
+
+---
+
+### Path A — Sandbox / Dummy Link (Recommended Starting Point)
+
+Use this when the user wants to quickly test CHIP without a full backend. Guide them to:
+
+1. Log in to https://portal.chip-in.asia/collect → **Developers** → enable **Test Mode**
+2. Copy their **Test Mode API Key** (Secret Key) and **Brand ID**
+
+> ⚠️ **Use the Test Mode API key, not your live key.** The Merchant Portal shows a different Secret Key when Test Mode is toggled ON — that is your test key. Using your live key here may trigger real charges. When in doubt, the test key is usually prefixed or labelled differently in the portal.
+
+3. Make a single `curl` or REST client (Postman / Insomnia / Thunder Client) call:
+
+```bash
+curl -X POST https://gate.chip-in.asia/api/v1/purchases/ \
+  -H "Authorization: Bearer <TEST_SECRET_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client": { "email": "test@example.com" },
+    "purchase": {
+      "currency": "MYR",
+      "products": [{ "name": "Test Item", "price": 100, "quantity": 1 }]
+    },
+    "brand_id": "<BRAND_ID>",
+    "success_callback": "https://example.com/success",
+    "failure_callback": "https://example.com/failure"
+  }'
+```
+
+4. Copy the `checkout_url` from the response and open it in a browser
+5. Complete a test payment using CHIP's sandbox test credentials (shown on the payment page)
+
+> ✅ No server required. No code required. Great for validating credentials and seeing the payment flow end-to-end before building.
+
+**Once the user is happy with sandbox testing, suggest moving to Path B.**
+
+---
+
+### Path B — Full System Integration
+
+Proceed with the steps below to wire CHIP into a real backend.
+
+---
+
+## Quick Reference
+
+| Item | Value |
+|---|---|
+| Base URL | `https://gate.chip-in.asia/api/v1/` |
+| Auth | `Authorization: Bearer <YOUR_SECRET_KEY>` |
+| Content-Type | `application/json` |
+| OpenAPI spec | https://docs.chip-in.asia/openapi/chip-collect.yaml |
+| Docs | https://docs.chip-in.asia/chip-collect/api-reference/purchases/create |
+| GitHub SDKs | https://github.com/CHIPAsia |
+
+---
+
+## Step 1 — Get Your Credentials & Generate `.env`
+
+1. Sign up / log in at https://portal.chip-in.asia
+2. Go to **Developers** tab in the Merchant Portal
+3. Toggle **Test Mode** ON — the portal will now display your **Test Mode API key**
+4. Copy your **Test Mode Secret Key** (for API auth) and **Test Mode Public Key** (for webhook verification)
+5. Note your **Brand ID** (same Brand ID is used for both test and live)
+
+> ⚠️ **Always use the Test Mode API key during development.** CHIP issues a separate Secret Key and Public Key for Test Mode vs Live Mode — they are not interchangeable. Using your live key in development risks real charges.
+
+> 💡 **Sandbox vs Live:** Test Mode credentials only simulate payments — no real money moves. Always develop with Test Mode ON, then swap to live credentials only when deploying to production.
+
+**Generate these two files in the project root:**
+
+`.env` — empty values for the user to fill in, must never be committed:
+```
+# .env
+# CHIP Payment Gateway — Test Mode credentials
+# Get these from https://portal.chip-in.asia/collect → Developers (toggle Test Mode ON)
+# ⚠️ Never commit this file. Make sure .env is in your .gitignore.
+
+CHIP_SECRET_KEY=
+CHIP_PUBLIC_KEY=
+CHIP_BRAND_ID=
+```
+
+`.env.example` — safe placeholder to commit to version control:
+```
+# .env.example
+# Copy this file to .env and fill in your credentials from https://portal.chip-in.asia
+CHIP_SECRET_KEY=your_test_mode_secret_key_here
+CHIP_PUBLIC_KEY=your_test_mode_public_key_here
+CHIP_BRAND_ID=your_brand_id_here
+```
+
+> ✅ Ensure `.env` is listed in `.gitignore`. If a `.gitignore` doesn't exist yet, create one and add `.env` to it.
+
+When going live, replace the values in `.env` with Live Mode credentials (toggle Test Mode OFF in the portal to reveal them).
+
+---
+
+## Step 2 — Create a Purchase
+
+This is the core API call. Your server creates a purchase object and returns a `checkout_url` to redirect the customer.
+
+### Endpoint
+```
+POST https://gate.chip-in.asia/api/v1/purchases/
+```
+
+### Required Headers
+```
+Authorization: Bearer <CHIP_SECRET_KEY>
+Content-Type: application/json
+```
+
+### Minimal Request Body
+```json
+{
+  "client": {
+    "email": "customer@example.com"
+  },
+  "purchase": {
+    "currency": "MYR",
+    "products": [
+      {
+        "name": "Order #1234",
+        "price": 5000,
+        "quantity": 1
+      }
+    ]
+  },
+  "brand_id": "<CHIP_BRAND_ID>",
+  "success_callback": "https://yoursite.com/payment/success",
+  "failure_callback": "https://yoursite.com/payment/failure",
+  "cancel_callback": "https://yoursite.com/payment/cancel"
+}
+```
+
+> **Note:** `price` is in **cents** (e.g. `5000` = RM 50.00)
+
+### Success Response (HTTP 201)
+```json
+{
+  "id": "abc123-purchase-id",
+  "checkout_url": "https://gate.chip-in.asia/p/abc123/",
+  "status": "created"
+}
+```
+
+**Redirect the user to `checkout_url`** to complete payment on CHIP's hosted page.
+
+---
+
+## Step 2.5 — Generate a Test Script (Verify Setup Works)
+
+**Always generate a standalone test script** alongside the integration code. This lets the user verify their `.env` credentials and API connectivity before wiring up the full UI.
+
+The test script must:
+- Load `CHIP_SECRET_KEY` and `CHIP_BRAND_ID` from `.env`
+- Call `POST /purchases/` with a hardcoded dummy payload (RM 1.00 test item)
+- Print the `checkout_url` to the console on success
+- Print a clear error message on failure
+
+Generate the script in the language that matches the user's project stack.
+
+**Node.js** — save as `test-chip.js`:
+```js
+require('dotenv').config();
+const https = require('https');
+
+const payload = JSON.stringify({
+  client: { email: 'test@example.com' },
+  purchase: {
+    currency: 'MYR',
+    products: [{ name: 'Test Item', price: 100, quantity: 1 }]
+  },
+  brand_id: process.env.CHIP_BRAND_ID,
+  success_callback: 'https://example.com/success',
+  failure_callback: 'https://example.com/failure'
+});
+
+const options = {
+  hostname: 'gate.chip-in.asia',
+  path: '/api/v1/purchases/',
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${process.env.CHIP_SECRET_KEY}`,
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(payload)
+  }
+};
+
+const req = https.request(options, (res) => {
+  let data = '';
+  res.on('data', chunk => data += chunk);
+  res.on('end', () => {
+    try {
+      const json = JSON.parse(data);
+      if (json.checkout_url) {
+        console.log('\n✅ CHIP credentials are working!');
+        console.log('👉 Open this URL in your browser to test the payment flow:');
+        console.log('\n' + json.checkout_url + '\n');
+      } else {
+        console.error('\n❌ Something went wrong:');
+        console.error(JSON.stringify(json, null, 2));
+      }
+    } catch (e) {
+      console.error('\n❌ Failed to parse response:', data);
+    }
+  });
+});
+
+req.on('error', e => console.error('❌ Request failed:', e.message));
+req.write(payload);
+req.end();
+```
+
+**Python** — save as `test_chip.py`:
+```python
+import os, json, urllib.request
+from dotenv import load_dotenv
+
+load_dotenv()
+
+payload = json.dumps({
+    "client": {"email": "test@example.com"},
+    "purchase": {
+        "currency": "MYR",
+        "products": [{"name": "Test Item", "price": 100, "quantity": 1}]
+    },
+    "brand_id": os.getenv("CHIP_BRAND_ID"),
+    "success_callback": "https://example.com/success",
+    "failure_callback": "https://example.com/failure"
+}).encode()
+
+req = urllib.request.Request(
+    "https://gate.chip-in.asia/api/v1/purchases/",
+    data=payload,
+    headers={
+        "Authorization": f"Bearer {os.getenv('CHIP_SECRET_KEY')}",
+        "Content-Type": "application/json"
+    }
+)
+
+try:
+    with urllib.request.urlopen(req) as res:
+        data = json.loads(res.read())
+        print("\n✅ CHIP credentials are working!")
+        print("👉 Open this URL in your browser to test the payment flow:")
+        print(f"\n{data['checkout_url']}\n")
+except Exception as e:
+    print(f"\n❌ Something went wrong: {e}")
+```
+
+**After generating the test script, instruct the user:**
+> 1. Fill in `CHIP_SECRET_KEY` and `CHIP_BRAND_ID` in your `.env` file (leave `CHIP_PUBLIC_KEY` for now — only needed for webhooks)
+> 2. Run: `node test-chip.js` or `python test_chip.py`
+> 3. A `checkout_url` will be printed — open it in your browser
+> 4. Complete a test payment to confirm the full flow works end-to-end
+> 5. Once confirmed ✅, delete the test script before deploying to production
+
+---
+
+## Step 3 — Handle Payment Result
+
+There are two complementary methods. **Implement both** for reliability.
+
+### Method A: Return URL (Browser Redirect)
+
+After payment, CHIP redirects the user to your `success_callback` / `failure_callback` URL with query parameters:
+
+```
+https://yoursite.com/payment/success?id=abc123&status=paid
+```
+
+Use the `id` to look up the purchase and verify status server-side (do not trust client-side data alone).
+
+### Method B: Webhook (Server-to-Server) — Recommended
+
+Configure a webhook in your Merchant Portal → Developers → Webhooks. CHIP will POST to your callback URL for events like `purchase.paid`.
+
+**Webhook payload example:**
+```json
+{
+  "event_type": "purchase.paid",
+  "object": {
+    "id": "abc123",
+    "status": "paid",
+    "purchase": { },
+    "client": { }
+  },
+  "is_test": false
+}
+```
+
+> Use webhooks as the **source of truth** — return URLs can fail if the user closes the browser before redirect.
+
+---
+
+## Step 4 — Verify Webhook Signature
+
+All CHIP webhook deliveries include an `X-Signature` header. Always verify it before processing.
+
+**Verification logic (pseudocode):**
+```
+1. Read raw request body (as bytes — do not parse JSON first)
+2. Base64-decode the X-Signature header
+3. Verify the signature against the raw body using:
+   - Algorithm: RSA PKCS#1 v1.5
+   - Digest: SHA-256
+   - Key: CHIP_PUBLIC_KEY from .env
+4. If verification fails → return HTTP 200 but skip processing
+```
+
+**Important:** Return `HTTP 200` even when rejecting invalid signatures — CHIP retries on non-200 responses.
+
+---
+
+## Step 5 — Retrieve a Purchase
+
+To verify payment status server-side at any point:
+
+```
+GET https://gate.chip-in.asia/api/v1/purchases/<purchase_id>/
+Authorization: Bearer <CHIP_SECRET_KEY>
+```
+
+Check the `status` field:
+
+| Status | Meaning |
+|---|---|
+| `created` | Purchase created, awaiting payment |
+| `paid` | Payment successful ✅ |
+| `failed` | Payment failed |
+| `cancelled` | Cancelled by user |
+| `hold` | Pre-authorized, not yet captured |
+
+---
+
+## Step 6 — Go Live Checklist
+
+> 🧪 **Complete all sandbox testing before switching to live credentials.**
+
+- [ ] `.env` created with Test Mode credentials and added to `.gitignore`
+- [ ] Test script ran successfully and `checkout_url` opened in browser
+- [ ] Full payment flow tested in sandbox (success, failure, cancel)
+- [ ] Webhook signature verification tested with test deliveries
+- [ ] Test script deleted before production deploy
+- [ ] Switch `.env` values to **Live Mode credentials** from Merchant Portal (toggle Test Mode OFF)
+- [ ] Order status updated from webhook, not only from return URL
+- [ ] HTTPS enabled on your server (required for callbacks)
+- [ ] Handle idempotency — webhook may be delivered more than once; check if order already updated before processing
+- [ ] No sensitive data in logs
+
+---
+
+## Available SDKs & Plugins
+
+| Type | Options |
+|---|---|
+| Libraries | PHP, Java, C#, Node.js (see https://github.com/CHIPAsia) |
+| Plugins | WooCommerce, OpenCart, Magento, PrestaShop, WHMCS, Gravity Forms |
+| Mobile SDKs | iOS, Android |
+
+If a ready-made SDK exists for the user's language, recommend it over raw HTTP calls.
+
+---
+
+## Common Issues & Fixes
+
+| Problem | Likely Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Wrong or missing API key | Check `Authorization: Bearer` header; confirm Test Mode key is used |
+| `400 Bad Request` | Missing required fields | Ensure `brand_id`, `client.email`, `purchase.currency`, and at least one product are present |
+| Test script shows no `checkout_url` | Empty `.env` values | Fill in `CHIP_SECRET_KEY` and `CHIP_BRAND_ID` in `.env` |
+| Webhook not received | Callback URL not public | Ensure URL is publicly accessible; test with https://webhook.site |
+| Signature mismatch | Parsing JSON before verifying | Verify against **raw bytes**, not parsed JSON |
+| Duplicate order updates | Webhook retries | Check if order is already marked paid before processing again |
+
+---
+
+## References
+
+- API Docs: https://docs.chip-in.asia/chip-collect/api-reference/purchases/create
+- Webhooks Guide: https://blog.chip-in.asia/chip-api-webhooks/
+- GitHub (all SDKs & plugins): https://github.com/CHIPAsia
+- Merchant Portal: https://portal.chip-in.asia/collect

--- a/.claude/skills/chip-send/SKILL.md
+++ b/.claude/skills/chip-send/SKILL.md
@@ -1,0 +1,575 @@
+---
+name: chip-send
+description: Use this skill whenever the user wants to integrate the CHIP Send (chip-in.asia) payouts API into their application. Trigger this skill for tasks involving listing accounts, registering recipient bank accounts, requesting budget allocations, creating send instructions, configuring webhooks, or troubleshooting the three-header auth scheme (Authorization + epoch + HMAC-SHA512 checksum). This skill covers backend API integration in a language-agnostic way.
+---
+
+# CHIP Send — Backend Integration Skill
+
+CHIP Send (chip-in.asia) is the payouts arm of the CHIP platform: it lets
+a registered merchant send MYR funds to recipient bank accounts
+programmatically, with a four-step flow (check balance → allocate budget
+→ register recipient → send).
+
+> **Always integrate from the server side.** CHIP Send, like CHIP Collect,
+> does not enable CORS. Never expose your API Secret to the
+> browser/client — the secret is used to compute per-request checksums
+> and must stay on your server.
+
+---
+
+## 📐 API Schema — Fetch, Don't Remember
+
+The authoritative source of truth for every endpoint is the CHIP Send
+OpenAPI spec:
+
+- **OpenAPI YAML:** https://docs.chip-in.asia/openapi/chip-send.yaml
+- **Rendered reference:** https://docs.chip-in.asia/chip-send/api-reference/introduction
+
+**Do not hardcode endpoint paths in your integration code.** When you
+need an endpoint:
+
+1. Fetch the spec (or the rendered reference) and copy the path
+   verbatim.
+2. If a path you "remember" isn't in the spec, the spec wins —
+   your memory is wrong.
+3. If you build a client library, generate it from the spec rather
+   than writing paths by hand.
+
+The endpoints referenced in this file (Accounts, Send Limits, Bank
+Accounts, Send Instructions) are kept here as **worked examples**,
+not as the canonical list. Always cross-check the spec.
+
+---
+
+## Quick Reference
+
+| Item | Value |
+|---|---|
+| Base URL (sandbox) | `https://staging-api.chip-in.asia/api` |
+| Base URL (production) | `https://api.chip-in.asia/api` |
+| Auth header 1 | `Authorization: Bearer <API Key>` |
+| Auth header 2 | `epoch: <unix seconds, must be within 30s of server>` |
+| Auth header 3 | `checksum: HEX( HMAC_SHA512( api_secret, "<epoch><api_key>" ) )` |
+| Content-Type | `application/json` |
+| OpenAPI spec | https://docs.chip-in.asia/openapi/chip-send.yaml |
+| Docs | https://docs.chip-in.asia/chip-send/api-reference/introduction |
+| Portal | https://portal.chip-in.asia/control/settings/applications |
+
+---
+
+## Prerequisites
+
+Unlike CHIP Collect (self-serve in the portal), CHIP Send requires
+**admin setup** before any integration can begin. The merchant's CHIP
+Account Manager must be contacted with:
+
+1. A **primary email address** for the Send account.
+2. The **email addresses of every required approver**. If two
+   approvals are required for budget allocations, both email
+   addresses must be provided.
+
+Two credentials are issued to the merchant:
+
+| Credential | Where it goes | What it does |
+|---|---|---|
+| **API Key** | `Authorization: Bearer <API Key>` header | Identifies the merchant. Sent on every request. |
+| **API Secret** | Never sent over the network. Used only for signing. | Computes the per-request checksum. Must be stored securely, like a password. |
+
+The API Key and the `api_key` value used inside the checksum string
+are the **same value**. The API Secret is **never** transmitted — it
+only lives on the merchant's server.
+
+Both credentials are available in the merchant portal at
+[CHIP Control → Settings → Applications](https://portal.chip-in.asia/control/settings/applications).
+
+---
+
+## How Authentication Works
+
+Every request must include three headers. Skipping any one of them
+returns `401 Unauthorized`.
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <API Key>` |
+| `epoch` | Current Unix timestamp in seconds (e.g. `1689826456`) |
+| `checksum` | Hex-encoded HMAC-SHA512 of the signing string, computed with the API Secret |
+
+**Clock skew:** the `epoch` value must be within **30 seconds** of
+the server's clock. If it's too old or too far in the future, the
+request is rejected as `Unauthorized`. The merchant's server clock
+must be synchronised (NTP, chrony, or your cloud provider's time
+service).
+
+### How to compute the checksum
+
+The signing string is formed by **concatenating the `epoch` value
+and the API Key with no separator, in that order**:
+
+```
+signing_string = <epoch> + <API Key>
+```
+
+For example, with `epoch = 1689826456` and
+`API Key = e0645c9e-fcf2-4f29-a327-202f7ed3d969`:
+
+```
+1689826456e0645c9e-fcf2-4f29-a327-202f7ed3d969
+```
+
+The checksum is then:
+
+```
+checksum = HEX( HMAC_SHA512( key = API Secret, message = signing_string ) )
+```
+
+The expected value for the example above is:
+
+```
+45bee62dba8087ab1e7e767d92f8d6e26f8bd19ee5fd2fef6386bb9425976498a86ffdbddb7a49919998e993c20626196ea652320f438a9528d2b8c9d19ec266
+```
+
+Use this as a unit-test fixture to verify your implementation before
+sending any real request.
+
+### Language examples
+
+**Node.js**:
+```js
+const crypto = require('crypto');
+
+const epoch = Math.floor(Date.now() / 1000).toString();
+const apiKey = process.env.CHIP_API_KEY;
+const apiSecret = process.env.CHIP_API_SECRET;
+
+const signingString = epoch + apiKey;
+const checksum = crypto
+  .createHmac('sha512', apiSecret)
+  .update(signingString)
+  .digest('hex');
+
+// Then send the request with headers:
+//   Authorization: Bearer <apiKey>
+//   epoch: <epoch>
+//   checksum: <checksum>
+```
+
+**Python**:
+```python
+import hashlib, hmac, time
+
+epoch = str(int(time.time()))
+api_key = os.getenv("CHIP_API_KEY")
+api_secret = os.getenv("CHIP_API_SECRET")
+
+signing_string = (epoch + api_key).encode()
+checksum = hmac.new(api_secret.encode(), signing_string, hashlib.sha512).hexdigest()
+
+# Then send the request with headers:
+#   Authorization: Bearer <api_key>
+#   epoch: <epoch>
+#   checksum: <checksum>
+```
+
+**PHP**:
+```php
+<?php
+$epoch = (string) time();
+$apiKey = getenv('CHIP_API_KEY');
+$apiSecret = getenv('CHIP_API_SECRET');
+
+$signingString = $epoch . $apiKey;
+$checksum = hash_hmac('sha512', $signingString, $apiSecret);
+
+// Then send the request with headers:
+//   Authorization: Bearer <apiKey>
+//   epoch: <epoch>
+//   checksum: <checksum>
+```
+
+> ⚠️ **The checksum must be recomputed for every request with a
+> fresh `epoch`.** A common integration bug is computing the
+> checksum once and reusing it across requests — the server will
+> reject these as `Unauthorized`.
+
+---
+
+## Step 1 — Generate `.env` and a Test Script
+
+Generate these two files in the project root:
+
+`.env` (must never be committed):
+```
+# .env
+# CHIP Send API credentials
+# Get these from https://portal.chip-in.asia/control → Settings → Applications
+# ⚠️ Never commit this file. Make sure .env is in your .gitignore.
+
+CHIP_API_KEY=
+CHIP_API_SECRET=
+```
+
+`.env.example` (safe to commit):
+```
+# .env.example
+# Copy to .env and fill in your credentials from https://portal.chip-in.asia
+CHIP_API_KEY=your_api_key_here
+CHIP_API_SECRET=your_api_secret_here
+```
+
+**Generate a smoke-test script.** This verifies your three-header
+auth works end-to-end before wiring up the full payout flow.
+
+**Node.js** — save as `test-chip-send.js`:
+```js
+require('dotenv').config();
+const https = require('https');
+const crypto = require('crypto');
+
+const apiKey = process.env.CHIP_API_KEY;
+const apiSecret = process.env.CHIP_API_SECRET;
+const epoch = Math.floor(Date.now() / 1000).toString();
+const signingString = epoch + apiKey;
+const checksum = crypto.createHmac('sha512', apiSecret).update(signingString).digest('hex');
+
+const options = {
+  hostname: 'staging-api.chip-in.asia',
+  path: '/api/send/accounts',
+  method: 'GET',
+  headers: {
+    'Authorization': `Bearer ${apiKey}`,
+    'epoch': epoch,
+    'checksum': checksum
+  }
+};
+
+const req = https.request(options, (res) => {
+  let data = '';
+  res.on('data', chunk => data += chunk);
+  res.on('end', () => {
+    console.log(`\nHTTP ${res.statusCode}`);
+    try {
+      const json = JSON.parse(data);
+      if (res.statusCode === 200) {
+        console.log('✅ CHIP Send auth is working!');
+        console.log(JSON.stringify(json, null, 2));
+      } else {
+        console.error('❌ Something went wrong:');
+        console.error(JSON.stringify(json, null, 2));
+      }
+    } catch (e) {
+      console.error('❌ Failed to parse response:', data);
+    }
+  });
+});
+req.on('error', e => console.error('❌ Request failed:', e.message));
+req.end();
+```
+
+**Python** — save as `test_chip_send.py`:
+```python
+import os, json, hmac, hashlib, time, urllib.request
+from dotenv import load_dotenv
+load_dotenv()
+
+api_key = os.getenv("CHIP_API_KEY")
+api_secret = os.getenv("CHIP_API_SECRET")
+epoch = str(int(time.time()))
+signing_string = (epoch + api_key).encode()
+checksum = hmac.new(api_secret.encode(), signing_string, hashlib.sha512).hexdigest()
+
+req = urllib.request.Request(
+    "https://staging-api.chip-in.asia/api/send/accounts",
+    headers={
+        "Authorization": f"Bearer {api_key}",
+        "epoch": epoch,
+        "checksum": checksum
+    }
+)
+try:
+    with urllib.request.urlopen(req) as res:
+        data = json.loads(res.read())
+        print("\n✅ CHIP Send auth is working!")
+        print(json.dumps(data, indent=2))
+except urllib.error.HTTPError as e:
+    print(f"\n❌ HTTP {e.code}: {e.read().decode()}")
+```
+
+Run it: `node test-chip-send.js` or `python test_chip_send.py`. A
+`200 OK` with an accounts payload confirms the three-header auth
+works. **Delete the test script before deploying to production.**
+
+---
+
+## Step 2 — The Four-Step Payout Flow
+
+A complete payout consists of four steps. **Steps 1-2 happen once per
+payout batch; steps 3-4 happen once per recipient.**
+
+### Step 2.1 — Check the convertible balance
+
+```
+GET /api/send/accounts
+```
+
+Returns one account per currency. The key fields are:
+
+- `current_balance` — the available balance for send instructions.
+- `convertible_balance_from_statement` — additional balance unlocked
+  from settled funds (resets daily in sandbox; real-time in production).
+
+**Why this matters:** every send instruction reduces `current_balance`.
+A `403 Forbidden` on a create-send-instruction call usually means
+insufficient balance.
+
+### Step 2.2 — Increase the send limit (allocate budget)
+
+```
+POST /api/send/send_limits
+Content-Type: application/json
+
+{
+  "amount": 5000
+}
+```
+
+The `amount` is in **MYR × 100** (so `5000` = RM 50.00, mirroring
+CHIP Collect's cents convention). This call allocates additional
+budget from `convertible_balance_from_statement` into
+`current_balance`.
+
+**Approval flow:** if your account requires approval, the request
+generates an email to each approver. Once all required approvers
+click **Approve** in the email, the new balance is reflected in the
+accounts response.
+
+You can re-send the approval email with:
+
+```
+POST /api/send/send_limits/{id}/resend_approval_requests
+```
+
+### Step 2.3 — Register a recipient bank account
+
+```
+POST /api/send/bank_accounts
+Content-Type: application/json
+
+{
+  "account_number": "157380112229",
+  "bank_code": "MBBEMYKL",
+  "name": "Ahmad Razali",
+  "reference": "VENDOR-EMP-001"
+}
+```
+
+- `account_number` — the recipient's bank account number (no dashes
+  or spaces).
+- `bank_code` — the SWIFT/BIC code of the recipient's bank
+  (e.g. `MBBEMYKL` for Maybank Malaysia).
+- `name` — the recipient's name as it appears on the account.
+- `reference` — **unique** value used to prevent duplicate
+  submissions. Reuse it across retries.
+
+Successful response returns a `bank_account_id` (an integer) and a
+status (`verified` or `unverified`). Use that ID in step 2.4.
+
+### Step 2.4 — Create a send instruction
+
+```
+POST /api/send/send_instructions
+Content-Type: application/json
+
+{
+  "bank_account_id": 1,
+  "amount": "100",
+  "description": "Vendor payout for invoice INV-2024-0892",
+  "email": "recipient@example.com",
+  "reference": "INV-2024-0892",
+  "send_recipient_receipt": true
+}
+```
+
+- `bank_account_id` — the ID returned by step 2.3.
+- `amount` — **string** in MYR × 100 (so `"100"` = RM 1.00).
+  Note this differs from Send Limit's numeric `amount`.
+- `description` — 1–140 chars, shown in the recipient receipt.
+- `reference` — your internal ID for the payout (1–40 chars).
+- `email` — recipient's email; receives the receipt if
+  `send_recipient_receipt` is `true`.
+- `send_recipient_receipt` — boolean, default `false`.
+
+A `200 OK` with `state: "completed"` confirms the payout cleared.
+The `receipt_url` field is the public receipt the recipient sees.
+
+> ⚠️ **`amount` is a string, not a number.** This is the most common
+> integration bug for Send. JSON numbers lose precision for large
+> values; strings don't. Always send `"100"`, never `100`.
+
+---
+
+## Step 3 — Idempotency and the `reference` Field
+
+The `reference` field on bank accounts, send limits, and send
+instructions exists specifically to **prevent duplicate
+submissions**. Use a deterministic value (e.g. your internal
+invoice ID) so a retried call after a network error doesn't
+create a second recipient or send a second payout.
+
+| Resource | `reference` field | Behavior on retry |
+|---|---|---|
+| Bank Account | Optional, max 65535 chars | A duplicate `reference` returns the existing record. |
+| Send Instruction | Required, 1–40 chars | A duplicate `reference` returns the existing payout, no double-spend. |
+
+---
+
+## Step 4 — Webhooks (recommended for production)
+
+Configure a webhook in
+[CHIP Control → Settings → Applications](https://portal.chip-in.asia/control/settings/applications).
+CHIP Send will POST to your callback URL for events like
+`send_instruction.created`, `send_instruction.completed`,
+`bank_account.verified`, etc.
+
+> Use webhooks as the **source of truth** for state transitions.
+> Polling `GET /send/send_instructions/{id}` works but is rate-limited
+> and stale by design (the list endpoint is cached for an hour).
+
+---
+
+## Step 5 — Webhook Signature Verification
+
+CHIP Send webhook payloads are signed. **The signature scheme is
+the same as the API auth** — `HMAC-SHA512`, keyed on your
+`api_secret`, encoded as **hex**. This is *different* from CHIP
+Collect, which uses RSA-SHA512 with Base64 encoding. Don't reuse
+Collect verification code on Send.
+
+**Algorithm (matches the description in the [OpenAPI spec](https://docs.chip-in.asia/openapi/chip-send.yaml) and the [rendered reference](https://docs.chip-in.asia/chip-send/api-reference/introduction)):**
+
+| Property | Value |
+|---|---|
+| Header | `X-Signature` |
+| Algorithm | `HMAC-SHA512` |
+| Encoding | **hex** (lowercase, 128 chars) |
+| Key | Your `api_secret` (the same value used for API auth) |
+| Signed payload | The **raw request body** as bytes (not the parsed JSON) |
+| Library (Node.js) | `crypto.createHmac('sha512', api_secret).update(rawBody).digest('hex')` |
+| Library (Python) | `hmac.new(api_secret.encode(), raw_body, hashlib.sha512).hexdigest()` |
+
+**Verification logic (pseudocode):**
+
+```
+1. Read the raw request body as bytes — do NOT parse JSON first
+2. Compute: expected = HEX( HMAC_SHA512( api_secret, body ) )
+3. Compare expected to the X-Signature header in constant time
+4. If they don't match -> return HTTP 200 but skip processing
+   (returning 4xx causes CHIP to retry; you want silent rejection)
+```
+
+> ⚠️ **Clock skew tolerance is 120 seconds in the past, 60
+> seconds in the future** on the inbound side (the merchant's
+> request to CHIP, not the webhook delivery). Plan your NTP
+> accordingly. The Send OpenAPI spec advertises 30 seconds; the
+> actual tolerance is more generous. Either is safe — the
+> difference matters only when debugging.
+
+**Node.js example:**
+
+```js
+const crypto = require('crypto');
+
+function verifySignature(rawBody, signatureHeader, apiSecret) {
+  const expected = crypto
+    .createHmac('sha512', apiSecret)
+    .update(rawBody)  // rawBody must be a Buffer, not a parsed object
+    .digest('hex');
+
+  // Constant-time comparison to avoid timing attacks
+  return crypto.timingSafeEqual(
+    Buffer.from(expected, 'hex'),
+    Buffer.from(signatureHeader, 'hex')
+  );
+}
+```
+
+**Python example:**
+
+```python
+import hmac, hashlib
+
+def chip_send_signature_valid(raw_body: bytes, signature_header: str, api_secret: str) -> bool:
+    expected = hmac.new(
+        api_secret.encode(),
+        raw_body,
+        hashlib.sha512
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+```
+
+> If your framework auto-parses the body (Express, FastAPI, etc.),
+> you must capture the raw bytes **before** parsing. In Express,
+> use `express.raw({ type: 'application/json' })` and call
+> `JSON.parse(rawBody)` after verification. In FastAPI, read
+> `await request.body()` before any Pydantic model parsing.
+
+---
+
+## Step 6 — Go Live Checklist
+
+> 🧪 **Complete all sandbox testing before switching to live credentials.**
+
+- [ ] `.env` created with sandbox API Key and Secret, added to `.gitignore`
+- [ ] Test script returned `200 OK` from `/send/accounts`
+- [ ] A full payout completed in sandbox (all four steps, ending
+      in `state: "completed"`)
+- [ ] Webhook signature verification tested with a test delivery
+- [ ] Idempotency tested: re-sending the same `reference` did not
+      create a duplicate
+- [ ] Test script deleted before production deploy
+- [ ] Server clock synchronised (NTP) — verify the `epoch` value
+      stays within 30 seconds of the server's clock
+- [ ] Switch `.env` values to **production** credentials from
+      [CHIP Control → Settings → Applications](https://portal.chip-in.asia/control/settings/applications)
+- [ ] Switch base URL from `staging-api.chip-in.asia` to
+      `api.chip-in.asia`
+- [ ] No sensitive data in logs (especially the API Secret, which
+      must never appear anywhere outside the server)
+
+---
+
+## Common Issues & Fixes
+
+| Problem | Likely cause | Fix |
+|---|---|---|
+| `401 Unauthorized` with no detail | `epoch` is more than 30 s off the server clock | NTP-sync the server; verify with `date +%s` against an NTP source |
+| `401 Unauthorized` with checksum error | Wrong signing string or encoding | Verify: (a) string is `<epoch><api_key>` **no separator**, (b) the message is a *string* not JSON, (c) output is **hex** (not base64), (d) **SHA-512** (not SHA-256) |
+| `401 Unauthorized` with auth error | `Authorization: Bearer <API Key>` header missing/malformed | Confirm header is present and the API Key is correct |
+| `400 Bad Request` on a valid-looking payload | `epoch` or `checksum` header missing or has unexpected characters | All three headers required on every request |
+| Works in Postman, fails from code | Checksum is being computed once and reused | Recompute checksum with a fresh `epoch` for every request |
+| `403 Forbidden` on create-send-instruction | Insufficient balance | Call `POST /send/send_limits` to allocate more, or wait for the existing allocation to be approved |
+| Recipient never receives the email | `send_recipient_receipt` is `false`, or email went to spam | Set the field to `true`; verify the recipient's email address |
+| `amount` field rejected as "must be string" | Sent a JSON number instead of a string | Send `"100"` (string) — Send requires string amounts to avoid float precision loss |
+
+---
+
+## Available SDKs & Plugins
+
+| Type | Options |
+|---|---|
+| Libraries | See https://github.com/CHIPAsia for the current list. CHIP Send ships with raw-HTTP examples only at the moment. |
+| Plugins | None at the moment. CHIP Send is payouts-only and used directly by merchant backends. |
+
+If a ready-made SDK exists for the user's language, recommend it
+over raw HTTP. Otherwise, use the language examples in
+**How to compute the checksum** as the starting point.
+
+---
+
+## References
+
+- API Docs: https://docs.chip-in.asia/chip-send/api-reference/introduction
+- OpenAPI Spec: https://docs.chip-in.asia/openapi/chip-send.yaml
+- Merchant Portal: https://portal.chip-in.asia/control/settings/applications
+- GitHub: https://github.com/CHIPAsia
+- Related skill (CHIP Collect): `npx -y github:CHIPAsia/skill`

--- a/db/migrations/001_tables.sql
+++ b/db/migrations/001_tables.sql
@@ -158,6 +158,13 @@ CREATE TABLE tournaments (
   venue_name                  varchar(255) NOT NULL,
   venue_state                 varchar(50) NOT NULL,
   venue_address               text NOT NULL,
+  -- ISO 3166-1 alpha-2 of the venue. Deliberately separate from `timezone`
+  -- below: the country decides which payout rails and currency a tournament's
+  -- money moves on, the timezone decides how its dates read. A country can span
+  -- several zones, so neither derives from the other.
+  -- The set an organizer may pick from is enforced in the app
+  -- (SUPPORTED_COUNTRIES in src/lib/venues.ts), which also owns venue_state.
+  venue_country               varchar(2)  NOT NULL DEFAULT 'MY',
   -- IANA timezone of the venue: a tournament's times belong to where it is played, not to whoever is reading them.
   -- start_date/end_date are calendar dates in this zone, timestamptz columns are instants displayed in it,
   -- and ongoing/upcoming/past is judged against "now" here.

--- a/db/migrations/001_tables.sql
+++ b/db/migrations/001_tables.sql
@@ -115,9 +115,11 @@ CREATE TABLE organizations (
   links                 jsonb,  -- {"website": "https://...", "facebook": "...", "twitter": "..."}
   email                 varchar(255),
   phone                 varchar(20),
-  bank_name             varchar(100),
-  bank_account_holder   varchar(255),
-  bank_account_number   varchar(50),
+  -- No bank columns here by design. The "Public can view approved organizations"
+  -- SELECT policy (004_rls.sql) has no column restriction, so anything stored on
+  -- this row is readable by anon through PostgREST. Payout bank details live in
+  -- organization_bank_accounts, which is RLS-gated on bank_account.manage and
+  -- superseded (not updated) on change so verification can't go stale.
   past_tournament_refs  text,
   approval_status       approval_status NOT NULL DEFAULT 'pending',
   reviewed_by           uuid REFERENCES users(id) ON DELETE SET NULL,

--- a/db/migrations/001_tables.sql
+++ b/db/migrations/001_tables.sql
@@ -178,7 +178,17 @@ CREATE TABLE tournaments (
   is_fide_rated               boolean NOT NULL DEFAULT false,
   is_mcf_rated                boolean NOT NULL DEFAULT false,
   entry_fees                  jsonb NOT NULL, -- {"standard": {"amount_cents": 4000},"additional": [{"type": "early_bird","valid_until": "2026-02-19T00:00:00+00:00","valid_for":20,"amount_cents": 3200},{"type": "age_based","age_max": 12,"age_min": 0,"amount_cents": 2400}]}
-  prizes                      jsonb,          -- {"categories": [{"name": "Open","entries": [{"place": "1st","amount_cents": 80000},{"place": "2nd","amount_cents": 48000},{"place": "3rd","amount_cents": 32000}]}],"subcategories": [{"name": "Best Under-1500","entries": [{"place": "1st","amount_cents": 20000}],"conditions": {"max_rating": 1499}},{"name": "Best Female Player","entries": [{"place": "1st","amount_cents": 20000}],"conditions": {"gender": "female"}}]}
+  -- Canonical shape is PrizesJson in src/lib/prize-funding.ts. Two lists:
+  -- `categories` are placed (1st/2nd/3rd) and hold `entries`; `special` prizes
+  -- are flat, one name and one amount, with the eligibility rule carried in the
+  -- name. `distribution` is who hands the money over — "organizer" (default) or
+  -- "platform".
+  -- Every category or special prize carrying money must declare `funding`:
+  -- entry fees never fund prizes, so there is no "entry_fees" funding source and
+  -- publish validation refuses money with no external source named. An empty
+  -- category is a structural placeholder and is exempt.
+  -- {"categories": [{"name": "Open","funding": {"source": "sponsor","funder_name": "Maybank Foundation"},"entries": [{"place": "1st","amount_cents": 80000},{"place": "2nd","amount_cents": 48000},{"place": "3rd","amount_cents": 32000}]}],"special": [{"name": "Best Under-1500","funding": {"source": "grant","funder_name": "Ministry of Youth and Sports"},"amount_cents": 20000}],"distribution": "organizer"}
+  prizes                      jsonb,
   restrictions                jsonb,          -- {"age": {"max": 18}} or {"gender": "female"}
   max_participants            integer NOT NULL,
   commission_rate             smallint NOT NULL DEFAULT 10, -- platform's cut (%)

--- a/db/migrations/002_indexes.sql
+++ b/db/migrations/002_indexes.sql
@@ -47,7 +47,7 @@ CREATE INDEX idx_payments_registration ON payments (registration_id);
 CREATE INDEX idx_payments_payout_summary ON payments (tournament_id, organization_id, type)
   INCLUDE (gross_amount_cents)
   WHERE status = 'paid'
-  AND type IN ('registration', 'player_prize', 'refund');
+  AND type IN ('registration', 'player_prize', 'refund', 'organizer_payout');
 
 -- At most one paid refund per registration. Defence-in-depth alongside the
 -- unique chip_transaction_id index: even if two settlement paths (sync response

--- a/db/migrations/003_functions_triggers.sql
+++ b/db/migrations/003_functions_triggers.sql
@@ -193,11 +193,42 @@ RETURNS boolean AS $$
 $$ LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public;
 
 -- =============================================
+-- AUDIT SNAPSHOT REDACTION
+-- audit_logs stores full row snapshots, so any sensitive column is copied
+-- verbatim into a table that outlives the row it came from. This masks the
+-- listed keys down to a last-4 suffix, keeping the snapshot useful for
+-- "did this value change?" without retaining the secret itself.
+-- Keys absent from the row are ignored; NULL values stay NULL so the audit
+-- trail still distinguishes "cleared" from "set to something".
+-- =============================================
+CREATE OR REPLACE FUNCTION redact_jsonb_columns(p_data jsonb, p_cols text[])
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN p_data IS NULL THEN NULL
+    ELSE (
+      SELECT jsonb_object_agg(
+        e.key,
+        CASE
+          WHEN e.key = ANY(p_cols) AND jsonb_typeof(e.value) = 'string'
+            THEN to_jsonb('****' || right(e.value #>> '{}', 4))
+          ELSE e.value
+        END
+      )
+      FROM jsonb_each(p_data) AS e(key, value)
+    )
+  END;
+$$;
+
+-- =============================================
 -- AUDIT TRAIL TRIGGER
 -- Generic trigger for all audited tables.
 -- TG_ARGV[0]: column name for record_id (defaults to 'id')
 -- Resolves organization_id from source table for RLS scoping.
 -- Reads app.audit_context session var for context tagging.
+-- Sensitive columns are redacted per-table before the snapshot is written.
 -- =============================================
 CREATE OR REPLACE FUNCTION audit_trigger_func()
 RETURNS TRIGGER AS $$
@@ -219,6 +250,15 @@ BEGIN
 
   -- Extract record_id from the appropriate column
   v_record_id := COALESCE(v_new, v_old) ->> v_pk_col;
+
+  -- Redact sensitive columns before the snapshot is persisted. Done after
+  -- record_id extraction so a redacted column can never be the PK. Without this
+  -- every bank-account write is copied verbatim into audit_logs, which is
+  -- retained far longer than the row itself.
+  IF TG_TABLE_NAME = 'player_profiles' THEN
+    v_old := redact_jsonb_columns(v_old, ARRAY['bank_account_number', 'oku_document_path']);
+    v_new := redact_jsonb_columns(v_new, ARRAY['bank_account_number', 'oku_document_path']);
+  END IF;
 
   -- Resolve organization_id based on source table
   IF TG_TABLE_NAME = 'organizations' THEN

--- a/db/migrations/003_functions_triggers.sql
+++ b/db/migrations/003_functions_triggers.sql
@@ -341,6 +341,74 @@ CREATE TRIGGER audit_trail AFTER INSERT OR UPDATE OR DELETE ON tournament_cancel
   FOR EACH ROW EXECUTE FUNCTION audit_trigger_func();
 
 -- =============================================
+-- TOURNAMENT EDIT FREEZE (money fields)
+-- entry_fees/prizes/max_participants and the commission split define what a
+-- player is buying. Once anyone has paid, changing them rewrites a concluded
+-- transaction — and moving `prizes` also shifts the payout holdback under a
+-- tournament that is already selling.
+--
+-- The PATCH route returns the readable 409 (naming the rejected fields); this
+-- trigger is the authority, so the rule holds for any writer including the
+-- service role and the SQL editor. Same belt-and-braces posture as
+-- settle_registration_payment's amount guard.
+--
+-- The "tournament has started" half of the freeze is NOT enforced here: it
+-- depends on today-in-the-venue-timezone, and pinning that in the DB would
+-- duplicate getTodayInTimeZone() with a second, drifting definition. It lives
+-- in the route only.
+--
+-- Deliberately allows the write when the value is unchanged, so a client that
+-- re-submits the whole form without touching money fields still succeeds.
+-- =============================================
+CREATE OR REPLACE FUNCTION guard_tournament_money_fields()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_changed text[] := ARRAY[]::text[];
+BEGIN
+  IF NEW.entry_fees IS DISTINCT FROM OLD.entry_fees THEN
+    v_changed := v_changed || 'entry_fees';
+  END IF;
+  IF NEW.prizes IS DISTINCT FROM OLD.prizes THEN
+    v_changed := v_changed || 'prizes';
+  END IF;
+  IF NEW.max_participants IS DISTINCT FROM OLD.max_participants THEN
+    v_changed := v_changed || 'max_participants';
+  END IF;
+  IF NEW.commission_rate IS DISTINCT FROM OLD.commission_rate THEN
+    v_changed := v_changed || 'commission_rate';
+  END IF;
+  IF NEW.organizer_commission_pct IS DISTINCT FROM OLD.organizer_commission_pct THEN
+    v_changed := v_changed || 'organizer_commission_pct';
+  END IF;
+
+  IF array_length(v_changed, 1) IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM payments p
+    WHERE p.tournament_id = NEW.id
+      AND p.type = 'registration'
+      AND p.status = 'paid'
+  ) THEN
+    RAISE EXCEPTION
+      'tournament % has paid registrations; these fields are locked: %',
+      NEW.id, array_to_string(v_changed, ', ')
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER guard_money_fields BEFORE UPDATE ON tournaments
+  FOR EACH ROW EXECUTE FUNCTION guard_tournament_money_fields();
+
+-- =============================================
 -- TOURNAMENT CAPACITY ENFORCEMENT
 -- Prevents over-registration via a row-level lock. A pending_payment seat is
 -- only held for a limited window (the payment timeout); after it lapses the seat

--- a/db/migrations/006_seed.sql
+++ b/db/migrations/006_seed.sql
@@ -148,6 +148,7 @@ DECLARE
   t_status     tournament_status;
   t_fee          integer;
   v_idx          integer;
+  f_idx          integer;
   t_restrictions jsonb;
 
   -- Name pools
@@ -253,6 +254,33 @@ DECLARE
     'Asia/Kuala_Lumpur','Asia/Kuala_Lumpur',
     'Asia/Bangkok','Asia/Jakarta','Asia/Singapore',
     'Asia/Kuala_Lumpur','Asia/Kuala_Lumpur'
+  ];
+  -- ISO 3166-1 alpha-2 of each venue (tournaments.venue_country). Deliberately
+  -- separate from the timezone above: the country decides which payout rails and
+  -- currency the money moves on, the timezone decides how the dates read. A
+  -- country can span several zones, so neither derives from the other.
+  --
+  -- Positions 7–9 are TH/ID/SG, which are NOT in SUPPORTED_COUNTRIES
+  -- (src/lib/venues.ts is MY-only today) — exactly as their venue_states above
+  -- already sit outside the Malaysian region list. They exist to exercise
+  -- cross-country reads; editing one through the creation wizard would fall back
+  -- to MY, which is the accepted cost of seeding venues the picklist cannot yet
+  -- express. Widening SUPPORTED_COUNTRIES is what makes them round-trip.
+  venue_countries text[] := ARRAY[
+    'MY','MY','MY','MY',
+    'MY','MY',
+    'TH','ID','SG',
+    'MY','MY'
+  ];
+  -- Prize funding. Entry fees never fund prizes (src/lib/prize-funding.ts), so
+  -- every category carrying money must name an external source and the party
+  -- putting it up. Publish validation rejects one that doesn't, so seeded
+  -- tournaments have to declare it or they could not be re-published.
+  funding_srcs text[] := ARRAY['sponsor','grant','organizer'];
+  funder_names text[] := ARRAY[
+    'Maybank Foundation',
+    'Ministry of Youth and Sports',
+    NULL  -- 'organizer' names the organizing body itself; filled in per row
   ];
   t_types   text[]    := ARRAY['rapid','blitz','classical','rapid','blitz'];
   t_rounds  integer[] := ARRAY[7, 9, 9, 7, 11];
@@ -518,6 +546,7 @@ BEGIN
 
       t_fee := fee_opts[((idx - 1) % 5) + 1];
       v_idx := ((idx - 1) % array_length(venue_names, 1)) + 1;
+      f_idx := (idx % array_length(funding_srcs, 1)) + 1;
 
       -- Vary restrictions: open, nationality, age, gender, rating, combined
       t_restrictions := CASE (idx % 6)
@@ -531,7 +560,7 @@ BEGIN
 
       INSERT INTO public.tournaments (
         organization_id, name, slug, description,
-        venue_name, venue_state, venue_address, timezone,
+        venue_name, venue_state, venue_address, venue_country, timezone,
         start_date, end_date, registration_deadline,
         format, time_control,
         is_fide_rated, is_mcf_rated,
@@ -555,6 +584,7 @@ BEGIN
         venue_names[v_idx],
         venue_states[v_idx],
         venue_addrs[v_idx],
+        venue_countries[v_idx],
         venue_tz[v_idx],
         t_start, t_end, t_deadline,
         json_build_object(
@@ -588,6 +618,12 @@ BEGIN
           'categories', json_build_array(
             json_build_object(
               'name', 'Open',
+              -- Every category carrying money names its source and funder;
+              -- publish validation refuses one that doesn't.
+              'funding', json_build_object(
+                'source', funding_srcs[f_idx],
+                'funder_name', COALESCE(funder_names[f_idx], org_names[i])
+              ),
               'entries', json_build_array(
                 json_build_object('place', '1st', 'amount_cents', t_fee * 20),
                 json_build_object('place', '2nd', 'amount_cents', t_fee * 12),
@@ -595,22 +631,32 @@ BEGIN
               )
             )
           ),
-          'subcategories', json_build_array(
+          -- Special prizes are flat — one name, one amount, its own funding —
+          -- not category-shaped (SpecialPrizeJson, src/lib/prize-funding.ts).
+          -- The eligibility rule lives in the name because nothing reads a
+          -- structured condition: the wizard's SpecialPrize has no field for one.
+          'special', json_build_array(
             json_build_object(
               'name', 'Best Under-1500',
-              'entries', json_build_array(
-                json_build_object('place', '1st', 'amount_cents', t_fee * 5)
+              'funding', json_build_object(
+                'source', funding_srcs[f_idx],
+                'funder_name', COALESCE(funder_names[f_idx], org_names[i])
               ),
-              'conditions', json_build_object('max_rating', 1499)
+              'amount_cents', t_fee * 5
             ),
             json_build_object(
               'name', 'Best Female Player',
-              'entries', json_build_array(
-                json_build_object('place', '1st', 'amount_cents', t_fee * 5)
+              'funding', json_build_object(
+                'source', funding_srcs[f_idx],
+                'funder_name', COALESCE(funder_names[f_idx], org_names[i])
               ),
-              'conditions', json_build_object('gender', 'female')
+              'amount_cents', t_fee * 5
             )
-          )
+          ),
+          -- Who hands the money to the winners. Mostly the organizer directly;
+          -- every 5th tournament appoints the platform, so the ring-fenced
+          -- prize balance Phase 8 needs has seed data to work against.
+          'distribution', CASE WHEN idx % 5 = 0 THEN 'platform' ELSE 'organizer' END
         ),
         t_restrictions,
         max_parts[(idx % 5) + 1],

--- a/db/migrations/006_seed.sql
+++ b/db/migrations/006_seed.sql
@@ -150,6 +150,9 @@ DECLARE
   v_idx          integer;
   f_idx          integer;
   t_restrictions jsonb;
+  t_local_end    timestamp;
+  t_utc_offset   interval;
+  t_valid_until  text;
 
   -- Name pools
   malay_first  text[] := ARRAY[
@@ -548,6 +551,28 @@ BEGIN
       v_idx := ((idx - 1) % array_length(venue_names, 1)) + 1;
       f_idx := (idx % array_length(funding_srcs, 1)) + 1;
 
+      -- An early-bird tier's `valid_until` is the instant its last day ENDS at
+      -- the venue, not the deadline instant itself: consumers test it with
+      -- `new Date(valid_until) < now`, so midnight would expire the tier for
+      -- the whole of the day the UI says is still included.
+      --
+      -- Built to be byte-identical to toValidUntilTimestamp() in
+      -- src/app/my/organizations/[orgId]/tournaments/create/_components/entryFees.ts
+      -- ("YYYY-MM-DDTHH:MI:SS+HH:MM"). entry_fees is jsonb and the money-field
+      -- freeze compares it exactly, so a seed row in any other shape would look
+      -- like a fee change the moment an organizer saved an unrelated edit — and
+      -- be refused, because these tournaments have paid registrations.
+      t_local_end  := (t_deadline AT TIME ZONE venue_tz[v_idx])::date + time '23:59:59';
+      t_utc_offset := t_local_end - ((t_local_end AT TIME ZONE venue_tz[v_idx]) AT TIME ZONE 'UTC');
+      t_valid_until := to_char(t_local_end, 'YYYY-MM-DD"T"HH24:MI:SS')
+                    || CASE WHEN t_utc_offset < interval '0' THEN '-' ELSE '+' END
+                    -- No abs() for intervals, and `@` was dropped in PG 14.
+                    || to_char(
+                         CASE WHEN t_utc_offset < interval '0'
+                              THEN -t_utc_offset ELSE t_utc_offset END,
+                         'HH24:MI'
+                       );
+
       -- Vary restrictions: open, nationality, age, gender, rating, combined
       t_restrictions := CASE (idx % 6)
         WHEN 0 THEN NULL                                                                            -- open
@@ -605,7 +630,7 @@ BEGIN
             json_build_object(
               'type', 'early_bird',
               'amount_cents', (t_fee * 0.8)::integer,
-              'valid_until', t_deadline
+              'valid_until', t_valid_until
             ),
             json_build_object(
               'type', 'age_based',

--- a/db/tests/audit_redaction.sql
+++ b/db/tests/audit_redaction.sql
@@ -1,0 +1,158 @@
+-- =============================================================================
+-- Regression test for audit-snapshot redaction (#516 / launch-readiness S3).
+--
+-- audit_trigger_func (003_functions_triggers.sql) writes full row snapshots into
+-- audit_logs, a table retained far longer than the rows it mirrors. Sensitive
+-- columns must be masked to a last-4 suffix on the way in — enough to answer
+-- "did this value change?", never enough to reconstruct the secret.
+--
+-- Covers:
+--   R1  redact_jsonb_columns masks listed keys and leaves the rest untouched
+--   R2  INSERT on player_profiles redacts bank_account_number in new_data
+--   R3  UPDATE redacts BOTH old_data and new_data (the old value is the one
+--       that would otherwise sit in the log forever)
+--   R4  oku_document_path is redacted too — it is a capability-bearing storage
+--       path, not just a label
+--   R5  NULL stays NULL, so "cleared" is still distinguishable from "set"
+--   R6  a non-redacted table (tournaments) is unaffected
+--
+-- HOW TO RUN: paste into the Supabase SQL editor (service role) AFTER applying
+-- the current migrations. Runs inside a transaction that ROLLBACKs, so it builds
+-- throwaway fixtures and persists NOTHING. A failing assertion RAISEs (and rolls
+-- back); on success it prints "ALL SCENARIOS PASSED" via NOTICE.
+-- =============================================================================
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_user  uuid;
+  v_org   uuid;
+  v_tour  uuid;
+  v_got   text;
+  v_json  jsonb;
+BEGIN
+  -- ---- R1: the helper in isolation ----------------------------------------
+  v_json := redact_jsonb_columns(
+    '{"bank_account_number": "1234567890", "bank_name": "Maybank", "rating": 1800}'::jsonb,
+    ARRAY['bank_account_number']
+  );
+
+  IF v_json ->> 'bank_account_number' <> '****7890' THEN
+    RAISE EXCEPTION 'R1 FAIL: masked value=% (expected ****7890)', v_json ->> 'bank_account_number';
+  END IF;
+  IF v_json ->> 'bank_name' <> 'Maybank' THEN
+    RAISE EXCEPTION 'R1 FAIL: unlisted key was altered (bank_name=%)', v_json ->> 'bank_name';
+  END IF;
+  -- Non-string values must survive as their original JSON type, not be
+  -- stringified — a snapshot that changes types is a broken snapshot.
+  IF jsonb_typeof(v_json -> 'rating') <> 'number' THEN
+    RAISE EXCEPTION 'R1 FAIL: numeric key changed type to %', jsonb_typeof(v_json -> 'rating');
+  END IF;
+  RAISE NOTICE 'R1 PASS — helper masks listed keys only, preserves types';
+
+  -- ---- fixtures (service role: RLS not enforced) --------------------------
+  INSERT INTO users (auth_user_id, email, first_name, last_name)
+    VALUES (gen_random_uuid(), 'redaction@test.local', 'R', 'T')
+    RETURNING id INTO v_user;
+
+  -- ---- R2: INSERT redacts new_data ----------------------------------------
+  INSERT INTO player_profiles (user_id, bank_name, bank_account_holder, bank_account_number)
+    VALUES (v_user, 'Maybank', 'Test Holder', '1234567890');
+
+  SELECT new_data ->> 'bank_account_number' INTO v_got
+  FROM audit_logs
+  WHERE table_name = 'player_profiles' AND record_id = v_user::text AND action = 'INSERT';
+
+  IF v_got IS DISTINCT FROM '****7890' THEN
+    RAISE EXCEPTION 'R2 FAIL: new_data.bank_account_number=% (expected ****7890)', v_got;
+  END IF;
+  RAISE NOTICE 'R2 PASS — INSERT snapshot redacted';
+
+  -- ---- R3: UPDATE redacts old_data as well as new_data --------------------
+  UPDATE player_profiles SET bank_account_number = '9876543210' WHERE user_id = v_user;
+
+  SELECT old_data ->> 'bank_account_number' INTO v_got
+  FROM audit_logs
+  WHERE table_name = 'player_profiles' AND record_id = v_user::text AND action = 'UPDATE'
+  ORDER BY id DESC LIMIT 1;
+
+  IF v_got IS DISTINCT FROM '****7890' THEN
+    RAISE EXCEPTION 'R3 FAIL: old_data.bank_account_number=% (expected ****7890 — the superseded value must not be retained in full)', v_got;
+  END IF;
+
+  SELECT new_data ->> 'bank_account_number' INTO v_got
+  FROM audit_logs
+  WHERE table_name = 'player_profiles' AND record_id = v_user::text AND action = 'UPDATE'
+  ORDER BY id DESC LIMIT 1;
+
+  IF v_got IS DISTINCT FROM '****3210' THEN
+    RAISE EXCEPTION 'R3 FAIL: new_data.bank_account_number=% (expected ****3210)', v_got;
+  END IF;
+
+  -- Nothing anywhere in the audit trail may hold the full number.
+  IF EXISTS (
+    SELECT 1 FROM audit_logs
+    WHERE table_name = 'player_profiles' AND record_id = v_user::text
+      AND (old_data::text LIKE '%1234567890%' OR new_data::text LIKE '%1234567890%'
+        OR old_data::text LIKE '%9876543210%' OR new_data::text LIKE '%9876543210%')
+  ) THEN
+    RAISE EXCEPTION 'R3 FAIL: a full account number survives somewhere in audit_logs';
+  END IF;
+  RAISE NOTICE 'R3 PASS — UPDATE redacts both sides, no full number anywhere';
+
+  -- ---- R4: oku_document_path is redacted too ------------------------------
+  UPDATE player_profiles
+    SET oku_document_path = 'users/' || v_user::text || '/oku/secret-card.pdf'
+    WHERE user_id = v_user;
+
+  SELECT new_data ->> 'oku_document_path' INTO v_got
+  FROM audit_logs
+  WHERE table_name = 'player_profiles' AND record_id = v_user::text AND action = 'UPDATE'
+  ORDER BY id DESC LIMIT 1;
+
+  IF v_got IS DISTINCT FROM '****.pdf' THEN
+    RAISE EXCEPTION 'R4 FAIL: oku_document_path=% (expected ****.pdf)', v_got;
+  END IF;
+  RAISE NOTICE 'R4 PASS — storage path redacted';
+
+  -- ---- R5: NULL stays NULL ------------------------------------------------
+  UPDATE player_profiles SET bank_account_number = NULL WHERE user_id = v_user;
+
+  SELECT new_data -> 'bank_account_number' INTO v_json
+  FROM audit_logs
+  WHERE table_name = 'player_profiles' AND record_id = v_user::text AND action = 'UPDATE'
+  ORDER BY id DESC LIMIT 1;
+
+  IF jsonb_typeof(v_json) <> 'null' THEN
+    RAISE EXCEPTION 'R5 FAIL: cleared column recorded as % (expected JSON null)', jsonb_typeof(v_json);
+  END IF;
+  RAISE NOTICE 'R5 PASS — cleared distinguishable from set';
+
+  -- ---- R6: unlisted tables are untouched ----------------------------------
+  INSERT INTO organizations (name) VALUES ('REDACTION ORG') RETURNING id INTO v_org;
+  INSERT INTO tournaments (
+    organization_id, name, venue_name, venue_state, venue_address,
+    start_date, end_date, registration_deadline, format, time_control,
+    entry_fees, max_participants
+  ) VALUES (
+    v_org, 'REDACTION CUP', 'Hall', 'Selangor', '1 Test Road',
+    current_date + 30, current_date + 31, now() + interval '20 days',
+    '{"type":"classical","rounds":5,"system":"swiss"}'::jsonb,
+    '{"base_minutes":90,"increment_seconds":30}'::jsonb,
+    '{"standard":{"amount_cents":10000}}'::jsonb, 20
+  ) RETURNING id INTO v_tour;
+
+  SELECT new_data ->> 'venue_name' INTO v_got
+  FROM audit_logs
+  WHERE table_name = 'tournaments' AND record_id = v_tour::text AND action = 'INSERT';
+
+  IF v_got <> 'Hall' THEN
+    RAISE EXCEPTION 'R6 FAIL: tournaments snapshot was altered (venue_name=%)', v_got;
+  END IF;
+  RAISE NOTICE 'R6 PASS — non-redacted tables unaffected';
+
+  RAISE NOTICE 'ALL SCENARIOS PASSED';
+END $$;
+
+ROLLBACK;

--- a/src/app/api/v1/organizations/[orgId]/tournaments/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/[id]/__tests__/route.test.ts
@@ -135,6 +135,14 @@ const EXISTING_TOURNAMENT = {
   start_date: "2099-09-01",
   end_date: "2099-09-02",
   timezone: "Asia/Kuala_Lumpur",
+  // The money columns the freeze compares against. Shaped exactly as the PATCH
+  // route writes them, because that is what a row edited through this route
+  // actually holds — and an unchanged resend has to compare equal to it.
+  entry_fees: { standard: { amount_cents: 4000 }, additional: [] },
+  prizes: null,
+  max_participants: 32,
+  commission_rate: 10,
+  organizer_commission_pct: 0,
 };
 
 const UPDATED_TOURNAMENT = {
@@ -614,6 +622,59 @@ describe("PATCH /api/v1/organizations/[orgId]/tournaments/[id]", () => {
         { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
       );
       expect(res.status).toBe(200);
+    });
+
+    // The edit wizard rebuilds the entire draft body on every save, so it always
+    // resends entry_fees and max_participants even when the organizer only
+    // touched the venue. Refusing that is a false 409: the trigger compares
+    // OLD/NEW and would have let it through. This is the payload the client
+    // actually sends, not a hand-trimmed one.
+    it("allows a venue edit that resends money fields unchanged", async () => {
+      setUser();
+      setTournamentFetchResult(PUBLISHED);
+      setTournamentUpdateResult({ ...UPDATED_TOURNAMENT, status: "published" });
+      setPaidRegistrationCount(1);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          venue_address: "2 New Road",
+          entry_fees: PUBLISHED.entry_fees,
+          max_participants: PUBLISHED.max_participants,
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    // jsonb equality ignores key order, so the freeze must too — otherwise the
+    // check would depend on how the client happened to serialise the object.
+    it("ignores key order when deciding a money field is unchanged", async () => {
+      setUser();
+      setTournamentFetchResult(PUBLISHED);
+      setTournamentUpdateResult({ ...UPDATED_TOURNAMENT, status: "published" });
+      setPaidRegistrationCount(1);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          entry_fees: { additional: [], standard: { amount_cents: 4000 } },
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("409s when a resent money field differs by even one cent", async () => {
+      setUser();
+      setTournamentFetchResult(PUBLISHED);
+      setPaidRegistrationCount(1);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          venue_address: "2 New Road",
+          entry_fees: { standard: { amount_cents: 4001 }, additional: [] },
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.details).toEqual(["entry_fees"]);
     });
 
     it("409s on any edit once the tournament has started", async () => {

--- a/src/app/api/v1/organizations/[orgId]/tournaments/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/[id]/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { getTodayInTimeZone } from "@/lib/datetime";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -10,6 +11,7 @@ const {
   mockMembershipBuilder,
   mockTournamentFetchBuilder,
   mockTournamentUpdateBuilder,
+  mockPaymentsBuilder,
   mockFrom,
   mockGetClaims,
 } = vi.hoisted(() => {
@@ -44,6 +46,9 @@ const {
   const mockMembershipBuilder = makeBuilder({ data: null, error: null });
   const mockTournamentFetchBuilder = makeBuilder({ data: null, error: null });
   const mockTournamentUpdateBuilder = makeBuilder({ data: null, error: null });
+  // Paid-registration probe for the money-field freeze. count 0 = nobody has
+  // paid yet, so money fields stay editable.
+  const mockPaymentsBuilder = makeBuilder({ count: 0, error: null });
 
   // Track tournament table calls: first is fetch, second is update
   let tournamentCallIndex = 0;
@@ -51,6 +56,7 @@ const {
   const mockFrom = vi.fn((table: string) => {
     if (table === "organizations") return mockOrgBuilder;
     if (table === "organization_memberships") return mockMembershipBuilder;
+    if (table === "payments") return mockPaymentsBuilder;
     if (table === "tournaments") {
       const builder =
         tournamentCallIndex === 0
@@ -75,6 +81,7 @@ const {
     mockMembershipBuilder,
     mockTournamentFetchBuilder,
     mockTournamentUpdateBuilder,
+    mockPaymentsBuilder,
     mockFrom,
     mockGetClaims,
   };
@@ -118,7 +125,17 @@ const APPROVED_ORG = {
   created_by: USER_ID,
 };
 
-const EXISTING_TOURNAMENT = { id: TOUR_ID };
+// A far-future draft: exempt from both freeze stages, so it exercises the
+// pre-freeze behaviour every other test relied on before the freeze existed.
+const EXISTING_TOURNAMENT = {
+  id: TOUR_ID,
+  status: "draft",
+  registration_deadline: "2099-08-01T00:00:00Z",
+  registration_closed_at: null,
+  start_date: "2099-09-01",
+  end_date: "2099-09-02",
+  timezone: "Asia/Kuala_Lumpur",
+};
 
 const UPDATED_TOURNAMENT = {
   id: TOUR_ID,
@@ -204,6 +221,14 @@ function setTournamentUpdateResult(data: unknown, error: unknown = null) {
   ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
 }
 
+/** How many paid registration payments the money-field freeze should see. */
+function setPaidRegistrationCount(count: number, error: unknown = null) {
+  (mockPaymentsBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ count, error }).then(onfulfilled, onrejected);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -217,6 +242,7 @@ beforeEach(() => {
   setMembershipResult({ roles: { name: "owner" } });
   setTournamentFetchResult(EXISTING_TOURNAMENT);
   setTournamentUpdateResult(UPDATED_TOURNAMENT);
+  setPaidRegistrationCount(0);
 });
 
 afterEach(() => {
@@ -456,8 +482,12 @@ describe("PATCH /api/v1/organizations/[orgId]/tournaments/[id]", () => {
       expect(body.data.updated_at).toBeDefined();
     });
 
-    it("works for a published tournament (post-publish edit)", async () => {
+    it("works for a published tournament that has not started yet", async () => {
       setUser();
+      setTournamentFetchResult({
+        ...EXISTING_TOURNAMENT,
+        status: "published",
+      });
       setTournamentUpdateResult({ ...UPDATED_TOURNAMENT, status: "published" });
       const res = await PATCH(makeRequest(), {
         params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }),
@@ -471,7 +501,7 @@ describe("PATCH /api/v1/organizations/[orgId]/tournaments/[id]", () => {
       setUser();
       // Published, closed_at still tracks the deadline (never closed early).
       setTournamentFetchResult({
-        id: TOUR_ID,
+        ...EXISTING_TOURNAMENT,
         status: "published",
         registration_deadline: "2026-08-01T00:00:00Z",
         registration_closed_at: "2026-08-01T00:00:00Z",
@@ -497,7 +527,7 @@ describe("PATCH /api/v1/organizations/[orgId]/tournaments/[id]", () => {
       // Published and closed early (closed_at < deadline) → deadline edits must
       // not resurrect/move the irreversible early-close timestamp.
       setTournamentFetchResult({
-        id: TOUR_ID,
+        ...EXISTING_TOURNAMENT,
         status: "published",
         registration_deadline: "2026-08-01T00:00:00Z",
         registration_closed_at: "2026-07-01T00:00:00Z",
@@ -520,6 +550,115 @@ describe("PATCH /api/v1/organizations/[orgId]/tournaments/[id]", () => {
           registration_closed_at: expect.anything(),
         }),
       );
+    });
+  });
+
+  // Two-stage freeze: money fields lock at the first paid registration,
+  // everything locks once the tournament starts.
+  describe("edit freeze", () => {
+    const PUBLISHED = { ...EXISTING_TOURNAMENT, status: "published" };
+    // Deliberately in the past so the date-derived state is "completed"
+    // regardless of when the suite runs.
+    const STARTED = {
+      ...PUBLISHED,
+      start_date: "2020-01-01",
+      end_date: "2020-01-02",
+    };
+    // "Today" must be resolved in the SAME timezone the route uses. Building it
+    // from toISOString() (UTC) makes this test fail for the eight hours a day
+    // when the UTC date is a day behind Kuala Lumpur's — the exact class of bug
+    // the timezone column exists to prevent.
+    const ONGOING_TODAY = (() => {
+      const today = getTodayInTimeZone(PUBLISHED.timezone);
+      return { ...PUBLISHED, start_date: today, end_date: today };
+    })();
+
+    it("allows money-field edits before anyone has paid", async () => {
+      setUser();
+      setTournamentFetchResult(PUBLISHED);
+      setTournamentUpdateResult({ ...UPDATED_TOURNAMENT, status: "published" });
+      setPaidRegistrationCount(0);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          entry_fees: { standard: { amount_cents: 5000 } },
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("409s on a money-field edit once a registration is paid", async () => {
+      setUser();
+      setTournamentFetchResult(PUBLISHED);
+      setPaidRegistrationCount(1);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          prizes: { categories: [] },
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.code).toBe("CONFLICT");
+      // The organizer needs to know WHICH field was refused.
+      expect(body.error.details).toContain("prizes");
+    });
+
+    it("still allows non-money edits after a registration is paid", async () => {
+      setUser();
+      setTournamentFetchResult(PUBLISHED);
+      setTournamentUpdateResult({ ...UPDATED_TOURNAMENT, status: "published" });
+      setPaidRegistrationCount(1);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, { venue_address: "2 New Road" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("409s on any edit once the tournament has started", async () => {
+      setUser();
+      setTournamentFetchResult(ONGOING_TODAY);
+      setPaidRegistrationCount(0);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, { venue_address: "2 New Road" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.message).toMatch(/started/i);
+    });
+
+    it("409s on any edit once the tournament has ended", async () => {
+      setUser();
+      setTournamentFetchResult(STARTED);
+      setPaidRegistrationCount(0);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, { venue_address: "2 New Road" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.message).toMatch(/ended/i);
+    });
+
+    it("exempts drafts from both stages", async () => {
+      setUser();
+      // A draft carries placeholder dates that are already "past" by the
+      // date-derived rule; freezing on that would make drafts uneditable.
+      setTournamentFetchResult({
+        ...EXISTING_TOURNAMENT,
+        start_date: "2020-01-01",
+        end_date: "2020-01-02",
+      });
+      setPaidRegistrationCount(1);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          entry_fees: { standard: { amount_cents: 5000 } },
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
     });
   });
 

--- a/src/app/api/v1/organizations/[orgId]/tournaments/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/[id]/__tests__/route.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { getTodayInTimeZone } from "@/lib/datetime";
+// The real wizard mapping, so a round-trip test exercises what the client
+// actually sends rather than a hand-built approximation of it.
+import {
+  fromPersistedEntryFees,
+  toPersistedEntryFees,
+} from "@/app/my/organizations/[orgId]/tournaments/create/_components/entryFees";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -135,6 +141,10 @@ const EXISTING_TOURNAMENT = {
   start_date: "2099-09-01",
   end_date: "2099-09-02",
   timezone: "Asia/Kuala_Lumpur",
+  // The venue pair the timezone is derived from. A patch may carry only one of
+  // them, so the route falls back to the stored value for the other.
+  venue_country: "MY",
+  venue_state: "Selangor",
   // The money columns the freeze compares against. Shaped exactly as the PATCH
   // route writes them, because that is what a row edited through this route
   // actually holds — and an unchanged resend has to compare equal to it.
@@ -155,7 +165,9 @@ const UPDATED_TOURNAMENT = {
 const VALID_PATCH_BODY = {
   name: "Updated Tournament Name",
   venue_name: "KLCC Convention Centre",
-  venue_state: "Kuala Lumpur",
+  // A real region name — the route validates it against venue_country and
+  // derives the timezone from it, so "Kuala Lumpur" is not a state.
+  venue_state: "W.P. Kuala Lumpur",
   venue_address: "Jalan Pinang, 50088 KL",
   format: { type: "rapid", system: "swiss", rounds: 9 },
   time_control: { base_minutes: 15, increment_seconds: 10, delay_seconds: 0 },
@@ -561,6 +573,94 @@ describe("PATCH /api/v1/organizations/[orgId]/tournaments/[id]", () => {
     });
   });
 
+  // The venue's country and state decide its timezone; the client no longer
+  // sends one. Three fields describing one place could otherwise disagree.
+  describe("venue timezone", () => {
+    it("derives the timezone from the venue rather than the request", async () => {
+      setUser();
+      setTournamentFetchResult(EXISTING_TOURNAMENT);
+      setTournamentUpdateResult(UPDATED_TOURNAMENT);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          venue_state: "Sabah",
+          // A client that still sends one is ignored, not trusted.
+          timezone: "America/New_York",
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+      expect(mockTournamentUpdateBuilder.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          venue_state: "Sabah",
+          timezone: "Asia/Kuala_Lumpur",
+        }),
+      );
+    });
+
+    // A patch that moves only the country still has to reconcile against the
+    // stored state, because the pair is what names the zone.
+    it("falls back to the stored half of the pair", async () => {
+      setUser();
+      setTournamentFetchResult(EXISTING_TOURNAMENT);
+      setTournamentUpdateResult(UPDATED_TOURNAMENT);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, { venue_country: "my" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+      expect(mockTournamentUpdateBuilder.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          venue_country: "MY",
+          timezone: "Asia/Kuala_Lumpur",
+        }),
+      );
+    });
+
+    it("leaves the timezone alone when the venue is not being moved", async () => {
+      setUser();
+      setTournamentFetchResult(EXISTING_TOURNAMENT);
+      setTournamentUpdateResult(UPDATED_TOURNAMENT);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, { name: "Renamed" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+      expect(mockTournamentUpdateBuilder.update).toHaveBeenCalledWith(
+        expect.not.objectContaining({ timezone: expect.anything() }),
+      );
+    });
+
+    // Silently coercing this used to pick a zone for a place the organizer
+    // never named.
+    it("400s on a state the country does not have", async () => {
+      setUser();
+      setTournamentFetchResult(EXISTING_TOURNAMENT);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          venue_country: "MY",
+          venue_state: "Singapore",
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    // A draft is saved from step one, before a state has been picked. Publish
+    // is what refuses an incomplete venue.
+    it("accepts an empty state on an unfinished draft", async () => {
+      setUser();
+      setTournamentFetchResult(EXISTING_TOURNAMENT);
+      setTournamentUpdateResult(UPDATED_TOURNAMENT);
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, { venue_state: "" }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
   // Two-stage freeze: money fields lock at the first paid registration,
   // everything locks once the tournament starts.
   describe("edit freeze", () => {
@@ -658,6 +758,45 @@ describe("PATCH /api/v1/organizations/[orgId]/tournaments/[id]", () => {
         }),
         { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
       );
+      expect(res.status).toBe(200);
+    });
+
+    // The regression the user hit on a seeded tournament: the wizard hydrates
+    // entry_fees, the organizer changes only the name, and the wizard writes
+    // the fees back. If that round trip is not lossless the freeze sees a fee
+    // change and refuses the whole PATCH — the name never lands either, and the
+    // client showed nothing. Built with the real helpers, so it fails if either
+    // direction of the mapping drifts.
+    it("allows a rename that resends fees hydrated from a non-canonical row", async () => {
+      const stored = {
+        standard: { amount_cents: 4000 },
+        additional: [
+          {
+            type: "early_bird",
+            amount_cents: 3200,
+            // The shape the seed used to write: the deadline instant, not the
+            // end of the day at the venue.
+            valid_until: "2099-08-01T00:00:00+00:00",
+          },
+        ],
+      };
+      setUser();
+      setTournamentFetchResult({ ...PUBLISHED, entry_fees: stored });
+      setTournamentUpdateResult({ ...UPDATED_TOURNAMENT, status: "published" });
+      setPaidRegistrationCount(1);
+
+      const res = await PATCH(
+        makeRequest(ORG_ID, TOUR_ID, {
+          name: "Renamed Tournament",
+          entry_fees: toPersistedEntryFees(
+            fromPersistedEntryFees(stored, "Asia/Kuala_Lumpur"),
+            "Asia/Kuala_Lumpur",
+          ),
+          max_participants: PUBLISHED.max_participants,
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID, id: TOUR_ID }) },
+      );
+
       expect(res.status).toBe(200);
     });
 

--- a/src/app/api/v1/organizations/[orgId]/tournaments/[id]/publish/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/[id]/publish/route.ts
@@ -7,6 +7,7 @@ import {
   tournamentTag,
 } from "@/lib/cache-tags";
 import { getTodayInTimeZone, resolveTimeZone } from "@/lib/datetime";
+import { validatePrizeFunding, type PrizesJson } from "@/lib/prize-funding";
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -31,6 +32,7 @@ interface TournamentRow {
   format: { type?: string; system?: string; rounds?: number } | null;
   time_control: { base_minutes?: number } | null;
   entry_fees: { standard?: { amount_cents?: number } } | null;
+  prizes: PrizesJson | null;
   status: string;
 }
 
@@ -136,7 +138,7 @@ export async function POST(
   const { data: tournament, error: tournamentError } = await supabaseAdmin
     .from("tournaments")
     .select(
-      "id, organization_id, slug, name, venue_name, venue_state, venue_address, timezone, start_date, end_date, registration_deadline, format, time_control, entry_fees, status",
+      "id, organization_id, slug, name, venue_name, venue_state, venue_address, timezone, start_date, end_date, registration_deadline, format, time_control, entry_fees, prizes, status",
     )
     .eq("id", id)
     .eq("organization_id", orgId)
@@ -225,6 +227,11 @@ export async function POST(
   if (!t.entry_fees?.standard) {
     validationErrors.push("Standard entry fee is required");
   }
+
+  // Entry fees are an administration fee and never fund prizes, so any prize
+  // with money attached has to name where that money actually comes from. See
+  // src/lib/prize-funding.ts for the reasoning.
+  validationErrors.push(...validatePrizeFunding(t.prizes));
 
   if (validationErrors.length > 0) {
     return NextResponse.json(

--- a/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
@@ -7,7 +7,7 @@ import {
   tournamentTag,
 } from "@/lib/cache-tags";
 import { getTodayInTimeZone, resolveTimeZone } from "@/lib/datetime";
-import { DEFAULT_COUNTRY_CODE, isSupportedCountry } from "@/lib/venues";
+import { DEFAULT_COUNTRY_CODE, findCountry } from "@/lib/venues";
 import { getTournamentDateState } from "@/app/tournaments/utils";
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
@@ -360,12 +360,12 @@ export async function PATCH(
       typeof body.venue_address === "string" ? body.venue_address.trim() : "";
   }
 
-  // An unrecognised country falls back to the platform default rather than
-  // erroring, matching create-route behaviour and the column default.
+  // An unrecognised country — or a non-string one — falls back to the platform
+  // default rather than erroring, matching create-route behaviour and the
+  // column default. `.code` is already the canonical uppercase form.
   if ("venue_country" in body) {
-    patch.venue_country = isSupportedCountry(body.venue_country as string)
-      ? (body.venue_country as string).toUpperCase()
-      : DEFAULT_COUNTRY_CODE;
+    patch.venue_country =
+      findCountry(body.venue_country)?.code ?? DEFAULT_COUNTRY_CODE;
   }
 
   // Moving the venue can move the timezone with it. Anything off the supported

--- a/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   tournamentTag,
 } from "@/lib/cache-tags";
 import { resolveTimeZone } from "@/lib/datetime";
+import { DEFAULT_COUNTRY_CODE, isSupportedCountry } from "@/lib/venues";
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -65,6 +66,7 @@ interface UpdateTournamentBody {
   venue_name?: unknown;
   venue_state?: unknown;
   venue_address?: unknown;
+  venue_country?: unknown;
   timezone?: unknown;
   format?: FormatInput;
   time_control?: TimeControlInput;
@@ -256,6 +258,14 @@ export async function PATCH(
   if ("venue_address" in body) {
     patch.venue_address =
       typeof body.venue_address === "string" ? body.venue_address.trim() : "";
+  }
+
+  // An unrecognised country falls back to the platform default rather than
+  // erroring, matching create-route behaviour and the column default.
+  if ("venue_country" in body) {
+    patch.venue_country = isSupportedCountry(body.venue_country as string)
+      ? (body.venue_country as string).toUpperCase()
+      : DEFAULT_COUNTRY_CODE;
   }
 
   // Moving the venue can move the timezone with it. Anything off the supported

--- a/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
@@ -6,8 +6,9 @@ import {
   TOURNAMENTS_LIST_TAG,
   tournamentTag,
 } from "@/lib/cache-tags";
-import { resolveTimeZone } from "@/lib/datetime";
+import { getTodayInTimeZone, resolveTimeZone } from "@/lib/datetime";
 import { DEFAULT_COUNTRY_CODE, isSupportedCountry } from "@/lib/venues";
+import { getTournamentDateState } from "@/app/tournaments/utils";
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -148,6 +149,103 @@ async function resolvePermission(
   return null;
 }
 
+// Columns that define what a player is paying for and what they can win. Once
+// somebody has paid, changing these rewrites the deal after the fact — and for
+// `prizes` it also moves the payout holdback under a tournament that is already
+// selling. Frozen at the first paid registration, not at publish, so an
+// organizer can still correct a typo on a listing nobody has bought into yet.
+const MONEY_FIELDS = [
+  "entry_fees",
+  "prizes",
+  "max_participants",
+  "commission_rate",
+  "organizer_commission_pct",
+] as const;
+
+interface FreezeSubject {
+  status: string;
+  start_date: string;
+  end_date: string;
+  timezone: string;
+}
+
+/**
+ * Two-stage edit freeze.
+ *
+ * Stage 1 — money fields lock at the first paid registration.
+ * Stage 2 — everything locks once the tournament starts.
+ *
+ * Both rules are also enforced by a BEFORE UPDATE trigger in
+ * 003_functions_triggers.sql; the DB is the authority and this is the readable
+ * error. Drafts are exempt: they have placeholder dates and can't have
+ * registrations, so neither stage can apply.
+ *
+ * Returns a 409 response when the edit is refused, else null.
+ */
+async function checkEditFreeze(
+  tournamentId: string,
+  existing: FreezeSubject,
+  patch: Record<string, unknown>,
+): Promise<NextResponse | null> {
+  if (existing.status === "draft") return null;
+
+  // Stage 2 first: it's the broader rule, and it needs no query.
+  const dateState = getTournamentDateState(
+    existing.start_date,
+    existing.end_date,
+    getTodayInTimeZone(existing.timezone),
+  );
+  if (dateState !== "upcoming") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "CONFLICT",
+          message:
+            dateState === "ongoing"
+              ? "This tournament has started and can no longer be edited"
+              : "This tournament has ended and can no longer be edited",
+        },
+      },
+      { status: 409 },
+    );
+  }
+
+  const touchedMoneyFields = MONEY_FIELDS.filter((f) => f in patch);
+  if (touchedMoneyFields.length === 0) return null;
+
+  // `head: true` — we only need to know whether one exists.
+  const { count, error } = await supabaseAdmin
+    .from("payments")
+    .select("id", { count: "exact", head: true })
+    .eq("tournament_id", tournamentId)
+    .eq("type", "registration")
+    .eq("status", "paid")
+    .limit(1);
+
+  if (error) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: error.message } },
+      { status: 500 },
+    );
+  }
+
+  if ((count ?? 0) > 0) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "CONFLICT",
+          message:
+            "Entry fees, prizes and capacity are locked once a player has paid",
+          details: touchedMoneyFields,
+        },
+      },
+      { status: 409 },
+    );
+  }
+
+  return null;
+}
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ orgId: string; id: string }> },
@@ -192,7 +290,9 @@ export async function PATCH(
 
   const { data: existing, error: tournamentError } = await supabaseAdmin
     .from("tournaments")
-    .select("id, status, registration_deadline, registration_closed_at")
+    .select(
+      "id, status, registration_deadline, registration_closed_at, start_date, end_date, timezone",
+    )
     .eq("id", id)
     .eq("organization_id", orgId)
     .single();
@@ -385,6 +485,9 @@ export async function PATCH(
       { status: 400 },
     );
   }
+
+  const freezeError = await checkEditFreeze(id, existing, patch);
+  if (freezeError) return freezeError;
 
   const { data: updated, error: updateError } = await supabaseAdmin
     .from("tournaments")

--- a/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
@@ -167,6 +167,47 @@ interface FreezeSubject {
   start_date: string;
   end_date: string;
   timezone: string;
+  entry_fees: unknown;
+  prizes: unknown;
+  max_participants: unknown;
+  commission_rate: unknown;
+  organizer_commission_pct: unknown;
+}
+
+/**
+ * Deep structural equality, used to answer "is this money field actually
+ * changing?" the same way the database does.
+ *
+ * The trigger compares with `IS DISTINCT FROM`, which on jsonb is semantic:
+ * key order doesn't matter, but a key being present-vs-absent does. This walks
+ * objects and arrays to match that, rather than comparing JSON.stringify output
+ * — two equal jsonb values can serialise to different strings purely by key
+ * order, and that would resurrect the false 409 this exists to prevent.
+ */
+function deepEquals(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  // Postgres has one null; a column read back as null and a patch that omits a
+  // value to `undefined` mean the same thing here.
+  if (a == null || b == null) return a == null && b == null;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((item, i) => deepEquals(item, b[i]));
+  }
+
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(
+    (k) =>
+      Object.prototype.hasOwnProperty.call(bObj, k) &&
+      deepEquals(aObj[k], bObj[k]),
+  );
 }
 
 /**
@@ -210,7 +251,15 @@ async function checkEditFreeze(
     );
   }
 
-  const touchedMoneyFields = MONEY_FIELDS.filter((f) => f in patch);
+  // Changed, not merely present. The edit wizard rebuilds the whole draft body
+  // on every save, so an organizer fixing a typo in the venue address still
+  // sends entry_fees and max_participants at their current values. Gating on
+  // presence would refuse that edit, while the trigger — which compares
+  // OLD/NEW — would have allowed it. Presence is the client's business; what
+  // the row ends up holding is the rule.
+  const touchedMoneyFields = MONEY_FIELDS.filter(
+    (f) => f in patch && !deepEquals(patch[f], existing[f]),
+  );
   if (touchedMoneyFields.length === 0) return null;
 
   // `head: true` — we only need to know whether one exists.
@@ -291,7 +340,9 @@ export async function PATCH(
   const { data: existing, error: tournamentError } = await supabaseAdmin
     .from("tournaments")
     .select(
-      "id, status, registration_deadline, registration_closed_at, start_date, end_date, timezone",
+      // The money columns are here for checkEditFreeze, which refuses an edit
+      // only when a value actually changes and so needs the current one.
+      "id, status, registration_deadline, registration_closed_at, start_date, end_date, timezone, entry_fees, prizes, max_participants, commission_rate, organizer_commission_pct",
     )
     .eq("id", id)
     .eq("organization_id", orgId)

--- a/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/[id]/route.ts
@@ -6,8 +6,13 @@ import {
   TOURNAMENTS_LIST_TAG,
   tournamentTag,
 } from "@/lib/cache-tags";
-import { getTodayInTimeZone, resolveTimeZone } from "@/lib/datetime";
-import { DEFAULT_COUNTRY_CODE, findCountry } from "@/lib/venues";
+import { getTodayInTimeZone } from "@/lib/datetime";
+import {
+  DEFAULT_COUNTRY_CODE,
+  findCountry,
+  isValidRegion,
+  timeZoneForRegion,
+} from "@/lib/venues";
 import { getTournamentDateState } from "@/app/tournaments/utils";
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
@@ -68,7 +73,7 @@ interface UpdateTournamentBody {
   venue_state?: unknown;
   venue_address?: unknown;
   venue_country?: unknown;
-  timezone?: unknown;
+  // No `timezone`: it is derived from venue_country + venue_state, not accepted.
   format?: FormatInput;
   time_control?: TimeControlInput;
   start_date?: unknown;
@@ -342,7 +347,9 @@ export async function PATCH(
     .select(
       // The money columns are here for checkEditFreeze, which refuses an edit
       // only when a value actually changes and so needs the current one.
-      "id, status, registration_deadline, registration_closed_at, start_date, end_date, timezone, entry_fees, prizes, max_participants, commission_rate, organizer_commission_pct",
+      // venue_country/venue_state are here because the timezone is derived from
+      // the pair, and a patch may only carry one half of it.
+      "id, status, registration_deadline, registration_closed_at, start_date, end_date, timezone, venue_country, venue_state, entry_fees, prizes, max_participants, commission_rate, organizer_commission_pct",
     )
     .eq("id", id)
     .eq("organization_id", orgId)
@@ -419,13 +426,34 @@ export async function PATCH(
       findCountry(body.venue_country)?.code ?? DEFAULT_COUNTRY_CODE;
   }
 
-  // Moving the venue can move the timezone with it. Anything off the supported
-  // picklist falls back to the platform default rather than storing a zone no
-  // formatter can read.
-  if ("timezone" in body) {
-    patch.timezone = resolveTimeZone(
-      typeof body.timezone === "string" ? body.timezone : null,
-    );
+  // Moving the venue moves the timezone with it, so the two are resolved
+  // together. A patch may carry only one of them — the stored value stands in
+  // for the other, because the row's zone has to stay consistent with wherever
+  // the venue ends up, not with whichever half the client happened to send.
+  if ("venue_country" in body || "venue_state" in body) {
+    const country =
+      (patch.venue_country as string | undefined) ??
+      existing.venue_country ??
+      DEFAULT_COUNTRY_CODE;
+    const state =
+      (patch.venue_state as string | undefined) ?? existing.venue_state ?? "";
+
+    // An empty state is a draft the organizer hasn't finished; publish catches
+    // that. A state set to something the country doesn't have would silently
+    // pick the wrong zone, so it is refused.
+    if (state && !isValidRegion(country, state)) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: `"${state}" is not a state of the selected country`,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    patch.timezone = timeZoneForRegion(country, state);
   }
 
   if ("format" in body && body.format && typeof body.format === "object") {

--- a/src/app/api/v1/organizations/[orgId]/tournaments/__tests__/route.test.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/__tests__/route.test.ts
@@ -104,7 +104,9 @@ const CREATED_TOURNAMENT = {
 const VALID_BODY = {
   name: "KL Open Rapid 2026",
   venue_name: "KLCC",
-  venue_state: "Kuala Lumpur",
+  // A real region name — the route validates it against venue_country and
+  // derives the timezone from it, so "Kuala Lumpur" is not a state.
+  venue_state: "W.P. Kuala Lumpur",
   venue_address: "Jalan Pinang, 50088 KL",
   format: { type: "rapid", system: "swiss", rounds: 7 },
   time_control: { base_minutes: 10, increment_seconds: 5, delay_seconds: 0 },
@@ -139,7 +141,10 @@ function makeRequest(
 // ---------------------------------------------------------------------------
 
 function setUser(id = USER_ID) {
-  mockGetClaims.mockResolvedValue({ data: { claims: { sub: id } }, error: null });
+  mockGetClaims.mockResolvedValue({
+    data: { claims: { sub: id } },
+    error: null,
+  });
 }
 
 function setNoUser() {
@@ -320,6 +325,41 @@ describe("POST /api/v1/organizations/[orgId]/tournaments", () => {
         params: Promise.resolve({ orgId: ORG_ID }),
       });
       expect(res.status).toBe(201);
+    });
+  });
+
+  // The venue's country and state decide its timezone; the client no longer
+  // sends one.
+  describe("venue timezone", () => {
+    it("derives the timezone from the venue rather than the request", async () => {
+      setUser();
+      const res = await POST(
+        makeRequest(ORG_ID, {
+          ...VALID_BODY,
+          venue_state: "Sarawak",
+          // A client that still sends one is ignored, not trusted.
+          timezone: "America/New_York",
+        }),
+        { params: Promise.resolve({ orgId: ORG_ID }) },
+      );
+      expect(res.status).toBe(201);
+      expect(mockInsertBuilder.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          venue_state: "Sarawak",
+          timezone: "Asia/Kuala_Lumpur",
+        }),
+      );
+    });
+
+    it("400s on a state the country does not have", async () => {
+      setUser();
+      const res = await POST(
+        makeRequest(ORG_ID, { ...VALID_BODY, venue_state: "Singapore" }),
+        { params: Promise.resolve({ orgId: ORG_ID }) },
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.code).toBe("VALIDATION_ERROR");
     });
   });
 

--- a/src/app/api/v1/organizations/[orgId]/tournaments/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/route.ts
@@ -1,7 +1,11 @@
 import { supabaseAdmin } from "@/services/supabase/admin";
 import { getAuthClaims } from "@/services/supabase/permission";
-import { resolveTimeZone } from "@/lib/datetime";
-import { DEFAULT_COUNTRY_CODE, findCountry } from "@/lib/venues";
+import {
+  DEFAULT_COUNTRY_CODE,
+  findCountry,
+  isValidRegion,
+  timeZoneForRegion,
+} from "@/lib/venues";
 import { NextRequest, NextResponse } from "next/server";
 
 const UUID_RE =
@@ -46,7 +50,7 @@ interface CreateTournamentBody {
   venue_state?: unknown;
   venue_address?: unknown;
   venue_country?: unknown;
-  timezone?: unknown;
+  // No `timezone`: it is derived from venue_country + venue_state, not accepted.
   format?: FormatInput;
   time_control?: TimeControlInput;
   start_date?: unknown;
@@ -186,14 +190,30 @@ export async function POST(
   // hand-rolled client can send — falls back to the platform default rather
   // than storing a country the payout rails can't route to. `.code` is already
   // the canonical uppercase form.
-  const venue_country = findCountry(body.venue_country)?.code ?? DEFAULT_COUNTRY_CODE;
+  const venue_country =
+    findCountry(body.venue_country)?.code ?? DEFAULT_COUNTRY_CODE;
 
-  // The venue's timezone anchors the tournament's dates and times. Anything off
-  // the supported picklist falls back to the platform default rather than
-  // storing a zone no formatter can read.
-  const timezone = resolveTimeZone(
-    typeof body.timezone === "string" ? body.timezone : null,
-  );
+  // A draft can be saved from step one, before a state has been picked, so an
+  // empty one is allowed here and caught at publish. A state that is set but
+  // does not belong to the country is a different thing — it would silently
+  // decide the wrong timezone below.
+  if (venue_state && !isValidRegion(venue_country, venue_state)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: `"${venue_state}" is not a state of the selected country`,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // The venue's timezone anchors the tournament's dates and times, and is
+  // derived from where the venue is rather than sent by the client — the two
+  // cannot then disagree. An unset state yields the platform default until the
+  // organizer picks one.
+  const timezone = timeZoneForRegion(venue_country, venue_state);
 
   const start_date =
     typeof body.start_date === "string" && body.start_date

--- a/src/app/api/v1/organizations/[orgId]/tournaments/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/route.ts
@@ -1,6 +1,7 @@
 import { supabaseAdmin } from "@/services/supabase/admin";
 import { getAuthClaims } from "@/services/supabase/permission";
 import { resolveTimeZone } from "@/lib/datetime";
+import { DEFAULT_COUNTRY_CODE, isSupportedCountry } from "@/lib/venues";
 import { NextRequest, NextResponse } from "next/server";
 
 const UUID_RE =
@@ -44,6 +45,7 @@ interface CreateTournamentBody {
   venue_name?: unknown;
   venue_state?: unknown;
   venue_address?: unknown;
+  venue_country?: unknown;
   timezone?: unknown;
   format?: FormatInput;
   time_control?: TimeControlInput;
@@ -180,6 +182,12 @@ export async function POST(
   const venue_address =
     typeof body.venue_address === "string" ? body.venue_address.trim() : "";
 
+  // Anything off the supported picklist falls back to the platform default
+  // rather than storing a country the payout rails can't route to.
+  const venue_country = isSupportedCountry(body.venue_country as string)
+    ? (body.venue_country as string).toUpperCase()
+    : DEFAULT_COUNTRY_CODE;
+
   // The venue's timezone anchors the tournament's dates and times. Anything off
   // the supported picklist falls back to the platform default rather than
   // storing a zone no formatter can read.
@@ -253,6 +261,7 @@ export async function POST(
       venue_name,
       venue_state,
       venue_address,
+      venue_country,
       timezone,
       start_date,
       end_date,

--- a/src/app/api/v1/organizations/[orgId]/tournaments/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/tournaments/route.ts
@@ -1,7 +1,7 @@
 import { supabaseAdmin } from "@/services/supabase/admin";
 import { getAuthClaims } from "@/services/supabase/permission";
 import { resolveTimeZone } from "@/lib/datetime";
-import { DEFAULT_COUNTRY_CODE, isSupportedCountry } from "@/lib/venues";
+import { DEFAULT_COUNTRY_CODE, findCountry } from "@/lib/venues";
 import { NextRequest, NextResponse } from "next/server";
 
 const UUID_RE =
@@ -182,11 +182,11 @@ export async function POST(
   const venue_address =
     typeof body.venue_address === "string" ? body.venue_address.trim() : "";
 
-  // Anything off the supported picklist falls back to the platform default
-  // rather than storing a country the payout rails can't route to.
-  const venue_country = isSupportedCountry(body.venue_country as string)
-    ? (body.venue_country as string).toUpperCase()
-    : DEFAULT_COUNTRY_CODE;
+  // Anything off the supported picklist — including a non-string, which a
+  // hand-rolled client can send — falls back to the platform default rather
+  // than storing a country the payout rails can't route to. `.code` is already
+  // the canonical uppercase form.
+  const venue_country = findCountry(body.venue_country)?.code ?? DEFAULT_COUNTRY_CODE;
 
   // The venue's timezone anchors the tournament's dates and times. Anything off
   // the supported picklist falls back to the platform default rather than

--- a/src/app/my/organizations/[orgId]/tournaments/[id]/_components/TournamentManageClient.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/[id]/_components/TournamentManageClient.tsx
@@ -2,10 +2,12 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import { getTournamentDateState } from "@/app/tournaments/utils";
 import TournamentActions from "./TournamentActions";
 import {
   formatCalendarDateRange,
   formatInstantDate,
+  getTodayInTimeZone,
   resolveTimeZone,
 } from "@/lib/datetime";
 
@@ -141,10 +143,20 @@ export default function TournamentManageClient({
 }: Props) {
   const [search, setSearch] = useState("");
   const statusConfig = STATUS_CONFIG[tournament.status] ?? STATUS_CONFIG.draft;
+  // Drafts are always editable. A published tournament stays editable only
+  // until it starts — after that the PATCH route refuses every field, so
+  // offering the button would just walk the organizer into a 409. "ongoing" and
+  // "completed" are date-derived and never stored, so the status column alone
+  // can't answer this; resolve today in the venue's own timezone, exactly as
+  // the server does.
   const isEditable =
     tournament.status === "draft" ||
-    tournament.status === "published" ||
-    tournament.status === "ongoing";
+    (tournament.status === "published" &&
+      getTournamentDateState(
+        tournament.start_date,
+        tournament.end_date,
+        getTodayInTimeZone(tournament.timezone),
+      ) === "upcoming");
 
   const filtered = participants.filter(
     (p) =>

--- a/src/app/my/organizations/[orgId]/tournaments/[id]/_data/getTournamentManageData.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/[id]/_data/getTournamentManageData.ts
@@ -29,7 +29,13 @@ interface TournamentManageData {
     end_date: string;
     registration_deadline: string | null;
     registration_closed_at: string | null;
-    venue: { name: string; state: string; address?: string | null };
+    venue: {
+      name: string;
+      state: string;
+      address?: string | null;
+      /** ISO 3166-1 alpha-2 — decides the payout rails, not the clock. */
+      country: string;
+    };
     /** IANA timezone of the venue — the zone its dates and times are read in. */
     timezone: string;
     format: { type?: string; system?: string; rounds?: number } | null;
@@ -165,7 +171,7 @@ export const getTournamentManageData = cache(
     const { data: tournament, error: tErr } = await supabaseAdmin
       .from("tournaments")
       .select(
-        "id, name, description, status, start_date, end_date, registration_deadline, registration_closed_at, venue_name, venue_state, venue_address, timezone, format, time_control, is_fide_rated, is_mcf_rated, max_participants, entry_fees, prizes, restrictions",
+        "id, name, description, status, start_date, end_date, registration_deadline, registration_closed_at, venue_name, venue_state, venue_address, venue_country, timezone, format, time_control, is_fide_rated, is_mcf_rated, max_participants, entry_fees, prizes, restrictions",
       )
       .eq("id", id)
       .eq("organization_id", orgId)
@@ -322,6 +328,7 @@ export const getTournamentManageData = cache(
             name: tournament.venue_name,
             state: tournament.venue_state,
             address: tournament.venue_address,
+            country: tournament.venue_country,
           },
           timezone: resolveTimeZone(tournament.timezone),
           format: tournament.format,

--- a/src/app/my/organizations/[orgId]/tournaments/[id]/edit/page.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/[id]/edit/page.tsx
@@ -77,6 +77,10 @@ async function fetchTournamentForEdit(
 function buildInitialData(t: TournamentForEdit): PersistedState {
   // Times come back as instants; the organizer edits them at the venue's wall
   // clock, which is the one they entered — not the clock of whoever is editing.
+  //
+  // Hydrated from the stored column rather than re-derived from country/state,
+  // so a row whose venue predates the current picklist still reads back in the
+  // zone it was actually entered in. Saving re-derives it.
   const timeZone = resolveTimeZone(t.timezone);
 
   const basicInfoData = {
@@ -86,7 +90,6 @@ function buildInitialData(t: TournamentForEdit): PersistedState {
     venueState: t.venue.state,
     venueAddress: t.venue.address ?? "",
     venueCountry: t.venue.country ?? DEFAULT_COUNTRY_CODE,
-    timezone: timeZone,
   };
 
   const restrictions = fromPersistedRestrictions(t.restrictions ?? []);

--- a/src/app/my/organizations/[orgId]/tournaments/[id]/edit/page.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/[id]/edit/page.tsx
@@ -14,6 +14,11 @@ import { fromPersistedRestrictions } from "@/app/my/organizations/[orgId]/tourna
 import { fromPersistedEntryFees } from "@/app/my/organizations/[orgId]/tournaments/create/_components/entryFees";
 import { resolveTimeZone, toLocalDateTimeInput } from "@/lib/datetime";
 import { DEFAULT_COUNTRY_CODE } from "@/lib/venues";
+import {
+  isPrizeDistribution,
+  isPrizeFundingSource,
+  type PrizesJson,
+} from "@/lib/prize-funding";
 
 export const metadata: Metadata = {
   title: "Edit Tournament",
@@ -45,13 +50,7 @@ interface TournamentForEdit {
   is_mcf_rated: boolean;
   max_participants: number;
   entry_fees: StoredEntryFees | null;
-  prizes: {
-    categories?: Array<{
-      name: string;
-      entries: Array<{ place: string; amount_cents: number }>;
-    }>;
-    special?: Array<{ name: string; amount_cents: number }>;
-  } | null;
+  prizes: PrizesJson | null;
   restrictions: PersistedRestriction[] | null;
 }
 
@@ -119,23 +118,36 @@ function buildInitialData(t: TournamentForEdit): PersistedState {
 
   const prizeCategories = (t.prizes?.categories ?? []).map((cat, ci) => ({
     id: `cat-${ci}`,
-    name: cat.name,
-    prizes: cat.entries.map((e, ei) => ({
+    name: cat.name ?? "",
+    prizes: (cat.entries ?? []).map((e, ei) => ({
       id: `prize-${ci}-${ei}`,
-      placement: e.place,
-      amount: e.amount_cents / 100,
+      placement: e.place ?? "",
+      amount: (e.amount_cents ?? 0) / 100,
     })),
+    // Tournaments created before funding was declarable have no `funding`;
+    // they hydrate as unselected and must pick a source before re-publishing.
+    fundingSource: isPrizeFundingSource(cat.funding?.source)
+      ? cat.funding.source
+      : ("" as const),
+    funderName: cat.funding?.funder_name ?? "",
   }));
 
   const specialPrizes = (t.prizes?.special ?? []).map((sp, si) => ({
     id: `sp-${si}`,
-    name: sp.name,
-    amount: sp.amount_cents / 100,
+    name: sp.name ?? "",
+    amount: (sp.amount_cents ?? 0) / 100,
+    fundingSource: isPrizeFundingSource(sp.funding?.source)
+      ? sp.funding.source
+      : ("" as const),
+    funderName: sp.funding?.funder_name ?? "",
   }));
 
   const prizesData = {
     categories: prizeCategories,
     specialPrizes,
+    distribution: isPrizeDistribution(t.prizes?.distribution)
+      ? t.prizes.distribution
+      : ("organizer" as const),
   };
 
   return {

--- a/src/app/my/organizations/[orgId]/tournaments/[id]/edit/page.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/[id]/edit/page.tsx
@@ -13,6 +13,7 @@ import WizardShell from "@/app/my/organizations/[orgId]/tournaments/create/_comp
 import { fromPersistedRestrictions } from "@/app/my/organizations/[orgId]/tournaments/create/_components/restrictions";
 import { fromPersistedEntryFees } from "@/app/my/organizations/[orgId]/tournaments/create/_components/entryFees";
 import { resolveTimeZone, toLocalDateTimeInput } from "@/lib/datetime";
+import { DEFAULT_COUNTRY_CODE } from "@/lib/venues";
 
 export const metadata: Metadata = {
   title: "Edit Tournament",
@@ -27,7 +28,12 @@ interface TournamentForEdit {
   start_date: string;
   end_date: string;
   registration_deadline: string;
-  venue: { name: string; state: string; address?: string | null };
+  venue: {
+    name: string;
+    state: string;
+    address?: string | null;
+    country?: string | null;
+  };
   timezone: string;
   format: { type?: string; system?: string; rounds?: number } | null;
   time_control: {
@@ -80,6 +86,7 @@ function buildInitialData(t: TournamentForEdit): PersistedState {
     venueName: t.venue.name,
     venueState: t.venue.state,
     venueAddress: t.venue.address ?? "",
+    venueCountry: t.venue.country ?? DEFAULT_COUNTRY_CODE,
     timezone: timeZone,
   };
 

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
@@ -17,6 +17,7 @@ import type {
   WizardStep,
 } from "../types";
 import { DEFAULT_TIME_ZONE } from "@/lib/datetime";
+import { DEFAULT_COUNTRY_CODE } from "@/lib/venues";
 
 export const WIZARD_STEPS: WizardStep[] = [
   { id: "basic-info", label: "Basic Info" },
@@ -30,6 +31,7 @@ const initialBasicInfo: BasicInfoData = {
   name: "",
   description: "",
   venueName: "",
+  venueCountry: DEFAULT_COUNTRY_CODE,
   venueState: "",
   venueAddress: "",
   timezone: DEFAULT_TIME_ZONE,

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
@@ -16,7 +16,7 @@ import type {
   PrizesData,
   WizardStep,
 } from "../types";
-import { DEFAULT_TIME_ZONE } from "@/lib/datetime";
+
 import { DEFAULT_COUNTRY_CODE } from "@/lib/venues";
 
 export const WIZARD_STEPS: WizardStep[] = [
@@ -34,12 +34,12 @@ const initialBasicInfo: BasicInfoData = {
   venueCountry: DEFAULT_COUNTRY_CODE,
   venueState: "",
   venueAddress: "",
-  timezone: DEFAULT_TIME_ZONE,
 };
 
 const initialFeesData: FeesData = {
   standardFee: "",
   tiers: [],
+  preservedTiers: [],
 };
 
 const initialPrizesData: PrizesData = {

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
@@ -45,6 +45,7 @@ const initialFeesData: FeesData = {
 const initialPrizesData: PrizesData = {
   categories: [],
   specialPrizes: [],
+  distribution: "organizer",
 };
 
 const initialFormatData: FormatData = {

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/WizardShell.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/WizardShell.tsx
@@ -64,11 +64,18 @@ export default function WizardShell({
     const timeZone = resolveTimeZone(basicInfoData.timezone);
     const entryFees = toPersistedEntryFees(feesData, timeZone);
 
+    // Funding is persisted as a nested object (matching PrizesJson) rather than
+    // flat columns, and omitted entirely when the source hasn't been chosen —
+    // an absent `funding` is what publish validation reports on.
+    const funding = (source: string, funderName: string) =>
+      source ? { source, funder_name: funderName.trim() } : undefined;
+
     const prizes =
       prizesData.categories.length > 0 || prizesData.specialPrizes.length > 0
         ? {
             categories: prizesData.categories.map((cat) => ({
               name: cat.name,
+              funding: funding(cat.fundingSource, cat.funderName),
               entries: cat.prizes.map((p) => ({
                 place: p.placement,
                 amount_cents:
@@ -77,9 +84,11 @@ export default function WizardShell({
             })),
             special: prizesData.specialPrizes.map((sp) => ({
               name: sp.name,
+              funding: funding(sp.fundingSource, sp.funderName),
               amount_cents:
                 sp.amount === "" ? 0 : Math.round(Number(sp.amount) * 100),
             })),
+            distribution: prizesData.distribution,
           }
         : undefined;
 

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/WizardShell.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/WizardShell.tsx
@@ -89,6 +89,7 @@ export default function WizardShell({
       venue_name: basicInfoData.venueName || undefined,
       venue_state: basicInfoData.venueState || undefined,
       venue_address: basicInfoData.venueAddress || undefined,
+      venue_country: basicInfoData.venueCountry || undefined,
       timezone: timeZone,
     };
 

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/WizardShell.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/WizardShell.tsx
@@ -6,7 +6,8 @@ import { WIZARD_STEPS, useTournamentWizard } from "./TournamentWizardContext";
 import WizardProgressBar from "./WizardProgressBar";
 import { toPersistedRestrictions } from "./restrictions";
 import { toPersistedEntryFees } from "./entryFees";
-import { resolveTimeZone, toInstantInTimeZone } from "@/lib/datetime";
+import { toInstantInTimeZone } from "@/lib/datetime";
+import { timeZoneForRegion } from "@/lib/venues";
 import BasicInfoStep from "./steps/BasicInfoStep";
 import FormatStep from "./steps/FormatStep";
 import FeesStep from "./steps/FeesStep";
@@ -52,7 +53,9 @@ export default function WizardShell({
   } = useTournamentWizard();
   const [isSaving, setIsSaving] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
-  const [publishError, setPublishError] = useState<string | null>(null);
+  // One banner for both buttons: a save and a publish fail the same way, and the
+  // organizer only ever has one of them in flight.
+  const [formError, setFormError] = useState<string | null>(null);
   const isFirstStep = currentStepIndex === 0;
   const isLastStep = currentStepIndex === WIZARD_STEPS.length - 1;
 
@@ -61,7 +64,13 @@ export default function WizardShell({
   function buildDraftBody(): Record<string, unknown> {
     // Everything dated in the wizard is dated at the venue, so the venue's
     // timezone is what turns the organizer's wall-clock entries into instants.
-    const timeZone = resolveTimeZone(basicInfoData.timezone);
+    // It is derived from where the venue is, not asked for separately, and the
+    // API derives it again from the same two fields — sending it would only
+    // create a value the server has to decide whether to trust.
+    const timeZone = timeZoneForRegion(
+      basicInfoData.venueCountry,
+      basicInfoData.venueState,
+    );
     const entryFees = toPersistedEntryFees(feesData, timeZone);
 
     // Funding is persisted as a nested object (matching PrizesJson) rather than
@@ -99,7 +108,6 @@ export default function WizardShell({
       venue_state: basicInfoData.venueState || undefined,
       venue_address: basicInfoData.venueAddress || undefined,
       venue_country: basicInfoData.venueCountry || undefined,
-      timezone: timeZone,
     };
 
     if (
@@ -148,7 +156,30 @@ export default function WizardShell({
     return body;
   }
 
-  async function saveDraftToApi(): Promise<string | null> {
+  /**
+   * The readable message behind a failed response. The API answers with
+   * `{ error: { message, details? } }`; `details` is the per-field list the
+   * publish validator and the edit freeze return, and is worth showing whole.
+   */
+  async function errorMessageFrom(
+    res: Response,
+    fallback: string,
+  ): Promise<string> {
+    try {
+      const json = (await res.json()) as {
+        error?: { message?: string; details?: string[] };
+      };
+      const details = json.error?.details;
+      if (details && details.length > 1) return details.join(" · ");
+      return json.error?.message ?? fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  type SaveResult = { ok: true; id: string } | { ok: false; message: string };
+
+  async function saveDraftToApi(): Promise<SaveResult> {
     const body = buildDraftBody();
 
     if (tournamentId) {
@@ -160,7 +191,16 @@ export default function WizardShell({
           body: JSON.stringify(body),
         },
       );
-      return res.ok ? tournamentId : null;
+      if (!res.ok) {
+        return {
+          ok: false,
+          message: await errorMessageFrom(
+            res,
+            "Failed to save your changes. Please try again.",
+          ),
+        };
+      }
+      return { ok: true, id: tournamentId };
     }
 
     const res = await fetch(`/api/v1/organizations/${orgId}/tournaments`, {
@@ -169,14 +209,26 @@ export default function WizardShell({
       body: JSON.stringify(body),
     });
 
-    if (!res.ok) return null;
+    if (!res.ok) {
+      return {
+        ok: false,
+        message: await errorMessageFrom(
+          res,
+          "Failed to save this tournament. Please try again.",
+        ),
+      };
+    }
     const json = (await res.json()) as { data: { id: string } };
-    return json.data.id;
+    return { ok: true, id: json.data.id };
   }
 
   const afterSaveRedirect = redirectPath ?? `/my/organizations/${orgId}`;
 
+  // A rejected save must leave the organizer on the wizard with their edits
+  // intact: clearing storage and redirecting anyway is what made a 409 from the
+  // edit freeze indistinguishable from success.
   async function handleSaveDraft() {
+    setFormError(null);
     if (!basicInfoData.name.trim()) {
       clearWizardStorage();
       router.push(afterSaveRedirect);
@@ -184,44 +236,40 @@ export default function WizardShell({
     }
     setIsSaving(true);
     try {
-      const id = await saveDraftToApi();
-      if (id) setTournamentId(id);
-    } finally {
-      setIsSaving(false);
+      const result = await saveDraftToApi();
+      if (!result.ok) {
+        setFormError(result.message);
+        return;
+      }
+      setTournamentId(result.id);
       clearWizardStorage();
       router.push(afterSaveRedirect);
+    } finally {
+      setIsSaving(false);
     }
   }
 
   async function handlePublish() {
-    setPublishError(null);
+    setFormError(null);
     setIsPublishing(true);
     try {
       if (!basicInfoData.name.trim()) {
         router.push(afterSaveRedirect);
         return;
       }
-      const draftId = await saveDraftToApi();
-      if (draftId) setTournamentId(draftId);
-      if (!draftId) {
-        setPublishError(
-          "Failed to save tournament before publishing. Please try again.",
-        );
+      const saved = await saveDraftToApi();
+      if (!saved.ok) {
+        setFormError(saved.message);
         return;
       }
+      setTournamentId(saved.id);
       const res = await fetch(
-        `/api/v1/organizations/${orgId}/tournaments/${draftId}/publish`,
+        `/api/v1/organizations/${orgId}/tournaments/${saved.id}/publish`,
         { method: "POST" },
       );
       if (!res.ok) {
-        const json = (await res.json()) as {
-          error?: { message?: string; details?: string[] };
-        };
-        const details = json.error?.details;
-        setPublishError(
-          details && details.length > 1
-            ? details.join(" · ")
-            : (json.error?.message ?? "Failed to publish tournament."),
+        setFormError(
+          await errorMessageFrom(res, "Failed to publish tournament."),
         );
         return;
       }
@@ -254,9 +302,12 @@ export default function WizardShell({
             must not mount until the context has restored sessionStorage. */}
         <div className="px-6 py-7 sm:px-8">{isHydrated && <StepContent />}</div>
 
-        {publishError && (
-          <div className="mx-6 mt-4 mb-0 rounded-md border border-red-400 bg-red-50 px-4 py-3 sm:mx-8">
-            <p className="font-lato text-xs text-red-700">{publishError}</p>
+        {formError && (
+          <div
+            role="alert"
+            className="mx-6 mt-4 mb-0 rounded-md border border-red-400 bg-red-50 px-4 py-3 sm:mx-8"
+          >
+            <p className="font-lato text-xs text-red-700">{formError}</p>
           </div>
         )}
 

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/__tests__/WizardShell.test.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/__tests__/WizardShell.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import WizardShell from "../WizardShell";
+import { TournamentWizardProvider } from "../TournamentWizardContext";
+import type { PersistedState } from "../../types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// The steps are not under test here — WizardShell's own save/publish handling
+// is. Stubbing them keeps this from depending on five forms' validation.
+vi.mock("../steps/BasicInfoStep", () => ({ default: () => <div /> }));
+vi.mock("../steps/FormatStep", () => ({ default: () => <div /> }));
+vi.mock("../steps/FeesStep", () => ({ default: () => <div /> }));
+vi.mock("../steps/PrizesStep", () => ({ default: () => <div /> }));
+vi.mock("../steps/ReviewStep", () => ({ default: () => <div /> }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const TOUR_ID = "22222222-2222-4222-8222-222222222222";
+
+const INITIAL: PersistedState = {
+  basicInfoData: {
+    name: "Singapore Blitz Chess Open",
+    description: "",
+    venueName: "Singapore Chess Centre",
+    venueCountry: "MY",
+    venueState: "Selangor",
+    venueAddress: "1 Marina Boulevard",
+  },
+  formatData: {
+    formatType: "Blitz",
+    system: "Swiss",
+    rounds: 9,
+    baseTime: 5,
+    increment: 3,
+    delay: 0,
+    startDate: "2099-09-01",
+    endDate: "2099-09-02",
+    registrationDeadline: "2099-08-25T23:59",
+    maxParticipants: 150,
+    fideRated: false,
+    mcfRated: true,
+    restrictions: [],
+  },
+  feesData: { standardFee: 50, tiers: [], preservedTiers: [] },
+  prizesData: { categories: [], specialPrizes: [], distribution: "organizer" },
+  tournamentId: TOUR_ID,
+  // The Review step is the only one that shows "Save Changes".
+  currentStepIndex: 4,
+  completedSteps: [0, 1, 2, 3],
+};
+
+function renderEditWizard() {
+  return render(
+    <TournamentWizardProvider
+      orgId={ORG_ID}
+      initialData={INITIAL}
+      storageKeySuffix={`edit-${TOUR_ID}`}
+      excludeId={TOUR_ID}
+    >
+      <WizardShell
+        orgId={ORG_ID}
+        orgName="Penang Chess Association"
+        title="Edit Tournament"
+        redirectPath={`/my/organizations/${ORG_ID}/tournaments/${TOUR_ID}`}
+        mode="edit"
+      />
+    </TournamentWizardProvider>,
+  );
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  mockPush.mockReset();
+  mockFetch.mockReset();
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("WizardShell — Save Changes", () => {
+  async function clickSaveChanges() {
+    renderEditWizard();
+    const button = await screen.findByRole("button", { name: /save changes/i });
+    fireEvent.click(button);
+    return button;
+  }
+
+  // The bug this covers: a rejected PATCH was collapsed to null, sessionStorage
+  // was cleared and the router pushed anyway, so the organizer landed back on
+  // the tournament page with their edits gone and nothing said. The freeze's
+  // readable 409 existed and was thrown away.
+  it("shows the API's message and stays put when the save is refused", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(409, {
+        error: {
+          code: "CONFLICT",
+          message:
+            "Entry fees, prizes and capacity are locked once a player has paid",
+          details: ["entry_fees"],
+        },
+      }),
+    );
+
+    await clickSaveChanges();
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "Entry fees, prizes and capacity are locked once a player has paid",
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+    // The organizer's edits must survive so they can correct and retry.
+    expect(
+      sessionStorage.getItem(`tournament-wizard-${ORG_ID}-edit-${TOUR_ID}`),
+    ).not.toBeNull();
+  });
+
+  it("joins a multi-item details list rather than showing only the summary", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(400, {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Tournament is not ready",
+          details: ["Prize category Open: name the sponsor", "Venue required"],
+        },
+      }),
+    );
+
+    await clickSaveChanges();
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "Prize category Open: name the sponsor · Venue required",
+    );
+  });
+
+  it("falls back to a readable message when the body is not JSON", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error("not json");
+      },
+    } as unknown as Response);
+
+    await clickSaveChanges();
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "Failed to save your changes. Please try again.",
+    );
+  });
+
+  it("redirects and clears the draft once the save succeeds", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { data: { id: TOUR_ID } }),
+    );
+
+    await clickSaveChanges();
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith(
+        `/my/organizations/${ORG_ID}/tournaments/${TOUR_ID}`,
+      ),
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(`/api/v1/organizations/${ORG_ID}/tournaments/${TOUR_ID}`);
+    expect(init.method).toBe("PATCH");
+    // The venue names the zone; the client does not send one.
+    expect(JSON.parse(init.body)).not.toHaveProperty("timezone");
+  });
+});

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/__tests__/entryFees.test.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/__tests__/entryFees.test.ts
@@ -20,22 +20,28 @@ function tier(overrides: Partial<FeeTier> & Pick<FeeTier, "type">): FeeTier {
   };
 }
 
+function feesData(overrides: Partial<FeesData> = {}): FeesData {
+  return { standardFee: "", tiers: [], preservedTiers: [], ...overrides };
+}
+
 describe("toPersistedEntryFees", () => {
   it("writes the canonical key names every consumer reads", () => {
-    const persisted = toPersistedEntryFees({
-      standardFee: 50,
-      tiers: [
-        tier({ type: "early_bird", amount: 40, validUntil: "2026-02-19" }),
-        tier({ type: "titled_players", amount: 0, titles: ["GM", "IM"] }),
-        tier({
-          type: "rating_based",
-          amount: 35,
-          ratingFrom: 0,
-          ratingTo: 1800,
-        }),
-        tier({ type: "age_based", amount: 30, ageFrom: 0, ageTo: 12 }),
-      ],
-    });
+    const persisted = toPersistedEntryFees(
+      feesData({
+        standardFee: 50,
+        tiers: [
+          tier({ type: "early_bird", amount: 40, validUntil: "2026-02-19" }),
+          tier({ type: "titled_players", amount: 0, titles: ["GM", "IM"] }),
+          tier({
+            type: "rating_based",
+            amount: 35,
+            ratingFrom: 0,
+            ratingTo: 1800,
+          }),
+          tier({ type: "age_based", amount: 30, ageFrom: 0, ageTo: 12 }),
+        ],
+      }),
+    );
 
     expect(persisted).toEqual({
       standard: { amount_cents: 5000 },
@@ -58,13 +64,14 @@ describe("toPersistedEntryFees", () => {
   });
 
   it("omits criteria that were left blank", () => {
-    const persisted = toPersistedEntryFees({
-      standardFee: "",
-      tiers: [
-        tier({ type: "early_bird", amount: "" }),
-        tier({ type: "age_based", amount: 20, ageFrom: 8, ageTo: "" }),
-      ],
-    });
+    const persisted = toPersistedEntryFees(
+      feesData({
+        tiers: [
+          tier({ type: "early_bird", amount: "" }),
+          tier({ type: "age_based", amount: 20, ageFrom: 8, ageTo: "" }),
+        ],
+      }),
+    );
 
     expect(persisted).toEqual({
       standard: { amount_cents: 0 },
@@ -94,11 +101,13 @@ describe("fromPersistedEntryFees", () => {
 
     expect(fromPersistedEntryFees(stored)).toEqual({
       standardFee: 50,
+      preservedTiers: [],
       tiers: [
         {
           type: "early_bird",
           amount: 40,
           validUntil: "2026-02-19",
+          validUntilSource: "2026-02-19T23:59:59+08:00",
           titles: [],
           ratingFrom: "",
           ratingTo: "",
@@ -109,6 +118,7 @@ describe("fromPersistedEntryFees", () => {
           type: "age_based",
           amount: 30,
           validUntil: "",
+          validUntilSource: undefined,
           titles: [],
           ratingFrom: "",
           ratingTo: "",
@@ -119,7 +129,7 @@ describe("fromPersistedEntryFees", () => {
     });
   });
 
-  it("skips tiers the wizard cannot edit instead of coercing them", () => {
+  it("sets aside tiers the wizard cannot edit instead of coercing them", () => {
     const fees = fromPersistedEntryFees({
       standard: { amount_cents: 5000 },
       additional: [
@@ -130,19 +140,24 @@ describe("fromPersistedEntryFees", () => {
     });
 
     expect(fees.tiers.map((t) => t.type)).toEqual(["age_based"]);
+    expect(fees.preservedTiers).toEqual([
+      { index: 0, tier: { type: "standard", amount_cents: 5000 } },
+      { index: 1, tier: { type: "gender", amount_cents: 2500 } },
+    ]);
   });
 
   it("falls back to an empty form for a tournament with no fees", () => {
     expect(fromPersistedEntryFees(null)).toEqual({
       standardFee: "",
       tiers: [],
+      preservedTiers: [],
     });
   });
 });
 
 describe("entry fee round trip", () => {
   it("survives save → resume unchanged", () => {
-    const original: FeesData = {
+    const original = feesData({
       standardFee: 50,
       tiers: [
         tier({ type: "early_bird", amount: 40, validUntil: "2026-02-19" }),
@@ -155,11 +170,85 @@ describe("entry fee round trip", () => {
         }),
         tier({ type: "age_based", amount: 30, ageFrom: 0, ageTo: 12 }),
       ],
+    });
+
+    const restored = fromPersistedEntryFees(toPersistedEntryFees(original));
+
+    // Resuming a draft picks up the instant that was just written, so the next
+    // save can reproduce it exactly. Nothing else about the form changes.
+    expect(restored.tiers[0].validUntilSource).toBe(
+      "2026-02-19T23:59:59+08:00",
+    );
+    expect(restored).toEqual({
+      ...original,
+      tiers: original.tiers.map((t, i) => ({
+        ...t,
+        validUntilSource: restored.tiers[i].validUntilSource,
+      })),
+    });
+  });
+
+  // The regression this suite exists to hold. `entry_fees` is jsonb, and both
+  // the PATCH route's deepEquals and guard_tournament_money_fields' IS DISTINCT
+  // FROM read any difference at all as a fee change — which is refused outright
+  // on a tournament that has taken payment. So hydrating a row and saving it
+  // back untouched has to reproduce it byte for byte, whatever shape it is in.
+  it.each([
+    ["canonical end-of-day", "2026-02-19T23:59:59+08:00"],
+    ["a midnight instant, as the seed wrote", "2026-02-19T00:00:00+00:00"],
+    ["a bare calendar date, as the wizard once wrote", "2026-02-19"],
+  ])("re-saves an untouched tier holding %s verbatim", (_label, stamp) => {
+    const stored: StoredEntryFees = {
+      standard: { amount_cents: 5000 },
+      additional: [
+        { type: "early_bird", amount_cents: 4000, valid_until: stamp },
+        { type: "age_based", amount_cents: 3000, age_min: 0, age_max: 12 },
+      ],
     };
 
-    expect(fromPersistedEntryFees(toPersistedEntryFees(original))).toEqual(
-      original,
+    expect(toPersistedEntryFees(fromPersistedEntryFees(stored))).toEqual(
+      stored,
     );
+  });
+
+  it("carries a non-editable tier through at its original index", () => {
+    const stored: StoredEntryFees = {
+      standard: { amount_cents: 5000 },
+      additional: [
+        { type: "gender", amount_cents: 2500 },
+        {
+          type: "early_bird",
+          amount_cents: 4000,
+          valid_until: "2026-02-19T23:59:59+08:00",
+        },
+        { type: "oku", amount_cents: 1000 },
+      ],
+    };
+
+    expect(toPersistedEntryFees(fromPersistedEntryFees(stored))).toEqual(
+      stored,
+    );
+  });
+
+  it("normalises a date the organizer actually moved", () => {
+    const hydrated = fromPersistedEntryFees({
+      standard: { amount_cents: 5000 },
+      additional: [
+        {
+          type: "early_bird",
+          amount_cents: 4000,
+          valid_until: "2026-02-19T00:00:00+00:00",
+        },
+      ],
+    });
+
+    hydrated.tiers[0].validUntil = "2026-02-25";
+
+    expect(toPersistedEntryFees(hydrated).additional[0]).toEqual({
+      type: "early_bird",
+      amount_cents: 4000,
+      valid_until: "2026-02-25T23:59:59+08:00",
+    });
   });
 });
 
@@ -198,13 +287,15 @@ describe("valid_until", () => {
   });
 
   it("round-trips a tier's valid_until through the venue timezone", () => {
-    const fees: FeesData = {
-      standardFee: 50,
-      tiers: [
-        tier({ type: "early_bird", amount: 40, validUntil: "2026-02-19" }),
-      ],
-    };
-    const persisted = toPersistedEntryFees(fees, "Asia/Manila");
+    const persisted = toPersistedEntryFees(
+      feesData({
+        standardFee: 50,
+        tiers: [
+          tier({ type: "early_bird", amount: 40, validUntil: "2026-02-19" }),
+        ],
+      }),
+      "Asia/Manila",
+    );
     expect(persisted.additional[0].valid_until).toBe(
       "2026-02-19T23:59:59+08:00",
     );

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/entryFees.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/entryFees.ts
@@ -24,7 +24,9 @@ import type {
   FeeTier,
   PersistedEntryFees,
   PersistedFeeTier,
+  PreservedFeeTier,
   StoredEntryFees,
+  StoredFeeTier,
   TierType,
 } from "../types";
 
@@ -92,6 +94,52 @@ export function fromValidUntilTimestamp(
 }
 
 /**
+ * The instant to write for a tier's `valid_until`.
+ *
+ * A tier whose date the organizer did not move is written back exactly as it
+ * was stored. `entry_fees` is compared byte-for-byte — by `deepEquals` in the
+ * PATCH route and by `IS DISTINCT FROM` in guard_tournament_money_fields — so
+ * normalising an already-stored value would report a money-field edit on a save
+ * that only changed the venue, and a tournament with a paid registration would
+ * be refused outright. Only a date the organizer actually picked is normalised.
+ */
+function validUntilFor(tier: FeeTier, timeZone: string): string {
+  if (
+    tier.validUntilSource &&
+    toCalendarDateInTimeZone(tier.validUntilSource, timeZone) ===
+      tier.validUntil
+  ) {
+    return tier.validUntilSource;
+  }
+  return toValidUntilTimestamp(tier.validUntil, timeZone);
+}
+
+/**
+ * Editable tiers with the non-editable ones spliced back at the indices they
+ * were stored at, since jsonb array equality is order-sensitive.
+ */
+function mergePreserved(
+  edited: PersistedFeeTier[],
+  preserved: PreservedFeeTier[],
+): (PersistedFeeTier | StoredFeeTier)[] {
+  if (preserved.length === 0) return edited;
+
+  const byIndex = new Map(preserved.map((p) => [p.index, p.tier]));
+  const merged: (PersistedFeeTier | StoredFeeTier)[] = [];
+  const remaining = [...edited];
+
+  for (let i = 0; i < edited.length + preserved.length; i++) {
+    const held = byIndex.get(i);
+    if (held) merged.push(held);
+    else if (remaining.length > 0) merged.push(remaining.shift()!);
+  }
+
+  // An index past the end of the merged array (a tier removed from the middle)
+  // leaves entries unplaced; append them rather than lose them.
+  return [...merged, ...remaining];
+}
+
+/**
  * Wizard fee state → canonical entry_fees for persistence. `timeZone` is the
  * venue's: an early-bird tier the organizer says runs "until the 19th" ends
  * when the 19th ends at the venue.
@@ -100,44 +148,43 @@ export function toPersistedEntryFees(
   data: FeesData,
   timeZone: string = DEFAULT_TIME_ZONE,
 ): PersistedEntryFees {
+  const edited = data.tiers.map((tier) => {
+    const persisted: PersistedFeeTier = {
+      type: tier.type,
+      amount_cents: toCents(tier.amount),
+    };
+
+    switch (tier.type) {
+      case "early_bird":
+        if (tier.validUntil) {
+          persisted.valid_until = validUntilFor(tier, timeZone);
+        }
+        break;
+      case "titled_players":
+        if (tier.titles.length > 0) persisted.titles = tier.titles;
+        break;
+      case "rating_based": {
+        const min = boundOrUndefined(tier.ratingFrom);
+        const max = boundOrUndefined(tier.ratingTo);
+        if (min !== undefined) persisted.rating_min = min;
+        if (max !== undefined) persisted.rating_max = max;
+        break;
+      }
+      case "age_based": {
+        const min = boundOrUndefined(tier.ageFrom);
+        const max = boundOrUndefined(tier.ageTo);
+        if (min !== undefined) persisted.age_min = min;
+        if (max !== undefined) persisted.age_max = max;
+        break;
+      }
+    }
+
+    return persisted;
+  });
+
   return {
     standard: { amount_cents: toCents(data.standardFee) },
-    additional: data.tiers.map((tier) => {
-      const persisted: PersistedFeeTier = {
-        type: tier.type,
-        amount_cents: toCents(tier.amount),
-      };
-
-      switch (tier.type) {
-        case "early_bird":
-          if (tier.validUntil) {
-            persisted.valid_until = toValidUntilTimestamp(
-              tier.validUntil,
-              timeZone,
-            );
-          }
-          break;
-        case "titled_players":
-          if (tier.titles.length > 0) persisted.titles = tier.titles;
-          break;
-        case "rating_based": {
-          const min = boundOrUndefined(tier.ratingFrom);
-          const max = boundOrUndefined(tier.ratingTo);
-          if (min !== undefined) persisted.rating_min = min;
-          if (max !== undefined) persisted.rating_max = max;
-          break;
-        }
-        case "age_based": {
-          const min = boundOrUndefined(tier.ageFrom);
-          const max = boundOrUndefined(tier.ageTo);
-          if (min !== undefined) persisted.age_min = min;
-          if (max !== undefined) persisted.age_max = max;
-          break;
-        }
-      }
-
-      return persisted;
-    }),
+    additional: mergePreserved(edited, data.preservedTiers ?? []),
   };
 }
 
@@ -145,33 +192,42 @@ export function toPersistedEntryFees(
  * Canonical entry_fees (from the DB) → wizard fee state for editing.
  *
  * Tiers the wizard has no editor for (the canonical gender/oku tiers, or the
- * implicit "standard" entry some rows carry) are skipped rather than coerced
- * into an early-bird row — an unrecognised tier is not editable here and must
- * not be silently rewritten as a different one.
+ * implicit "standard" entry some rows carry) are not coerced into an early-bird
+ * row — an unrecognised tier is not editable here and must not be silently
+ * rewritten as a different one. They are set aside with their index instead of
+ * discarded, so saving an unrelated field does not delete them.
  */
 export function fromPersistedEntryFees(
   fees: StoredEntryFees | null | undefined,
   timeZone: string = DEFAULT_TIME_ZONE,
 ): FeesData {
   const tiers: FeeTier[] = [];
+  const preservedTiers: PreservedFeeTier[] = [];
 
-  for (const stored of fees?.additional ?? []) {
-    if (!EDITABLE_TIER_TYPES.has(stored.type)) continue;
+  const stored = fees?.additional ?? [];
+  for (let index = 0; index < stored.length; index++) {
+    const tier = stored[index];
+    if (!EDITABLE_TIER_TYPES.has(tier.type)) {
+      preservedTiers.push({ index, tier });
+      continue;
+    }
 
     tiers.push({
-      type: stored.type as TierType,
-      amount: fromCents(stored.amount_cents),
-      validUntil: fromValidUntilTimestamp(stored.valid_until, timeZone),
-      titles: stored.titles ?? [],
-      ratingFrom: boundOrEmpty(stored.rating_min),
-      ratingTo: boundOrEmpty(stored.rating_max),
-      ageFrom: boundOrEmpty(stored.age_min),
-      ageTo: boundOrEmpty(stored.age_max),
+      type: tier.type as TierType,
+      amount: fromCents(tier.amount_cents),
+      validUntil: fromValidUntilTimestamp(tier.valid_until, timeZone),
+      validUntilSource: tier.valid_until ?? undefined,
+      titles: tier.titles ?? [],
+      ratingFrom: boundOrEmpty(tier.rating_min),
+      ratingTo: boundOrEmpty(tier.rating_max),
+      ageFrom: boundOrEmpty(tier.age_min),
+      ageTo: boundOrEmpty(tier.age_max),
     });
   }
 
   return {
     standardFee: fromCents(fees?.standard?.amount_cents),
     tiers,
+    preservedTiers,
   };
 }

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
@@ -1,28 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { SUPPORTED_COUNTRIES, regionsForCountry } from "@/lib/venues";
 import type { BasicInfoData } from "../../types";
 import { useTournamentWizard } from "../TournamentWizardContext";
 import { VENUE_TIME_ZONES } from "@/lib/datetime";
-
-const MALAYSIAN_STATES = [
-  "Johor",
-  "Kedah",
-  "Kelantan",
-  "Melaka",
-  "Negeri Sembilan",
-  "Pahang",
-  "Perak",
-  "Perlis",
-  "Pulau Pinang",
-  "Sabah",
-  "Sarawak",
-  "Selangor",
-  "Terengganu",
-  "W.P. Kuala Lumpur",
-  "W.P. Labuan",
-  "W.P. Putrajaya",
-];
 
 type NameStatus = "idle" | "checking" | "available" | "taken" | "error";
 
@@ -145,6 +127,15 @@ export default function BasicInfoStep() {
     setForm((f) => ({ ...f, [key]: value }));
   };
 
+  const regions = regionsForCountry(form.venueCountry);
+
+  // Changing country invalidates the selected state — the two lists don't
+  // overlap, so keeping the old value would submit a region the new country
+  // doesn't have and fail server-side validation.
+  const handleCountryChange = (code: string) => {
+    setForm((f) => ({ ...f, venueCountry: code, venueState: "" }));
+  };
+
   return (
     <div>
       <h2 className="font-cinzel text-text-primary mb-1 text-lg font-bold tracking-wide">
@@ -241,6 +232,32 @@ export default function BasicInfoStep() {
 
         <div className="form-group">
           <div className="label-row">
+            <label htmlFor="venue-country" className="input-label">
+              Country
+            </label>
+            <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
+              *
+            </span>
+          </div>
+          <select
+            id="venue-country"
+            className="input"
+            value={form.venueCountry}
+            onChange={(e) => handleCountryChange(e.target.value)}
+          >
+            {SUPPORTED_COUNTRIES.map((c) => (
+              <option key={c.code} value={c.code}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <p className="input-hint">
+            Sets the timezone your tournament dates are read in.
+          </p>
+        </div>
+
+        <div className="form-group">
+          <div className="label-row">
             <label htmlFor="venue-state" className="input-label">
               State
             </label>
@@ -255,7 +272,7 @@ export default function BasicInfoStep() {
             onChange={(e) => field("venueState", e.target.value)}
           >
             <option value="">Select state…</option>
-            {MALAYSIAN_STATES.map((s) => (
+            {regions.map((s) => (
               <option key={s} value={s}>
                 {s}
               </option>

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { SUPPORTED_COUNTRIES, regionsForCountry } from "@/lib/venues";
+import {
+  SUPPORTED_COUNTRIES,
+  regionsForCountry,
+  timeZoneForRegion,
+} from "@/lib/venues";
 import type { BasicInfoData } from "../../types";
 import { useTournamentWizard } from "../TournamentWizardContext";
-import { VENUE_TIME_ZONES } from "@/lib/datetime";
+import { timeZoneAbbreviation } from "@/lib/datetime";
 
 type NameStatus = "idle" | "checking" | "available" | "taken" | "error";
 
@@ -129,6 +133,10 @@ export default function BasicInfoStep() {
 
   const regions = regionsForCountry(form.venueCountry);
 
+  // Derived, never picked. Shown so the organizer can see which clock the dates
+  // they are about to enter will be read in.
+  const timeZone = timeZoneForRegion(form.venueCountry, form.venueState);
+
   // Changing country invalidates the selected state — the two lists don't
   // overlap, so keeping the old value would submit a region the new country
   // doesn't have and fail server-side validation.
@@ -252,7 +260,7 @@ export default function BasicInfoStep() {
             ))}
           </select>
           <p className="input-hint">
-            Sets the timezone your tournament dates are read in.
+            Decides how players pay and are paid out.
           </p>
         </div>
 
@@ -272,44 +280,22 @@ export default function BasicInfoStep() {
             onChange={(e) => field("venueState", e.target.value)}
           >
             <option value="">Select state…</option>
-            {regions.map((s) => (
-              <option key={s} value={s}>
-                {s}
+            {regions.map((r) => (
+              <option key={r.name} value={r.name}>
+                {r.name}
               </option>
             ))}
           </select>
-          {showErrors && errors.venueState && (
+          {showErrors && errors.venueState ? (
             <p className="input-hint error">{errors.venueState}</p>
+          ) : (
+            form.venueState && (
+              <p className="input-hint">
+                Times are {timeZoneAbbreviation(timeZone)} ({timeZone}).
+              </p>
+            )
           )}
         </div>
-      </div>
-
-      {/* Venue Timezone */}
-      <div className="form-group">
-        <div className="label-row">
-          <label htmlFor="venue-timezone" className="input-label">
-            Venue Timezone
-          </label>
-          <span aria-hidden="true" className="text-danger ml-0.5 text-sm">
-            *
-          </span>
-        </div>
-        <select
-          id="venue-timezone"
-          className="input"
-          value={form.timezone}
-          onChange={(e) => field("timezone", e.target.value)}
-        >
-          {VENUE_TIME_ZONES.map((z) => (
-            <option key={z.id} value={z.id}>
-              {z.label} ({z.abbreviation})
-            </option>
-          ))}
-        </select>
-        <p className="input-hint">
-          Every date and time you enter is in this timezone, and that is how
-          players see them wherever they are.
-        </p>
       </div>
 
       {/* Venue Address */}

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import type { FormatData, Restriction, RestrictionKind } from "../../types";
 import { useTournamentWizard } from "../TournamentWizardContext";
 import { newRowId } from "../rowId";
@@ -8,6 +8,7 @@ import { RESTRICTION_KINDS, RESTRICTION_LABELS } from "../restrictions";
 import { CountryDropdown } from "@/components/ui/country-dropdown";
 import { nameToAlpha3 } from "@/lib/countries";
 import { getTodayInTimeZone } from "@/lib/datetime";
+import { timeZoneForRegion } from "@/lib/venues";
 
 const FORMAT_TYPES = ["Rapid", "Blitz", "Classical"];
 const SYSTEMS = ["Swiss", "Round Robin", "Knockout"];
@@ -28,7 +29,7 @@ type FieldErrors = Partial<
 
 const NO_ERRORS: FieldErrors = {};
 
-function validate(data: FormatData): FieldErrors {
+function validate(data: FormatData, timeZone: string): FieldErrors {
   const errors: FieldErrors = {};
 
   if (!data.formatType) errors.formatType = "Format type is required.";
@@ -46,9 +47,12 @@ function validate(data: FormatData): FieldErrors {
     errors.baseTime = "Base time must be at least 1 minute.";
   }
 
+  // "Today" is today at the venue, not wherever the organizer's browser is: a
+  // Bangkok tournament starting tomorrow is not in the past because the editor
+  // is an hour ahead. Same zone the publish route and the edit freeze use.
   if (!data.startDate) {
     errors.startDate = "Start date is required.";
-  } else if (data.startDate <= getTodayInTimeZone()) {
+  } else if (data.startDate <= getTodayInTimeZone(timeZone)) {
     // Publish rejects a past start date anyway (422 from the publish route);
     // catching it here means the organizer finds out on the step that owns the
     // field instead of at the end of the wizard. It also matters more now that
@@ -100,8 +104,20 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 }
 
 export default function FormatStep() {
-  const { formatData, setFormatData, goNext, registerStepHandler } =
-    useTournamentWizard();
+  const {
+    basicInfoData,
+    formatData,
+    setFormatData,
+    goNext,
+    registerStepHandler,
+  } = useTournamentWizard();
+
+  // Memoized so it is a stable dependency of attemptNext below.
+  const timeZone = useMemo(
+    () =>
+      timeZoneForRegion(basicInfoData.venueCountry, basicInfoData.venueState),
+    [basicInfoData.venueCountry, basicInfoData.venueState],
+  );
 
   // WizardShell only mounts steps after the context has hydrated, so the
   // context value is already the restored one here.
@@ -110,7 +126,7 @@ export default function FormatStep() {
   const uid = useId();
 
   // Errors are derived from the form — no need to mirror them into state.
-  const errors = showErrors ? validate(form) : NO_ERRORS;
+  const errors = showErrors ? validate(form, timeZone) : NO_ERRORS;
 
   const field = <K extends keyof FormatData>(key: K, value: FormatData[K]) => {
     setForm((f) => ({ ...f, [key]: value }));
@@ -155,14 +171,14 @@ export default function FormatStep() {
 
   const attemptNext = useCallback(async () => {
     setShowErrors(true);
-    const fieldErrors = validate(form);
+    const fieldErrors = validate(form, timeZone);
     const hasErrors =
       Object.keys(fieldErrors).filter((k) => k !== "restrictions").length > 0 ||
       Object.keys(fieldErrors.restrictions ?? {}).length > 0;
     if (hasErrors) return;
     setFormatData(form);
     goNext();
-  }, [form, setFormatData, goNext]);
+  }, [form, timeZone, setFormatData, goNext]);
 
   useEffect(() => {
     registerStepHandler(1, attemptNext);

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
@@ -7,6 +7,7 @@ import { newRowId } from "../rowId";
 import { RESTRICTION_KINDS, RESTRICTION_LABELS } from "../restrictions";
 import { CountryDropdown } from "@/components/ui/country-dropdown";
 import { nameToAlpha3 } from "@/lib/countries";
+import { getTodayInTimeZone } from "@/lib/datetime";
 
 const FORMAT_TYPES = ["Rapid", "Blitz", "Classical"];
 const SYSTEMS = ["Swiss", "Round Robin", "Knockout"];
@@ -45,7 +46,16 @@ function validate(data: FormatData): FieldErrors {
     errors.baseTime = "Base time must be at least 1 minute.";
   }
 
-  if (!data.startDate) errors.startDate = "Start date is required.";
+  if (!data.startDate) {
+    errors.startDate = "Start date is required.";
+  } else if (data.startDate <= getTodayInTimeZone()) {
+    // Publish rejects a past start date anyway (422 from the publish route);
+    // catching it here means the organizer finds out on the step that owns the
+    // field instead of at the end of the wizard. It also matters more now that
+    // edits freeze at tournament start — a draft saved with a past date would
+    // be unpublishable and uneditable at the same time.
+    errors.startDate = "Start date must be in the future.";
+  }
   if (!data.endDate) {
     errors.endDate = "End date is required.";
   } else if (data.startDate && data.endDate < data.startDate) {

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/PrizesStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/PrizesStep.tsx
@@ -9,6 +9,12 @@ import type {
 } from "../../types";
 import { useTournamentWizard } from "../TournamentWizardContext";
 import { newRowId } from "../rowId";
+import {
+  PRIZE_FUNDING_LABELS,
+  PRIZE_FUNDING_SOURCES,
+  type PrizeDistribution,
+  type PrizeFundingSource,
+} from "@/lib/prize-funding";
 
 type PrizeRowErrors = Partial<{ placement: string; amount: string }>;
 type CategoryErrors = Partial<{
@@ -108,6 +114,7 @@ function PrizeCategoryBlock({
   onAddPrize,
   onUpdatePrize,
   onRemovePrize,
+  onUpdateFunding,
 }: {
   category: PrizeCategory;
   catErrors: CategoryErrors;
@@ -117,6 +124,10 @@ function PrizeCategoryBlock({
   onAddPrize: () => void;
   onUpdatePrize: (id: string, changes: Partial<PrizeRow>) => void;
   onRemovePrize: (id: string) => void;
+  onUpdateFunding: (changes: {
+    fundingSource?: PrizeFundingSource | "";
+    funderName?: string;
+  }) => void;
 }) {
   const prizeErrors = catErrors.prizes ?? {};
 
@@ -197,6 +208,71 @@ function PrizeCategoryBlock({
       </div>
 
       <AddRowButton onClick={onAddPrize}>+ Add Prize</AddRowButton>
+
+      <PrizeFundingFields
+        idPrefix={`cat-${category.id}`}
+        source={category.fundingSource}
+        funderName={category.funderName}
+        onChange={onUpdateFunding}
+      />
+    </div>
+  );
+}
+
+// Entry fees pay for running the event; prize money has to come from somewhere
+// else. Asking per category (rather than once per tournament) is deliberate —
+// a sponsored Open section alongside grant-funded age groups is the common case.
+function PrizeFundingFields({
+  idPrefix,
+  source,
+  funderName,
+  onChange,
+}: {
+  idPrefix: string;
+  source: PrizeFundingSource | "";
+  funderName: string;
+  onChange: (changes: {
+    fundingSource?: PrizeFundingSource | "";
+    funderName?: string;
+  }) => void;
+}) {
+  return (
+    <div className="border-border mt-3 grid grid-cols-1 gap-2 border-t pt-3 sm:grid-cols-2">
+      <div>
+        <label className="input-label" htmlFor={`${idPrefix}-source`}>
+          Prize funded by
+        </label>
+        <select
+          id={`${idPrefix}-source`}
+          className="input w-full"
+          value={source}
+          onChange={(e) =>
+            onChange({
+              fundingSource: e.target.value as PrizeFundingSource | "",
+            })
+          }
+        >
+          <option value="">Select source…</option>
+          {PRIZE_FUNDING_SOURCES.map((s) => (
+            <option key={s} value={s}>
+              {PRIZE_FUNDING_LABELS[s]}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="input-label" htmlFor={`${idPrefix}-funder`}>
+          Funder name
+        </label>
+        <input
+          id={`${idPrefix}-funder`}
+          type="text"
+          className="input w-full"
+          placeholder="e.g. ACME Sdn Bhd"
+          value={funderName}
+          onChange={(e) => onChange({ funderName: e.target.value })}
+        />
+      </div>
     </div>
   );
 }
@@ -220,8 +296,22 @@ export default function PrizesStep() {
       id: newRowId(),
       name: "",
       prizes: [{ id: newRowId(), placement: "", amount: "" }],
+      fundingSource: "",
+      funderName: "",
     };
     setForm((f) => ({ ...f, categories: [...f.categories, newCat] }));
+  };
+
+  const updateCategoryFunding = (
+    catId: string,
+    changes: Partial<Pick<PrizeCategory, "fundingSource" | "funderName">>,
+  ) => {
+    setForm((f) => ({
+      ...f,
+      categories: f.categories.map((c) =>
+        c.id === catId ? { ...c, ...changes } : c,
+      ),
+    }));
   };
 
   const removeCategory = (catId: string) => {
@@ -284,7 +374,13 @@ export default function PrizesStep() {
   // ── Special prize helpers ─────────────────────────────────
 
   const addSpecialPrize = () => {
-    const newSp: SpecialPrize = { id: newRowId(), name: "", amount: "" };
+    const newSp: SpecialPrize = {
+      id: newRowId(),
+      name: "",
+      amount: "",
+      fundingSource: "",
+      funderName: "",
+    };
     setForm((f) => ({ ...f, specialPrizes: [...f.specialPrizes, newSp] }));
   };
 
@@ -346,6 +442,9 @@ export default function PrizesStep() {
               updatePrize(cat.id, rowId, changes)
             }
             onRemovePrize={(rowId) => removePrize(cat.id, rowId)}
+            onUpdateFunding={(changes) =>
+              updateCategoryFunding(cat.id, changes)
+            }
           />
         );
       })}
@@ -366,47 +465,58 @@ export default function PrizesStep() {
           {form.specialPrizes.map((sp) => {
             const se = errors.specialPrizes[sp.id] ?? {};
             return (
-              <div key={sp.id} className="flex items-start gap-2">
-                <div className="min-w-0 flex-1">
-                  <input
-                    type="text"
-                    className={`input w-full ${showErrors && se.name ? "input-error" : ""}`}
-                    placeholder="Prize name (e.g. Best Female Player)"
-                    value={sp.name}
-                    onChange={(e) =>
-                      updateSpecialPrize(sp.id, { name: e.target.value })
-                    }
-                  />
-                  {showErrors && se.name && (
-                    <p className="input-hint error mt-0.5">{se.name}</p>
-                  )}
-                </div>
-                <div style={{ width: "130px", flexShrink: 0 }}>
-                  <div className="flex items-center gap-1.5">
-                    <span className="font-lato text-text-muted shrink-0 text-sm">
-                      RM
-                    </span>
+              <div
+                key={sp.id}
+                className="bg-bg-base border-border rounded-lg border p-3"
+              >
+                <div className="flex items-start gap-2">
+                  <div className="min-w-0 flex-1">
                     <input
-                      type="number"
-                      className={`input w-full text-right tabular-nums ${showErrors && se.amount ? "input-error" : ""}`}
-                      placeholder="0"
-                      min={0}
-                      value={sp.amount === "" ? "" : String(sp.amount)}
-                      onChange={(e) => {
-                        const raw = e.target.value;
-                        updateSpecialPrize(sp.id, {
-                          amount: raw === "" ? "" : Number(raw),
-                        });
-                      }}
+                      type="text"
+                      className={`input w-full ${showErrors && se.name ? "input-error" : ""}`}
+                      placeholder="Prize name (e.g. Best Female Player)"
+                      value={sp.name}
+                      onChange={(e) =>
+                        updateSpecialPrize(sp.id, { name: e.target.value })
+                      }
                     />
+                    {showErrors && se.name && (
+                      <p className="input-hint error mt-0.5">{se.name}</p>
+                    )}
                   </div>
-                  {showErrors && se.amount && (
-                    <p className="input-hint error mt-0.5">{se.amount}</p>
-                  )}
+                  <div style={{ width: "130px", flexShrink: 0 }}>
+                    <div className="flex items-center gap-1.5">
+                      <span className="font-lato text-text-muted shrink-0 text-sm">
+                        RM
+                      </span>
+                      <input
+                        type="number"
+                        className={`input w-full text-right tabular-nums ${showErrors && se.amount ? "input-error" : ""}`}
+                        placeholder="0"
+                        min={0}
+                        value={sp.amount === "" ? "" : String(sp.amount)}
+                        onChange={(e) => {
+                          const raw = e.target.value;
+                          updateSpecialPrize(sp.id, {
+                            amount: raw === "" ? "" : Number(raw),
+                          });
+                        }}
+                      />
+                    </div>
+                    {showErrors && se.amount && (
+                      <p className="input-hint error mt-0.5">{se.amount}</p>
+                    )}
+                  </div>
+                  <RemoveButton
+                    onClick={() => removeSpecialPrize(sp.id)}
+                    label="Remove special prize"
+                  />
                 </div>
-                <RemoveButton
-                  onClick={() => removeSpecialPrize(sp.id)}
-                  label="Remove special prize"
+                <PrizeFundingFields
+                  idPrefix={`sp-${sp.id}`}
+                  source={sp.fundingSource}
+                  funderName={sp.funderName}
+                  onChange={(changes) => updateSpecialPrize(sp.id, changes)}
                 />
               </div>
             );
@@ -415,6 +525,59 @@ export default function PrizesStep() {
       )}
 
       <AddRowButton onClick={addSpecialPrize}>+ Add Special Prize</AddRowButton>
+
+      {/* Distribution */}
+      <h3 className="font-cinzel text-gold-muted border-border mt-6 mb-3 border-t pt-4 text-xs font-bold tracking-widest uppercase">
+        Prize Distribution
+      </h3>
+      <p className="font-lato text-text-muted mb-3 text-xs">
+        Entry fees cover the cost of running your tournament and are never used
+        to pay prizes — prize money must come from a sponsor, a grant, or your
+        own funds.
+      </p>
+      <div className="flex flex-col gap-2">
+        {(
+          [
+            [
+              "organizer",
+              "I'll pay the winners myself",
+              "You collect the prize money and hand it out. Nothing extra to do here.",
+            ],
+            [
+              "platform",
+              "MY Chess Tour distributes the prizes",
+              "You or your sponsor pay the prize pool to us up front; we transfer it to the winners after the event.",
+            ],
+          ] as const
+        ).map(([value, label, hint]) => (
+          <label
+            key={value}
+            className="border-border hover:border-gold-muted flex cursor-pointer gap-3 rounded-lg border p-3 transition duration-200"
+          >
+            <input
+              type="radio"
+              name="prize-distribution"
+              className="mt-1 shrink-0"
+              value={value}
+              checked={form.distribution === value}
+              onChange={() =>
+                setForm((f) => ({
+                  ...f,
+                  distribution: value as PrizeDistribution,
+                }))
+              }
+            />
+            <span>
+              <span className="font-lato text-text-primary block text-sm">
+                {label}
+              </span>
+              <span className="font-lato text-text-muted block text-xs">
+                {hint}
+              </span>
+            </span>
+          </label>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/ReviewStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/ReviewStep.tsx
@@ -8,9 +8,9 @@ import { RESTRICTION_LABELS } from "../restrictions";
 import {
   VENUE_TIME_ZONES,
   formatCalendarDate,
-  resolveTimeZone,
   timeZoneAbbreviation,
 } from "@/lib/datetime";
+import { timeZoneForRegion } from "@/lib/venues";
 
 const COMMISSION = 0.1;
 
@@ -111,7 +111,10 @@ export default function ReviewStep() {
 
   // ── Basic Info ────────────────────────────────────────────
 
-  const timeZone = resolveTimeZone(basicInfoData.timezone);
+  const timeZone = timeZoneForRegion(
+    basicInfoData.venueCountry,
+    basicInfoData.venueState,
+  );
   const timeZoneLabel = `${
     VENUE_TIME_ZONES.find((z) => z.id === timeZone)?.label ?? timeZone
   } (${timeZoneAbbreviation(timeZone)})`;

--- a/src/app/my/organizations/[orgId]/tournaments/create/types.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/types.ts
@@ -7,7 +7,10 @@
 // server component that seeds an edit session can reference them without
 // importing a "use client" module.
 
-import type { PrizeDistribution, PrizeFundingSource } from "@/lib/prize-funding";
+import type {
+  PrizeDistribution,
+  PrizeFundingSource,
+} from "@/lib/prize-funding";
 
 // =============================================
 // WIZARD STATE
@@ -31,18 +34,17 @@ export interface BasicInfoData {
   venueName: string;
   /**
    * ISO 3166-1 alpha-2 of the venue's country. Decides which regions the state
-   * dropdown offers, and which payout rails the tournament's money will move
-   * on. Independent of `timezone` — a country can span several zones.
+   * dropdown offers, and which payout rails the tournament's money will move on.
    */
   venueCountry: string;
+  /**
+   * The venue's state / province. Together with `venueCountry` this also decides
+   * the timezone every date in the wizard is entered in — see timeZoneForRegion
+   * in src/lib/venues.ts. There is deliberately no separate `timezone` field:
+   * the organizer states where the venue is, once.
+   */
   venueState: string;
   venueAddress: string;
-  /**
-   * IANA timezone of the venue. Every date and time in the wizard is entered in
-   * this zone — it is what the organizer means by "6pm" — and it is what the
-   * tournament is later displayed and bucketed in.
-   */
-  timezone: string;
 }
 
 /**
@@ -108,6 +110,14 @@ export interface FeeTier {
   type: TierType;
   amount: number | "";
   validUntil: string;
+  /**
+   * The `valid_until` instant this tier hydrated from, kept so an untouched
+   * tier can be written back byte-for-byte. `validUntil` above is only its
+   * calendar date, so re-deriving an instant from it would rewrite any value
+   * not already anchored to end-of-day — and `entry_fees` is compared exactly
+   * by the money-field freeze. Absent on tiers the organizer just added.
+   */
+  validUntilSource?: string;
   titles: string[];
   ratingFrom: number | "";
   ratingTo: number | "";
@@ -118,6 +128,19 @@ export interface FeeTier {
 export interface FeesData {
   standardFee: number | "";
   tiers: FeeTier[];
+  /**
+   * Tiers the wizard has no editor for (the canonical gender/oku tiers), held
+   * at their original index so they can be spliced back on save. Dropping them
+   * silently deleted a tournament's pricing and, because `entry_fees` is
+   * compared exactly, made every save look like a money-field edit.
+   */
+  preservedTiers: PreservedFeeTier[];
+}
+
+export interface PreservedFeeTier {
+  /** Index in the stored `additional` array. jsonb arrays compare in order. */
+  index: number;
+  tier: StoredFeeTier;
 }
 
 export interface PrizeRow {
@@ -197,7 +220,11 @@ export interface PersistedFeeTier {
 
 export interface PersistedEntryFees {
   standard: { amount_cents: number };
-  additional: PersistedFeeTier[];
+  /**
+   * `StoredFeeTier` is in the union because tiers the wizard cannot edit are
+   * carried through untouched rather than rewritten — see FeesData.preservedTiers.
+   */
+  additional: (PersistedFeeTier | StoredFeeTier)[];
 }
 
 /**

--- a/src/app/my/organizations/[orgId]/tournaments/create/types.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/types.ts
@@ -7,6 +7,8 @@
 // server component that seeds an edit session can reference them without
 // importing a "use client" module.
 
+import type { PrizeDistribution, PrizeFundingSource } from "@/lib/prize-funding";
+
 // =============================================
 // WIZARD STATE
 // =============================================
@@ -128,17 +130,26 @@ export interface PrizeCategory {
   id: string;
   name: string;
   prizes: PrizeRow[];
+  // Entry fees never fund prizes (see src/lib/prize-funding.ts), so any
+  // category carrying money must declare where that money comes from. Empty
+  // string = not chosen yet; publish rejects that.
+  fundingSource: PrizeFundingSource | "";
+  funderName: string;
 }
 
 export interface SpecialPrize {
   id: string;
   name: string;
   amount: number | "";
+  fundingSource: PrizeFundingSource | "";
+  funderName: string;
 }
 
 export interface PrizesData {
   categories: PrizeCategory[];
   specialPrizes: SpecialPrize[];
+  /** Who pays the winners — the organizer directly, or the platform. */
+  distribution: PrizeDistribution;
 }
 
 export interface PersistedState {

--- a/src/app/my/organizations/[orgId]/tournaments/create/types.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/types.ts
@@ -27,6 +27,12 @@ export interface BasicInfoData {
   name: string;
   description: string;
   venueName: string;
+  /**
+   * ISO 3166-1 alpha-2 of the venue's country. Decides which regions the state
+   * dropdown offers, and which payout rails the tournament's money will move
+   * on. Independent of `timezone` — a country can span several zones.
+   */
+  venueCountry: string;
   venueState: string;
   venueAddress: string;
   /**

--- a/src/app/my/organizations/__tests__/navigationLinks.test.tsx
+++ b/src/app/my/organizations/__tests__/navigationLinks.test.tsx
@@ -69,7 +69,12 @@ const tournament = {
   end_date: "2026-08-02",
   registration_deadline: "2026-07-25T00:00:00Z",
   registration_closed_at: null,
-  venue: { name: "City Hall", state: "Selangor", address: "1 Main St" },
+  venue: {
+    name: "City Hall",
+    state: "Selangor",
+    address: "1 Main St",
+    country: "MY",
+  },
   timezone: "Asia/Kuala_Lumpur",
   format: null,
   max_participants: 16,

--- a/src/app/tournaments/[slug]/types.ts
+++ b/src/app/tournaments/[slug]/types.ts
@@ -22,14 +22,19 @@ interface PrizeCategory {
   entries: PrizeEntry[];
 }
 
-interface PrizeSubCategory {
+interface SpecialPrize {
   name: string;
-  entries: PrizeEntry[];
-  conditions: unknown;
+  amount_cents?: number;
 }
+
 interface PrizesData {
   categories: PrizeCategory[];
-  subcategories?: PrizeSubCategory[] | null;
+  /**
+   * Flat one-off prizes, the counterpart of `categories`. Named `special` to
+   * match PrizesJson (src/lib/prize-funding.ts) — the key the wizard writes and
+   * publish validation reads. Not rendered on this page yet.
+   */
+  special?: SpecialPrize[] | null;
 }
 
 export interface Restrictions {

--- a/src/app/tournaments/_components/TournamentsClient.tsx
+++ b/src/app/tournaments/_components/TournamentsClient.tsx
@@ -29,7 +29,9 @@ function SectionBanner({ label }: { label: string }) {
 
 // Every supported country's regions, flattened — discovery filters across all
 // venues, not one country at a time.
-const ALL_REGIONS = SUPPORTED_COUNTRIES.flatMap((c) => c.regions);
+const ALL_REGIONS = SUPPORTED_COUNTRIES.flatMap((c) =>
+  c.regions.map((r) => r.name),
+);
 
 interface Props {
   tournaments: Tournament[];

--- a/src/app/tournaments/_components/TournamentsClient.tsx
+++ b/src/app/tournaments/_components/TournamentsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { SUPPORTED_COUNTRIES } from "@/lib/venues";
 import type { Tournament } from "../types";
 import { getTournamentDateState } from "../utils";
 import {
@@ -26,24 +27,9 @@ function SectionBanner({ label }: { label: string }) {
   );
 }
 
-const MALAYSIAN_STATES = [
-  "Johor",
-  "Kedah",
-  "Kelantan",
-  "Melaka",
-  "Negeri Sembilan",
-  "Pahang",
-  "Perak",
-  "Perlis",
-  "Pulau Pinang",
-  "Sabah",
-  "Sarawak",
-  "Selangor",
-  "Terengganu",
-  "W.P. Kuala Lumpur",
-  "W.P. Labuan",
-  "W.P. Putrajaya",
-];
+// Every supported country's regions, flattened — discovery filters across all
+// venues, not one country at a time.
+const ALL_REGIONS = SUPPORTED_COUNTRIES.flatMap((c) => c.regions);
 
 interface Props {
   tournaments: Tournament[];
@@ -178,7 +164,7 @@ export default function TournamentsClient({ tournaments, now }: Props) {
         onRatingsChange={setRatings}
         dateFilter={dateFilter}
         onDateFilterChange={setDateFilter}
-        allStates={MALAYSIAN_STATES}
+        allStates={ALL_REGIONS}
       />
 
       {/* Tournament sections */}

--- a/src/lib/__tests__/prize-funding.test.ts
+++ b/src/lib/__tests__/prize-funding.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  PRIZE_FUNDING_SOURCES,
+  isPrizeDistribution,
+  isPrizeFundingSource,
+  totalDeclaredPrizeCents,
+  validatePrizeFunding,
+  type PrizesJson,
+} from "../prize-funding";
+
+const SPONSORED = { source: "sponsor" as const, funder_name: "ACME Sdn Bhd" };
+
+describe("funding sources", () => {
+  it("never accepts entry fees as a prize funding source", () => {
+    // The whole design rests on this: entry fees are an administration fee and
+    // prize money must come from outside the pool of competitors.
+    expect(PRIZE_FUNDING_SOURCES).not.toContain("entry_fees");
+    expect(isPrizeFundingSource("entry_fees")).toBe(false);
+  });
+
+  it("accepts the three external sources and nothing else", () => {
+    expect(isPrizeFundingSource("sponsor")).toBe(true);
+    expect(isPrizeFundingSource("grant")).toBe(true);
+    expect(isPrizeFundingSource("organizer")).toBe(true);
+    expect(isPrizeFundingSource("registrations")).toBe(false);
+    expect(isPrizeFundingSource(null)).toBe(false);
+  });
+
+  it("validates distribution modes", () => {
+    expect(isPrizeDistribution("organizer")).toBe(true);
+    expect(isPrizeDistribution("platform")).toBe(true);
+    expect(isPrizeDistribution("sponsor")).toBe(false);
+  });
+});
+
+describe("totalDeclaredPrizeCents", () => {
+  it("is 0 for null/empty prizes", () => {
+    expect(totalDeclaredPrizeCents(null)).toBe(0);
+    expect(totalDeclaredPrizeCents({})).toBe(0);
+  });
+
+  it("sums categories and special prizes together", () => {
+    const prizes: PrizesJson = {
+      categories: [
+        {
+          name: "Open",
+          funding: SPONSORED,
+          entries: [{ amount_cents: 80000 }, { amount_cents: 48000 }],
+        },
+      ],
+      special: [
+        { name: "Best Female", funding: SPONSORED, amount_cents: 20000 },
+      ],
+    };
+    expect(totalDeclaredPrizeCents(prizes)).toBe(148000);
+  });
+
+  it("ignores entries with no amount", () => {
+    const prizes: PrizesJson = {
+      categories: [{ name: "Open", entries: [{ place: "1st" }] }],
+    };
+    expect(totalDeclaredPrizeCents(prizes)).toBe(0);
+  });
+});
+
+describe("validatePrizeFunding", () => {
+  it("passes when there are no prizes at all", () => {
+    expect(validatePrizeFunding(null)).toEqual([]);
+    expect(validatePrizeFunding({ categories: [], special: [] })).toEqual([]);
+  });
+
+  it("passes when every funded prize names its source", () => {
+    const prizes: PrizesJson = {
+      categories: [
+        {
+          name: "Open",
+          funding: SPONSORED,
+          entries: [{ amount_cents: 50000 }],
+        },
+      ],
+      special: [
+        { name: "Best Junior", funding: SPONSORED, amount_cents: 10000 },
+      ],
+      distribution: "organizer",
+    };
+    expect(validatePrizeFunding(prizes)).toEqual([]);
+  });
+
+  it("rejects a funded category with no funding declared", () => {
+    const prizes: PrizesJson = {
+      categories: [{ name: "Open", entries: [{ amount_cents: 50000 }] }],
+    };
+    const errors = validatePrizeFunding(prizes);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("Open");
+  });
+
+  it("rejects a declared source with no funder named", () => {
+    const prizes: PrizesJson = {
+      categories: [
+        {
+          name: "Open",
+          funding: { source: "sponsor", funder_name: "   " },
+          entries: [{ amount_cents: 50000 }],
+        },
+      ],
+    };
+    expect(validatePrizeFunding(prizes)[0]).toMatch(/name the sponsor/i);
+  });
+
+  it("ignores a category with no money attached", () => {
+    // An empty category is a structural placeholder, not a promise to pay.
+    const prizes: PrizesJson = {
+      categories: [{ name: "Open", entries: [{ place: "1st" }] }],
+    };
+    expect(validatePrizeFunding(prizes)).toEqual([]);
+  });
+
+  it("reports every offending prize, not just the first", () => {
+    const prizes: PrizesJson = {
+      categories: [
+        { name: "Open", entries: [{ amount_cents: 50000 }] },
+        { name: "Under-12", entries: [{ amount_cents: 20000 }] },
+      ],
+      special: [{ name: "Best Veteran", amount_cents: 10000 }],
+    };
+    expect(validatePrizeFunding(prizes)).toHaveLength(3);
+  });
+
+  it("falls back to a generic label for an unnamed category", () => {
+    const prizes: PrizesJson = {
+      categories: [{ entries: [{ amount_cents: 50000 }] }],
+    };
+    expect(validatePrizeFunding(prizes)[0]).toMatch(/^Prize category/);
+  });
+
+  it("rejects an unknown distribution mode", () => {
+    const prizes = {
+      distribution: "sponsor",
+    } as unknown as PrizesJson;
+    expect(validatePrizeFunding(prizes)[0]).toMatch(/organizer or platform/);
+  });
+});

--- a/src/lib/__tests__/venues.test.ts
+++ b/src/lib/__tests__/venues.test.ts
@@ -6,7 +6,9 @@ import {
   isSupportedCountry,
   isValidRegion,
   regionsForCountry,
+  timeZoneForRegion,
 } from "../venues";
+import { DEFAULT_TIME_ZONE, isSupportedTimeZone } from "../datetime";
 
 describe("SUPPORTED_COUNTRIES", () => {
   it("uses uppercase ISO 3166-1 alpha-2 codes", () => {
@@ -23,7 +25,19 @@ describe("SUPPORTED_COUNTRIES", () => {
   it("gives every country at least one region, with no duplicates", () => {
     for (const c of SUPPORTED_COUNTRIES) {
       expect(c.regions.length).toBeGreaterThan(0);
-      expect(new Set(c.regions).size).toBe(c.regions.length);
+      const names = c.regions.map((r) => r.name);
+      expect(new Set(names).size).toBe(names.length);
+    }
+  });
+
+  // A region's zone is written straight to tournaments.timezone and then read
+  // back by resolveTimeZone, which silently swaps anything off the picklist for
+  // the default. A typo here would relocate a venue's clock without a word.
+  it("gives every region a timezone the platform recognises", () => {
+    for (const c of SUPPORTED_COUNTRIES) {
+      for (const r of c.regions) {
+        expect(isSupportedTimeZone(r.timeZone)).toBe(true);
+      }
     }
   });
 
@@ -61,7 +75,7 @@ describe("findCountry / isSupportedCountry", () => {
 
 describe("regionsForCountry / isValidRegion", () => {
   it("returns regions for a known country and empty for an unknown one", () => {
-    expect(regionsForCountry("MY")).toContain("Selangor");
+    expect(regionsForCountry("MY").map((r) => r.name)).toContain("Selangor");
     expect(regionsForCountry("ZZ")).toEqual([]);
   });
 
@@ -80,5 +94,25 @@ describe("regionsForCountry / isValidRegion", () => {
     expect(() => isValidRegion("MY", 123)).not.toThrow();
     expect(isValidRegion("MY", 123)).toBe(false);
     expect(isValidRegion(123, "Selangor")).toBe(false);
+  });
+});
+
+describe("timeZoneForRegion", () => {
+  it("resolves a region to the zone its dates are read in", () => {
+    expect(timeZoneForRegion("MY", "Selangor")).toBe("Asia/Kuala_Lumpur");
+    // East Malaysia keeps the same clock as the peninsula.
+    expect(timeZoneForRegion("MY", "Sarawak")).toBe("Asia/Kuala_Lumpur");
+  });
+
+  // Callers write the result straight to tournaments.timezone, so it has to be
+  // a zone Intl can format — throwing or returning "" would take down every
+  // page that renders one of the tournament's dates.
+  it("falls back to the platform default rather than failing", () => {
+    expect(timeZoneForRegion("MY", "Atlantis")).toBe(DEFAULT_TIME_ZONE);
+    expect(timeZoneForRegion("ZZ", "Selangor")).toBe(DEFAULT_TIME_ZONE);
+    // An unfinished draft has no state yet.
+    expect(timeZoneForRegion("MY", "")).toBe(DEFAULT_TIME_ZONE);
+    expect(timeZoneForRegion(null, null)).toBe(DEFAULT_TIME_ZONE);
+    expect(() => timeZoneForRegion(123, {})).not.toThrow();
   });
 });

--- a/src/lib/__tests__/venues.test.ts
+++ b/src/lib/__tests__/venues.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_COUNTRY_CODE,
+  SUPPORTED_COUNTRIES,
+  findCountry,
+  isSupportedCountry,
+  isValidRegion,
+  regionsForCountry,
+} from "../venues";
+
+describe("SUPPORTED_COUNTRIES", () => {
+  it("uses uppercase ISO 3166-1 alpha-2 codes", () => {
+    for (const c of SUPPORTED_COUNTRIES) {
+      expect(c.code).toMatch(/^[A-Z]{2}$/);
+    }
+  });
+
+  it("has no duplicate country codes", () => {
+    const codes = SUPPORTED_COUNTRIES.map((c) => c.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it("gives every country at least one region, with no duplicates", () => {
+    for (const c of SUPPORTED_COUNTRIES) {
+      expect(c.regions.length).toBeGreaterThan(0);
+      expect(new Set(c.regions).size).toBe(c.regions.length);
+    }
+  });
+
+  it("includes the default country", () => {
+    expect(findCountry(DEFAULT_COUNTRY_CODE)).toBeDefined();
+  });
+});
+
+describe("findCountry / isSupportedCountry", () => {
+  it("matches case-insensitively", () => {
+    expect(findCountry("my")?.code).toBe("MY");
+    expect(isSupportedCountry("My")).toBe(true);
+  });
+
+  it("rejects unknown, empty, and nullish codes", () => {
+    expect(isSupportedCountry("ZZ")).toBe(false);
+    expect(isSupportedCountry("")).toBe(false);
+    expect(isSupportedCountry(null)).toBe(false);
+    expect(isSupportedCountry(undefined)).toBe(false);
+  });
+});
+
+describe("regionsForCountry / isValidRegion", () => {
+  it("returns regions for a known country and empty for an unknown one", () => {
+    expect(regionsForCountry("MY")).toContain("Selangor");
+    expect(regionsForCountry("ZZ")).toEqual([]);
+  });
+
+  it("validates a region against its own country only", () => {
+    expect(isValidRegion("MY", "Selangor")).toBe(true);
+    expect(isValidRegion("MY", "Atlantis")).toBe(false);
+    expect(isValidRegion("ZZ", "Selangor")).toBe(false);
+  });
+
+  it("treats empty and nullish regions as invalid", () => {
+    expect(isValidRegion("MY", "")).toBe(false);
+    expect(isValidRegion("MY", null)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/venues.test.ts
+++ b/src/lib/__tests__/venues.test.ts
@@ -44,6 +44,19 @@ describe("findCountry / isSupportedCountry", () => {
     expect(isSupportedCountry(null)).toBe(false);
     expect(isSupportedCountry(undefined)).toBe(false);
   });
+
+  // These arrive from `await request.json()`, where the declared field type is
+  // a claim about well-behaved clients and nothing more. Guarding only
+  // falsiness would let every truthy non-string reach .toUpperCase() and throw,
+  // turning a bad request body into a 500.
+  it("rejects non-string codes instead of throwing", () => {
+    for (const bad of [123, true, {}, ["MY"], () => "MY"]) {
+      expect(() => findCountry(bad)).not.toThrow();
+      expect(findCountry(bad)).toBeUndefined();
+      expect(isSupportedCountry(bad)).toBe(false);
+      expect(regionsForCountry(bad)).toEqual([]);
+    }
+  });
 });
 
 describe("regionsForCountry / isValidRegion", () => {
@@ -61,5 +74,11 @@ describe("regionsForCountry / isValidRegion", () => {
   it("treats empty and nullish regions as invalid", () => {
     expect(isValidRegion("MY", "")).toBe(false);
     expect(isValidRegion("MY", null)).toBe(false);
+  });
+
+  it("treats non-string regions as invalid instead of throwing", () => {
+    expect(() => isValidRegion("MY", 123)).not.toThrow();
+    expect(isValidRegion("MY", 123)).toBe(false);
+    expect(isValidRegion(123, "Selangor")).toBe(false);
   });
 });

--- a/src/lib/prize-funding.ts
+++ b/src/lib/prize-funding.ts
@@ -1,0 +1,156 @@
+// Where a tournament's prize money comes from, and who distributes it.
+//
+// THE RULE: entry fees never fund prizes.
+//
+// Entry fees are an administration fee — venue, arbiters, equipment, rating
+// fees — an ordinary commercial exchange for organizing a competition. Prizes
+// must come from somewhere else: a sponsor, a grant, or the organizer's own
+// funds. A pool that every competitor pays into and the winners take out is a
+// different kind of arrangement entirely, and the platform does not host it.
+//
+// Publish validation enforces this: a tournament that declares prize money
+// without naming an external source for it cannot go live. There is
+// deliberately no "entry_fees" member of PrizeFundingSource — the rule is
+// expressed in the type, not just in a check.
+//
+// Consequence for payouts: because entry-fee revenue never owes anything to a
+// prize pool, an organizer's payout is their net revenue in full, with no prize
+// holdback. Prize money the platform holds (distribution === "platform") is
+// ring-fenced in its own balance and never mixed into organizer revenue.
+
+export const PRIZE_FUNDING_SOURCES = ["sponsor", "grant", "organizer"] as const;
+export type PrizeFundingSource = (typeof PRIZE_FUNDING_SOURCES)[number];
+
+export const PRIZE_FUNDING_LABELS: Record<PrizeFundingSource, string> = {
+  sponsor: "Sponsor",
+  grant: "Grant / government funding",
+  organizer: "Organizer's own funds",
+};
+
+/**
+ * Who hands the money to the winners.
+ * - "organizer" (default): the organizer pays winners directly, off-platform.
+ * - "platform": the organizer appoints us to distribute. The pool must be paid
+ *   in and fully funded before any winner is paid.
+ */
+export const PRIZE_DISTRIBUTION_MODES = ["organizer", "platform"] as const;
+export type PrizeDistribution = (typeof PRIZE_DISTRIBUTION_MODES)[number];
+
+export interface PrizeFunding {
+  source: PrizeFundingSource;
+  /** Who is actually putting up the money. Required, and shown publicly. */
+  funder_name: string;
+}
+
+export interface PrizeEntry {
+  place?: string;
+  amount_cents?: number;
+}
+
+export interface PrizeCategoryJson {
+  name?: string;
+  funding?: PrizeFunding | null;
+  entries?: PrizeEntry[];
+}
+
+export interface SpecialPrizeJson {
+  name?: string;
+  funding?: PrizeFunding | null;
+  amount_cents?: number;
+}
+
+/** The shape stored in `tournaments.prizes`. */
+export interface PrizesJson {
+  categories?: PrizeCategoryJson[];
+  special?: SpecialPrizeJson[];
+  distribution?: PrizeDistribution;
+}
+
+export function isPrizeFundingSource(v: unknown): v is PrizeFundingSource {
+  return (
+    typeof v === "string" &&
+    (PRIZE_FUNDING_SOURCES as readonly string[]).includes(v)
+  );
+}
+
+export function isPrizeDistribution(v: unknown): v is PrizeDistribution {
+  return (
+    typeof v === "string" &&
+    (PRIZE_DISTRIBUTION_MODES as readonly string[]).includes(v)
+  );
+}
+
+function categoryTotal(cat: PrizeCategoryJson): number {
+  return (cat.entries ?? []).reduce(
+    (sum, e) => sum + (typeof e.amount_cents === "number" ? e.amount_cents : 0),
+    0,
+  );
+}
+
+/** Total declared prize money across categories and special prizes, in cents. */
+export function totalDeclaredPrizeCents(
+  prizes: PrizesJson | null | undefined,
+): number {
+  if (!prizes) return 0;
+  const cats = (prizes.categories ?? []).reduce(
+    (sum, c) => sum + categoryTotal(c),
+    0,
+  );
+  const special = (prizes.special ?? []).reduce(
+    (sum, s) => sum + (typeof s.amount_cents === "number" ? s.amount_cents : 0),
+    0,
+  );
+  return cats + special;
+}
+
+function fundingErrorsFor(
+  label: string,
+  funding: PrizeFunding | null | undefined,
+): string[] {
+  if (!funding || !isPrizeFundingSource(funding.source)) {
+    return [`${label}: choose where the prize money comes from`];
+  }
+  if (!funding.funder_name?.trim()) {
+    return [`${label}: name the sponsor or funder`];
+  }
+  return [];
+}
+
+/**
+ * Validates the prize-funding declaration for publish.
+ *
+ * Only prizes with money attached need a source — an empty category is a
+ * structural placeholder, not a promise to pay anyone. Returns human-readable
+ * messages in the same style as the rest of the publish validation, so they can
+ * be appended straight onto its `validationErrors` array.
+ */
+export function validatePrizeFunding(
+  prizes: PrizesJson | null | undefined,
+): string[] {
+  if (!prizes) return [];
+
+  const errors: string[] = [];
+
+  for (const cat of prizes.categories ?? []) {
+    if (categoryTotal(cat) <= 0) continue;
+    errors.push(
+      ...fundingErrorsFor(cat.name?.trim() || "Prize category", cat.funding),
+    );
+  }
+
+  for (const sp of prizes.special ?? []) {
+    if (!sp.amount_cents || sp.amount_cents <= 0) continue;
+    errors.push(
+      ...fundingErrorsFor(sp.name?.trim() || "Special prize", sp.funding),
+    );
+  }
+
+  if (
+    prizes.distribution !== undefined &&
+    !isPrizeDistribution(prizes.distribution)
+  ) {
+    errors.push("Prize distribution must be either organizer or platform");
+  }
+
+  return errors;
+}

--- a/src/lib/venues.ts
+++ b/src/lib/venues.ts
@@ -5,28 +5,41 @@
 // discovery filter bar and the creation wizard — with no country attached, so
 // "which states may an organizer pick?" had two answers that could drift apart.
 //
-// The venue's *timezone* is deliberately NOT here. It is a separate stored
-// column that the organizer picks (see VENUE_TIME_ZONES in src/lib/datetime.ts),
-// because the country a venue sits in and the clock its dates are read in are
-// independent choices — a country can span several zones, and picking the zone
-// directly is what an organizer can actually verify.
+// The venue's *timezone* is derived here, from the region rather than the
+// country, and written to tournaments.timezone on save. The organizer used to
+// pick it from a separate list, which let three fields describing one place
+// disagree: a venue could be stated as Singapore, countried as Malaysia and
+// clocked in Bangkok, with nothing to reconcile them. A region knows what time
+// it is; asking twice only creates a way to get it wrong.
 //
-// Venue country exists for the payout work: it decides the rails and currency a
-// tournament's money moves on, which is a question no timezone can answer.
+// Per-region and not per-country because a country can span several zones —
+// Indonesia's WIB/WITA/WIT are the case this shape exists for.
+//
+// Venue country stays a separate stored column: it decides the payout rails and
+// currency a tournament's money moves on, which is a question no timezone can
+// answer, and a country's regions can share a zone without sharing a currency.
 //
 // This is also deliberately NOT src/lib/countries.ts, which wraps
 // `country-data-list` for player *nationality*. Venue country and player
 // nationality answer different questions and must not be conflated.
 
+import { DEFAULT_TIME_ZONE } from "./datetime";
+
+export interface VenueRegion {
+  /** State / province / region, stored in tournaments.venue_state. */
+  name: string;
+  /** IANA zone the region's calendar dates are read in. */
+  timeZone: string;
+}
+
 export interface SupportedCountry {
   /** ISO 3166-1 alpha-2, stored in tournaments.venue_country. */
   code: string;
   name: string;
-  /** States / provinces / regions, stored in tournaments.venue_state. */
-  regions: readonly string[];
+  regions: readonly VenueRegion[];
 }
 
-const MALAYSIAN_STATES = [
+const MALAYSIAN_STATES: readonly VenueRegion[] = [
   "Johor",
   "Kedah",
   "Kelantan",
@@ -43,7 +56,8 @@ const MALAYSIAN_STATES = [
   "W.P. Kuala Lumpur",
   "W.P. Labuan",
   "W.P. Putrajaya",
-] as const;
+  // Malaysia is one zone throughout, East and West alike, and observes no DST.
+].map((name) => ({ name, timeZone: "Asia/Kuala_Lumpur" }));
 
 export const SUPPORTED_COUNTRIES: readonly SupportedCountry[] = [
   {
@@ -75,12 +89,29 @@ export function isSupportedCountry(code: unknown): boolean {
 }
 
 /** Regions for a country; empty when the code is unknown. */
-export function regionsForCountry(code: unknown): readonly string[] {
+export function regionsForCountry(code: unknown): readonly VenueRegion[] {
   return findCountry(code)?.regions ?? [];
+}
+
+function findRegion(code: unknown, region: unknown): VenueRegion | undefined {
+  if (typeof region !== "string" || !region) return undefined;
+  return regionsForCountry(code).find((r) => r.name === region);
 }
 
 /** True when `region` is a known region of `code`. Used by write-path validation. */
 export function isValidRegion(code: unknown, region: unknown): boolean {
-  if (typeof region !== "string" || !region) return false;
-  return regionsForCountry(code).includes(region);
+  return findRegion(code, region) !== undefined;
+}
+
+/**
+ * The timezone a venue's dates are read in, derived from where it is.
+ *
+ * Falls back to the platform default for an unknown country or region rather
+ * than throwing: callers write the result straight to `tournaments.timezone`,
+ * and a zone `Intl` cannot parse takes down every page that formats a date.
+ * Write paths validate the region separately (isValidRegion), so the fallback
+ * is a safety net, not the way a bad region gets accepted.
+ */
+export function timeZoneForRegion(code: unknown, region: unknown): string {
+  return findRegion(code, region)?.timeZone ?? DEFAULT_TIME_ZONE;
 }

--- a/src/lib/venues.ts
+++ b/src/lib/venues.ts
@@ -1,0 +1,83 @@
+// Single source of truth for where a tournament can be held: the countries the
+// platform accepts as a venue, and the regions (states / provinces) each one has.
+//
+// Before this module the Malaysian state list was hardcoded in two places — the
+// discovery filter bar and the creation wizard — with no country attached, so
+// "which states may an organizer pick?" had two answers that could drift apart.
+//
+// The venue's *timezone* is deliberately NOT here. It is a separate stored
+// column that the organizer picks (see VENUE_TIME_ZONES in src/lib/datetime.ts),
+// because the country a venue sits in and the clock its dates are read in are
+// independent choices — a country can span several zones, and picking the zone
+// directly is what an organizer can actually verify.
+//
+// Venue country exists for the payout work: it decides the rails and currency a
+// tournament's money moves on, which is a question no timezone can answer.
+//
+// This is also deliberately NOT src/lib/countries.ts, which wraps
+// `country-data-list` for player *nationality*. Venue country and player
+// nationality answer different questions and must not be conflated.
+
+export interface SupportedCountry {
+  /** ISO 3166-1 alpha-2, stored in tournaments.venue_country. */
+  code: string;
+  name: string;
+  /** States / provinces / regions, stored in tournaments.venue_state. */
+  regions: readonly string[];
+}
+
+const MALAYSIAN_STATES = [
+  "Johor",
+  "Kedah",
+  "Kelantan",
+  "Melaka",
+  "Negeri Sembilan",
+  "Pahang",
+  "Perak",
+  "Perlis",
+  "Pulau Pinang",
+  "Sabah",
+  "Sarawak",
+  "Selangor",
+  "Terengganu",
+  "W.P. Kuala Lumpur",
+  "W.P. Labuan",
+  "W.P. Putrajaya",
+] as const;
+
+export const SUPPORTED_COUNTRIES: readonly SupportedCountry[] = [
+  {
+    code: "MY",
+    name: "Malaysia",
+    regions: MALAYSIAN_STATES,
+  },
+] as const;
+
+/** The platform's home country. Matches the tournaments.venue_country default. */
+export const DEFAULT_COUNTRY_CODE = "MY";
+
+export function findCountry(code: string | null | undefined) {
+  if (!code) return undefined;
+  const upper = code.toUpperCase();
+  return SUPPORTED_COUNTRIES.find((c) => c.code === upper);
+}
+
+export function isSupportedCountry(code: string | null | undefined): boolean {
+  return findCountry(code) !== undefined;
+}
+
+/** Regions for a country; empty when the code is unknown. */
+export function regionsForCountry(
+  code: string | null | undefined,
+): readonly string[] {
+  return findCountry(code)?.regions ?? [];
+}
+
+/** True when `region` is a known region of `code`. Used by write-path validation. */
+export function isValidRegion(
+  code: string | null | undefined,
+  region: string | null | undefined,
+): boolean {
+  if (!region) return false;
+  return regionsForCountry(code).includes(region);
+}

--- a/src/lib/venues.ts
+++ b/src/lib/venues.ts
@@ -56,28 +56,31 @@ export const SUPPORTED_COUNTRIES: readonly SupportedCountry[] = [
 /** The platform's home country. Matches the tournaments.venue_country default. */
 export const DEFAULT_COUNTRY_CODE = "MY";
 
-export function findCountry(code: string | null | undefined) {
-  if (!code) return undefined;
+// These take `unknown` on purpose. Their callers are request handlers holding a
+// parsed JSON body, where a field typed `string` in an interface is only a claim
+// about what a well-behaved client sends — `{"venue_country": 123}` parses fine
+// and would otherwise reach `.toUpperCase()` and throw. Validating the type here
+// rather than at each call site means a caller cannot forget, and none of them
+// need a cast to compile.
+
+/** The supported country `code` names, or undefined for anything else. */
+export function findCountry(code: unknown): SupportedCountry | undefined {
+  if (typeof code !== "string" || !code) return undefined;
   const upper = code.toUpperCase();
   return SUPPORTED_COUNTRIES.find((c) => c.code === upper);
 }
 
-export function isSupportedCountry(code: string | null | undefined): boolean {
+export function isSupportedCountry(code: unknown): boolean {
   return findCountry(code) !== undefined;
 }
 
 /** Regions for a country; empty when the code is unknown. */
-export function regionsForCountry(
-  code: string | null | undefined,
-): readonly string[] {
+export function regionsForCountry(code: unknown): readonly string[] {
   return findCountry(code)?.regions ?? [];
 }
 
 /** True when `region` is a known region of `code`. Used by write-path validation. */
-export function isValidRegion(
-  code: string | null | undefined,
-  region: string | null | undefined,
-): boolean {
-  if (!region) return false;
+export function isValidRegion(code: unknown, region: unknown): boolean {
+  if (typeof region !== "string" || !region) return false;
   return regionsForCountry(code).includes(region);
 }


### PR DESCRIPTION
Implements Phase 1 of #515. Closes #516.

Independent hardening jobs that the payout system will depend on. No CHIP integration, no new money surface — this is groundwork, and every piece stands on its own.

Reviewable commit by commit; each is a coherent change with its own rationale in the message.

> **Rebased onto `staging` after #527 and #529 merged.** #529 shipped per-tournament timezone, which overlapped with this branch's original commit 2 — see [Rebase notes](#rebase-notes) below for what changed and why. Commits 5 and 6 are review fixes.

---

## 1. Redact bank data from audit snapshots, drop dead org bank columns

`audit_trigger_func` writes full row snapshots into `audit_logs`, which is retained far longer than the rows it mirrors — so every write to `player_profiles.bank_account_number` left a permanent verbatim copy. `redact_jsonb_columns` masks listed keys to a `****last4` suffix on the way in: enough to answer "did this change?", never enough to reconstruct the value. `oku_document_path` is masked for the same reason — it is a capability-bearing storage path, not a label.

Closes the **S3** item in `wiki/launch-readiness.md`, flagged there as "the only item that gets strictly worse with every day of delay".

`organizations.bank_name` / `bank_account_holder` / `bank_account_number` are **dropped**, not reused. Nothing read or wrote them, and the `"Public can view approved organizations"` policy in `004_rls.sql` has no column restriction — the moment anything had written them they'd have been readable by `anon` through PostgREST. Payout bank details will live in their own RLS-gated table in Phase 3.

## 2. Store the venue's country per tournament

The Malaysian state list was hardcoded in two places — the discovery filter bar and the creation wizard — as a bare 16-string array with no country attached. "Which states may an organizer pick?" therefore had two answers free to drift apart, and neither could be widened without editing both.

`src/lib/venues.ts` becomes the single source for the countries the platform accepts as a venue and the regions each one has, and `tournaments.venue_country` records which one was chosen. Deliberately separate from `src/lib/countries.ts`, which wraps `country-data-list` for player *nationality* and answers a different question.

**`venue_country` is not a second way of spelling the venue's timezone.** The timezone is its own column, picked by the organizer from `VENUE_TIME_ZONES` (`src/lib/datetime.ts`, from #529), because a country can span several zones and the zone is the thing an organizer can actually verify. What the country decides is which **payout rails and currency** a tournament's money moves on — a question no timezone can answer, and the reason this lands with the payout work.

Defaults to `MY`, so **this is behaviour-preserving on existing data**.

## 3. Freeze tournament edits once players pay and once play starts

There were **no guards at all** on editing a tournament. The PATCH route checked authentication, org approval and role, and nothing else. A published, in-progress, finished, or even cancelled tournament could have its `start_date`, `entry_fees` and `prizes` rewritten. `TournamentManageClient` went further and listed `"ongoing"` as an editable state.

Two stages, because the two risks arrive at different moments:

| Stage | Freezes | When |
|---|---|---|
| 1 | `entry_fees`, `prizes`, `max_participants`, `commission_rate`, `organizer_commission_pct` | first **paid** registration |
| 2 | everything | tournament **starts** |

Stage 1 is at first payment rather than at publish so an organizer can still fix a typo on a listing nobody has bought into. Changing those fields afterwards rewrites a concluded transaction — and moving `prizes` also shifts the payout holdback under a tournament that is already selling.

**Enforced twice on purpose.** `guard_tournament_money_fields` is the authority, so the rule survives any writer including the service role and the SQL editor; the route produces the readable 409 naming the rejected fields. The started-at half stays in the route only — it depends on today-in-the-venue-timezone, and duplicating that in SQL would create a second definition free to drift.

Drafts are exempt from both stages: they carry placeholder dates (`2099-12-31`) that would otherwise read as long past.

## 4. Require prizes to declare an external funding source

Entry fees are an administration fee — venue, arbiters, equipment, rating fees — an ordinary exchange for the service of running a competition. Prize money must come from somewhere else: a sponsor, a grant, or the organizer's own funds. A pool that every competitor pays into and the winners take out is a different arrangement, and the platform does not host it.

**The rule is expressed in the type, not only in a check**: there is no `entry_fees` member of `PrizeFundingSource`, so it cannot be selected. Publish validation rejects any category or special prize carrying money without naming its source and funder. Empty categories are exempt — a category with no amount is a structural placeholder, not a promise to pay anyone.

Also adds a per-tournament distribution mode: `organizer` (default, they pay winners directly) or `platform` (they appoint us, which will require the pool to be paid in and fully funded first — Phase 8).

**This is what removes the prize holdback from the payout math.** Because entry-fee revenue never owes anything to a prize pool, an organizer's payout is their net revenue in full, and prize money the platform holds stays ring-fenced in its own balance.

## 5. Validate `venue_country`'s type instead of asserting it

`{"venue_country": 123}` is well-formed JSON, so it survived the `request.json()` try/catch and reached `findCountry`, which guarded only falsiness before calling `code.toUpperCase()`. Every truthy non-string — `123`, `true`, `{}`, `["MY"]` — threw an uncaught `TypeError`, turning a bad request body into a **500** on both the create and update routes. Only `0`, `""`, `null` and `undefined` reached the intended fallback, and by accident: they are falsy, so they exited early.

The venues helpers now take `unknown` and check the type themselves, because their callers hold a parsed JSON body where a field declared `string` is a claim about well-behaved clients and nothing more. The two `as string` casts that made this compile were that forgetting, written down. Call sites now read `findCountry(...)?.code`, which cannot throw and drops the separate `toUpperCase()` — `SupportedCountry.code` is already canonical.

Worth noting the neighbouring fields in the same handler (`venue_name`, `venue_state`, `venue_address`, `timezone`) all guarded with `typeof` already. The country lines were the outlier.

## 6. Refuse money-field edits only when the value actually changes

The commit-3 preflight gated on **presence** — `MONEY_FIELDS.filter((f) => f in patch)` — while `guard_tournament_money_fields` gates on **change**, comparing OLD/NEW with `IS DISTINCT FROM` and returning early when nothing differs. The route was therefore stricter than the rule it exists to explain.

That gap is reachable by the ordinary path, not a crafted request: the edit wizard rebuilds the entire draft body on every save, always sending `entry_fees` and always sending `max_participants` because the edit page hydrates it from the stored row. So an organizer with one paid registration who corrected a typo in the venue address, before the tournament started, got a **409 naming two fields they never touched** — on an edit the database would have accepted.

The freeze now compares each money field against the stored value and reports only what genuinely differs, which is why the PATCH fetch reads those columns. Comparison is **structural rather than `JSON.stringify`**, because jsonb equality ignores key order: two equal `entry_fees` objects can serialise differently depending on how the client built them, which would resurrect the same false 409 in a form harder to see.

---

## Verification

- `npm test` — **1640 passed** (108 files). Includes 9 freeze cases, 14 prize-funding cases, 11 venues cases.
- `npm run lint` — clean.
- `npm run build` — compiles.
- `npx tsc --noEmit` — **no new errors**. 39 errors remain, all pre-existing: `staging` at `c093436` reports the identical 39 (test fixtures missing `slug`, plus `session-cookie.test.ts`).
- **DB:** `db/tests/audit_redaction.sql` — paste into the Supabase SQL editor as service role after applying migrations. Transaction-wrapped, rolls back, prints `ALL SCENARIOS PASSED`. Six scenarios, including "no full account number survives anywhere in `audit_logs`".

The commit-6 tests were confirmed to fail against the pre-fix code, so they pin the behaviour rather than passing vacuously.

Manual check worth doing on staging: create a tournament, pay a registration, confirm entry-fee edits are refused **while an unchanged-money-fields venue edit through the wizard still succeeds**; then push `start_date` into the past and confirm all edits are refused.

> ⚠️ **`001_tables.sql` is an edited base schema, not an additive migration.** `venue_country` and #529's `timezone` now sit adjacent in the `tournaments` DDL; any environment already carrying the old schema needs both applied by hand.

## Rebase notes

This branch originally carried its own per-tournament-timezone commit, adding `venue_country` **and** `venue_timezone` with the zone derived server-side from the country. #529 then shipped the same feature differently — `tournaments.timezone`, organizer-picked from `VENUE_TIME_ZONES`, plus a full `src/lib/datetime.ts`. Neither was a patch-id duplicate of the other, so the rebase had to reconcile them by hand across 17 conflicting files.

**#529 stays authoritative.** The branch commit was reduced to the half #529 doesn't cover — `venue_country` and the countries/regions list — and `src/lib/venues.ts` lost `DEFAULT_TIME_ZONE` and `timezoneForCountry` so exactly one module owns timezone. Where the two implementations were saying the same thing in different words (`TournamentActions`, `TournamentManageClient`, `cancel/route.ts`, `tournaments/utils.ts`), #529's version was taken outright.

The one thing lost in the merge is the anti-spoofing property: a derived timezone can't be claimed by a client, an organizer-picked one can. That was judged an acceptable trade for not reverting shipped, tested work — and `venue_country`, which is what payouts actually route on, is still server-validated against `SUPPORTED_COUNTRIES`.

## Reviewer notes

Three judgment calls that differ from the issue text, all deliberate:

1. **The audit-redaction test is a new `db/tests/audit_redaction.sql`**, not an extension of `identity_indirection.sql` as #516 suggested. That file is scoped to RLS identity indirection; audit redaction is an unrelated concern and the other test files are one-concern-each.
2. **The trigger enforces only the money half of the freeze.** Rationale in the commit message and in a comment on the migration.
3. **`oku_document_path` is redacted alongside `bank_account_number`** — #516 named only the latter, but S3 in `launch-readiness.md` names both and it's the same one-line change.

Two test bugs found along the way, both worth calling out because each validates a premise of this branch:

- The "tournament has started" case originally built its fixture date from `toISOString()` (UTC) while the route resolves today in Kuala Lumpur. It passed all afternoon and failed after 16:00 UTC. Now uses `getTodayInTimeZone()` — precisely the bug class the per-tournament `timezone` column exists to prevent.
- The "still allows non-money edits" case hand-builds `{ venue_address }`, a body no client actually sends, which is why the whole suite stayed green while the real wizard path was returning false 409s (commit 6).

## Deferred, not forgotten

`RegistrationsClient` uses browser-local midnight and buckets on `start_date`, so a multi-day tournament reads as "past" the day it starts. Behaviourally unchanged today (Malaysia is single-timezone) and visibly wrong the moment a second country is added.

*(The `TournamentsClient` bucketing inconsistency previously listed here was fixed by #529, which now resolves "today" per tournament in its own zone.)*

## Next

Phase 2 (#517) — the Organizer Agreement and versioned acceptance — must reach production before Phase 3's application form, or organizers onboard with no agreement on file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
