### PR TITLE
fix: resume drafts with their fee criteria intact (#478)

### DIFF
--- a/src/app/api/v1/tournaments/[slug]/checkout/route.ts
+++ b/src/app/api/v1/tournaments/[slug]/checkout/route.ts
@@ -154,6 +154,8 @@ export async function POST(
     valid_until?: undefined;
     age_min?: undefined;
     age_max?: undefined;
+    rating_min?: undefined;
+    rating_max?: undefined;
     gender?: undefined;
     oku?: undefined;
     titles?: undefined;
@@ -198,10 +200,18 @@ export async function POST(
   }
 
   const restrictions = normalizeRestrictions(tournament.restrictions);
+  // Which rating list rating-based restrictions/tiers are judged against.
+  const ratingContext = {
+    formatType: (tournament.format as { type: string }).type,
+    isFideRated: tournament.is_fide_rated === true,
+    isMcfRated: tournament.is_mcf_rated === true,
+  };
 
   const needsTierProfile =
     matchedTier.age_min != null ||
     matchedTier.age_max != null ||
+    matchedTier.rating_min != null ||
+    matchedTier.rating_max != null ||
     matchedTier.gender != null ||
     matchedTier.oku === true ||
     (matchedTier.titles?.length ?? 0) > 0;
@@ -232,13 +242,18 @@ export async function POST(
       const restrictionError = checkRestrictions(
         restrictions,
         profile,
-        (tournament.format as { type: string }).type,
+        ratingContext,
         startDate,
       );
       if (restrictionError) return restrictionError;
     }
 
-    const tierError = checkFeeTierEligibility(matchedTier, profile, startDate);
+    const tierError = checkFeeTierEligibility(
+      matchedTier,
+      profile,
+      startDate,
+      ratingContext,
+    );
     if (tierError) return tierError;
 
     const ratedError = checkRatedRequirements(

--- a/src/app/api/v1/tournaments/[slug]/registrations/__tests__/validators.test.ts
+++ b/src/app/api/v1/tournaments/[slug]/registrations/__tests__/validators.test.ts
@@ -6,12 +6,33 @@ import {
   normalizeRestrictions,
 } from "../validators";
 import type { EligibilityProfile, FeeTier } from "../validators";
+import type { RatingContext } from "@/app/tournaments/utils";
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
 const NOW = new Date("2026-05-12T00:00:00Z");
+
+// Which rating list a check reads. A FIDE-rated event is judged on the FIDE
+// list for its format and an MCF-rated one on the national rating, with no
+// substitution between them; an event rated by neither takes whichever the
+// player has.
+const FIDE = (formatType: string): RatingContext => ({
+  formatType,
+  isFideRated: true,
+  isMcfRated: false,
+});
+const MCF = (formatType: string): RatingContext => ({
+  formatType,
+  isFideRated: false,
+  isMcfRated: true,
+});
+const UNRATED_EVENT = (formatType: string): RatingContext => ({
+  formatType,
+  isFideRated: false,
+  isMcfRated: false,
+});
 
 // At NOW, DOB_18 yields age 18, DOB_17 yields age 17
 const DOB_18 = "2008-05-12";
@@ -145,7 +166,7 @@ describe("checkRestrictions", () => {
         checkRestrictions(
           { nationality: "Malaysia" },
           makeProfile({ nationality: "Malaysia" }),
-          "rapid",
+          FIDE("rapid"),
           NOW,
         ),
       ).toBeNull();
@@ -156,7 +177,7 @@ describe("checkRestrictions", () => {
         checkRestrictions(
           { nationality: "MY" },
           makeProfile({ nationality: "Malaysia" }),
-          "rapid",
+          FIDE("rapid"),
           NOW,
         ),
       ).toBeNull();
@@ -166,7 +187,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { nationality: "Malaysia" },
         makeProfile({ nationality: "Singapore" }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result?.status).toBe(422);
@@ -179,7 +200,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { nationality: "Malaysia" },
         makeProfile({ nationality: null }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result?.status).toBe(422);
@@ -193,7 +214,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { gender: "female" },
         makeProfile({ gender: "male" }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -206,7 +227,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { gender: "female" },
         makeProfile({ gender: "female" }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result).toBeNull();
@@ -216,7 +237,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { gender: "female" },
         null,
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -228,14 +249,16 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { min_rating: null, max_rating: null, min_age: null, max_age: null },
         makeProfile(),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result).toBeNull();
     });
 
     it("returns null for empty restrictions object", () => {
-      expect(checkRestrictions({}, makeProfile(), "rapid", NOW)).toBeNull();
+      expect(
+        checkRestrictions({}, makeProfile(), FIDE("rapid"), NOW),
+      ).toBeNull();
     });
   });
 
@@ -248,7 +271,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { titles: ["GM", "IM"] },
         makeProfile({ title: "GM" }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result).toBeNull();
@@ -258,7 +281,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { titles: ["GM", "IM"] },
         makeProfile({ title: null }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result).not.toBeNull();
@@ -271,7 +294,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { titles: ["GM", "IM"] },
         makeProfile({ title: "FM" }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -289,7 +312,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { min_rating: 1000, max_rating: 1800 },
         makeProfile({ fide_rating: { rapid: 1500 } }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result).toBeNull();
@@ -299,7 +322,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { min_rating: 1800 },
         makeProfile({ fide_rating: { rapid: 1600 } }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -312,7 +335,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { min_rating: 1800 },
         makeProfile({ fide_rating: null, national_rating: null }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -322,7 +345,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { max_rating: 1500 },
         makeProfile({ fide_rating: { rapid: 1800 } }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -335,20 +358,60 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { max_rating: 1500 },
         makeProfile({ fide_rating: null, national_rating: null }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result).toBeNull();
     });
 
-    it("falls back to national_rating when no FIDE rating for the format", () => {
+    it("does not substitute national_rating on a FIDE-rated tournament", async () => {
       const result = checkRestrictions(
         { min_rating: 1800 },
         makeProfile({ fide_rating: null, national_rating: 1900 }),
-        "rapid",
+        FIDE("rapid"),
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+    });
+
+    it("does not substitute another FIDE list for the format's own", async () => {
+      const result = checkRestrictions(
+        { min_rating: 1800 },
+        makeProfile({ fide_rating: { standard: 1900 } }),
+        FIDE("rapid"),
+        NOW,
+      );
+      expect(result!.status).toBe(422);
+    });
+
+    it("reads the national rating on an MCF-rated tournament", () => {
+      const result = checkRestrictions(
+        { min_rating: 1800 },
+        makeProfile({ fide_rating: { rapid: 1500 }, national_rating: 1900 }),
+        MCF("rapid"),
         NOW,
       );
       expect(result).toBeNull();
+    });
+
+    it("accepts either rating when the tournament is rated by neither federation", () => {
+      expect(
+        checkRestrictions(
+          { min_rating: 1800 },
+          makeProfile({ fide_rating: null, national_rating: 1900 }),
+          UNRATED_EVENT("rapid"),
+          NOW,
+        ),
+      ).toBeNull();
+
+      expect(
+        checkRestrictions(
+          { min_rating: 1800 },
+          makeProfile({ fide_rating: { rapid: 1900 }, national_rating: null }),
+          UNRATED_EVENT("rapid"),
+          NOW,
+        ),
+      ).toBeNull();
     });
 
     it("uses the blitz key for blitz format tournaments", async () => {
@@ -357,7 +420,7 @@ describe("checkRestrictions", () => {
         makeProfile({
           fide_rating: { standard: 2000, rapid: 2000, blitz: 1600 },
         }),
-        "blitz",
+        FIDE("blitz"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -367,7 +430,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { min_rating: 1800 },
         makeProfile({ fide_rating: { standard: 2000, rapid: 1600 } }),
-        "classical",
+        FIDE("classical"),
         NOW,
       );
       expect(result).toBeNull();
@@ -383,7 +446,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { min_age: 16, max_age: 20 },
         makeProfile({ date_of_birth: DOB_18 }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result).toBeNull();
@@ -393,7 +456,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { min_age: 18 },
         makeProfile({ date_of_birth: null }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -405,7 +468,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { min_age: 18 },
         makeProfile({ date_of_birth: DOB_17 }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -418,7 +481,7 @@ describe("checkRestrictions", () => {
       const result = checkRestrictions(
         { max_age: 17 },
         makeProfile({ date_of_birth: DOB_18 }),
-        "rapid",
+        FIDE("rapid"),
         NOW,
       );
       expect(result!.status).toBe(422);
@@ -432,7 +495,7 @@ describe("checkRestrictions", () => {
         checkRestrictions(
           { min_age: 18 },
           makeProfile({ date_of_birth: DOB_18 }),
-          "rapid",
+          FIDE("rapid"),
           NOW,
         ),
       ).toBeNull();
@@ -441,7 +504,7 @@ describe("checkRestrictions", () => {
         checkRestrictions(
           { max_age: 18 },
           makeProfile({ date_of_birth: DOB_18 }),
-          "rapid",
+          FIDE("rapid"),
           NOW,
         ),
       ).toBeNull();
@@ -457,7 +520,9 @@ describe("checkFeeTierEligibility", () => {
   describe("no tier restrictions", () => {
     it("returns null for a standard tier with no restrictions", () => {
       const tier: FeeTier = {};
-      expect(checkFeeTierEligibility(tier, makeProfile(), NOW)).toBeNull();
+      expect(
+        checkFeeTierEligibility(tier, makeProfile(), NOW, FIDE("classical")),
+      ).toBeNull();
     });
   });
 
@@ -472,6 +537,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ gender: "male" }),
         NOW,
+        FIDE("classical"),
       );
       expect(result!.status).toBe(400);
       const json = await result!.json();
@@ -485,6 +551,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ gender: "female" }),
         NOW,
+        FIDE("classical"),
       );
       expect(result).toBeNull();
     });
@@ -501,6 +568,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ oku_status: "none" }),
         NOW,
+        FIDE("classical"),
       );
       expect(result!.status).toBe(400);
       const json = await result!.json();
@@ -513,6 +581,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ oku_status: "pending" }),
         NOW,
+        FIDE("classical"),
       );
       expect(result!.status).toBe(400);
     });
@@ -523,6 +592,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ oku_status: "verified" }),
         NOW,
+        FIDE("classical"),
       );
       expect(result).toBeNull();
     });
@@ -539,6 +609,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ title: null }),
         NOW,
+        FIDE("classical"),
       );
       expect(result!.status).toBe(400);
       const json = await result!.json();
@@ -551,6 +622,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ title: "FM" }),
         NOW,
+        FIDE("classical"),
       );
       expect(result!.status).toBe(400);
     });
@@ -561,8 +633,166 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ title: "FM" }),
         NOW,
+        FIDE("classical"),
       );
       expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Age
+  // -------------------------------------------------------------------------
+
+  describe("rating restriction", () => {
+    it("returns null when the player's rating is inside the tier range", () => {
+      const tier: FeeTier = { rating_min: 1500, rating_max: 1800 };
+      expect(
+        checkFeeTierEligibility(
+          tier,
+          makeProfile({ fide_rating: { standard: 1700 } }),
+          NOW,
+          FIDE("classical"),
+        ),
+      ).toBeNull();
+    });
+
+    it("returns 400 when the player's rating is below the tier's rating_min", async () => {
+      const tier: FeeTier = { rating_min: 1800 };
+      const result = checkFeeTierEligibility(
+        tier,
+        makeProfile({ fide_rating: { standard: 1600 } }),
+        NOW,
+        FIDE("classical"),
+      );
+      expect(result!.status).toBe(400);
+      const json = await result!.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+      expect(json.error.message).toContain("1800");
+    });
+
+    it("returns 400 when the player's rating exceeds the tier's rating_max", async () => {
+      const tier: FeeTier = { rating_max: 1799 };
+      const result = checkFeeTierEligibility(
+        tier,
+        makeProfile({ fide_rating: { standard: 2000 } }),
+        NOW,
+        FIDE("classical"),
+      );
+      expect(result!.status).toBe(400);
+      const json = await result!.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+      expect(json.error.message).toContain("1799");
+    });
+
+    it("treats the tier bounds as inclusive", () => {
+      expect(
+        checkFeeTierEligibility(
+          { rating_min: 1500, rating_max: 1800 },
+          makeProfile({ fide_rating: { standard: 1500 } }),
+          NOW,
+          FIDE("classical"),
+        ),
+      ).toBeNull();
+
+      expect(
+        checkFeeTierEligibility(
+          { rating_min: 1500, rating_max: 1800 },
+          makeProfile({ fide_rating: { standard: 1800 } }),
+          NOW,
+          FIDE("classical"),
+        ),
+      ).toBeNull();
+    });
+
+    it("blocks an unrated player from a tier with a floor", async () => {
+      const result = checkFeeTierEligibility(
+        { rating_min: 1500 },
+        makeProfile({ fide_rating: null, national_rating: null }),
+        NOW,
+        FIDE("classical"),
+      );
+      expect(result!.status).toBe(400);
+      const json = await result!.json();
+      expect(json.error.code).toBe("INVALID_FEE_TIER");
+      expect(json.error.message).toMatch(/no FIDE standard rating/);
+    });
+
+    it("admits an unrated player to a tier that only caps the rating", () => {
+      expect(
+        checkFeeTierEligibility(
+          { rating_max: 1500 },
+          makeProfile({ fide_rating: null, national_rating: null }),
+          NOW,
+          FIDE("classical"),
+        ),
+      ).toBeNull();
+    });
+
+    it("ignores the national rating on a FIDE-rated tournament", async () => {
+      // Nationally 1600, but no FIDE standard rating → unrated here, so the
+      // cap admits them and the floor doesn't.
+      const profile = makeProfile({
+        fide_rating: null,
+        national_rating: 1600,
+      });
+
+      expect(
+        checkFeeTierEligibility(
+          { rating_max: 1500 },
+          profile,
+          NOW,
+          FIDE("classical"),
+        ),
+      ).toBeNull();
+
+      const result = checkFeeTierEligibility(
+        { rating_min: 1500 },
+        profile,
+        NOW,
+        FIDE("classical"),
+      );
+      expect(result!.status).toBe(400);
+      expect((await result!.json()).error.message).toContain("FIDE standard");
+    });
+
+    it("judges an MCF-rated tournament on the national rating", async () => {
+      const profile = makeProfile({
+        fide_rating: { standard: 1400 },
+        national_rating: 1600,
+      });
+
+      const result = checkFeeTierEligibility(
+        { rating_max: 1500 },
+        profile,
+        NOW,
+        MCF("classical"),
+      );
+      expect(result!.status).toBe(400);
+    });
+
+    it("takes whichever rating exists when neither federation rates the event", () => {
+      expect(
+        checkFeeTierEligibility(
+          { rating_min: 1500 },
+          makeProfile({ fide_rating: null, national_rating: 1600 }),
+          NOW,
+          UNRATED_EVENT("classical"),
+        ),
+      ).toBeNull();
+    });
+
+    it("judges a blitz tournament on the blitz rating, not the standard one", () => {
+      const tier: FeeTier = { rating_max: 1500 };
+      const profile = makeProfile({
+        fide_rating: { standard: 2000, blitz: 1400 },
+      });
+
+      expect(
+        checkFeeTierEligibility(tier, profile, NOW, FIDE("blitz")),
+      ).toBeNull();
+      expect(
+        checkFeeTierEligibility(tier, profile, NOW, FIDE("classical"))!.status,
+      ).toBe(400);
     });
   });
 
@@ -577,6 +807,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ date_of_birth: null }),
         NOW,
+        FIDE("classical"),
       );
       expect(result!.status).toBe(422);
       const json = await result!.json();
@@ -589,6 +820,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ date_of_birth: DOB_17 }),
         NOW,
+        FIDE("classical"),
       );
       expect(result!.status).toBe(400);
       const json = await result!.json();
@@ -601,6 +833,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ date_of_birth: DOB_18 }),
         NOW,
+        FIDE("classical"),
       );
       expect(result!.status).toBe(400);
       const json = await result!.json();
@@ -613,6 +846,7 @@ describe("checkFeeTierEligibility", () => {
           { age_min: 18 },
           makeProfile({ date_of_birth: DOB_18 }),
           NOW,
+          FIDE("classical"),
         ),
       ).toBeNull();
 
@@ -621,6 +855,7 @@ describe("checkFeeTierEligibility", () => {
           { age_max: 18 },
           makeProfile({ date_of_birth: DOB_18 }),
           NOW,
+          FIDE("classical"),
         ),
       ).toBeNull();
     });
@@ -631,6 +866,7 @@ describe("checkFeeTierEligibility", () => {
         tier,
         makeProfile({ date_of_birth: DOB_18 }),
         NOW,
+        FIDE("classical"),
       );
       expect(result).toBeNull();
     });

--- a/src/app/api/v1/tournaments/[slug]/registrations/validators.ts
+++ b/src/app/api/v1/tournaments/[slug]/registrations/validators.ts
@@ -2,7 +2,13 @@ import { NextResponse } from "next/server";
 import type { ChessTitle } from "@/app/tournaments/types";
 import type { Restrictions } from "@/app/tournaments/[slug]/types";
 import type { OkuStatus } from "@/app/profile/types";
-import { checkAgeEligibility } from "@/app/tournaments/utils";
+import {
+  checkAgeEligibility,
+  checkRatingEligibility,
+  describeRatingList,
+  resolvePlayerRating,
+} from "@/app/tournaments/utils";
+import type { RatingContext } from "@/app/tournaments/utils";
 import { nationalityMatches, resolveCountry } from "@/lib/countries";
 
 export interface EligibilityProfile {
@@ -20,6 +26,8 @@ export interface EligibilityProfile {
 export interface FeeTier {
   age_min?: number | null;
   age_max?: number | null;
+  rating_min?: number | null;
+  rating_max?: number | null;
   gender?: string | null;
   oku?: boolean | null;
   titles?: ChessTitle[] | null;
@@ -75,7 +83,7 @@ export function normalizeRestrictions(raw: unknown): Restrictions | null {
 export function checkRestrictions(
   restrictions: Restrictions,
   profile: EligibilityProfile | null,
-  formatType: string,
+  rating: RatingContext,
   startDate: Date,
 ): NextResponse | null {
   if (restrictions.gender != null && profile?.gender !== restrictions.gender) {
@@ -139,19 +147,13 @@ export function checkRestrictions(
   }
 
   if (restrictions.min_rating != null || restrictions.max_rating != null) {
-    const ratingKey =
-      formatType === "blitz"
-        ? "blitz"
-        : formatType === "rapid"
-          ? "rapid"
-          : "standard";
-    const playerRating =
-      profile?.fide_rating?.[ratingKey] ?? profile?.national_rating ?? null;
+    const ratingResult = checkRatingEligibility(
+      resolvePlayerRating(profile, rating),
+      restrictions.min_rating ?? null,
+      restrictions.max_rating ?? null,
+    );
 
-    if (
-      restrictions.min_rating != null &&
-      (playerRating == null || playerRating < restrictions.min_rating)
-    ) {
+    if (ratingResult === "below_min") {
       return NextResponse.json(
         {
           error: {
@@ -163,11 +165,7 @@ export function checkRestrictions(
       );
     }
 
-    if (
-      restrictions.max_rating != null &&
-      playerRating != null &&
-      playerRating > restrictions.max_rating
-    ) {
+    if (ratingResult === "above_max") {
       return NextResponse.json(
         {
           error: {
@@ -229,10 +227,17 @@ export function checkRestrictions(
   return null;
 }
 
+/**
+ * Whether the player may claim `tier`'s price. `rating` names the list a
+ * rating-based tier is judged against — the tournament's format plus which
+ * federation rates it (see resolvePlayerRating), the same way checkRestrictions
+ * does.
+ */
 export function checkFeeTierEligibility(
   tier: FeeTier,
   profile: EligibilityProfile | null,
   startDate: Date,
+  rating: RatingContext,
 ): NextResponse | null {
   if (tier.gender === "female" && profile?.gender !== "female") {
     return NextResponse.json(
@@ -271,6 +276,45 @@ export function checkFeeTierEligibility(
       },
       { status: 400 },
     );
+  }
+
+  if (tier.rating_min != null || tier.rating_max != null) {
+    const playerRating = resolvePlayerRating(profile, rating);
+    const ratingResult = checkRatingEligibility(
+      playerRating,
+      tier.rating_min ?? null,
+      tier.rating_max ?? null,
+    );
+
+    // A rating isn't self-serviceable (FIDE ratings are synced, national ones
+    // come from the federation), so a missing one is a hard block for a tier
+    // with a floor rather than a fixable VALIDATION_ERROR.
+    if (ratingResult === "below_min") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "INVALID_FEE_TIER",
+            message:
+              playerRating == null
+                ? `This fee tier requires a rating of at least ${tier.rating_min}, and your profile has no ${describeRatingList(rating)} rating`
+                : `This fee tier requires a minimum rating of ${tier.rating_min}`,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    if (ratingResult === "above_max") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "INVALID_FEE_TIER",
+            message: `Your rating exceeds this fee tier's maximum (${tier.rating_max})`,
+          },
+        },
+        { status: 400 },
+      );
+    }
   }
 
   if (tier.age_min != null || tier.age_max != null) {

--- a/src/app/my/organizations/[orgId]/tournaments/[id]/edit/page.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/[id]/edit/page.tsx
@@ -4,35 +4,19 @@ import type { Metadata } from "next";
 import NavBar from "@/components/NavBar";
 import { getAuthClaims } from "@/services/supabase/permission";
 import { TournamentWizardProvider } from "@/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext";
-import type { PersistedState } from "@/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext";
+import type {
+  PersistedRestriction,
+  PersistedState,
+  StoredEntryFees,
+} from "@/app/my/organizations/[orgId]/tournaments/create/types";
 import WizardShell from "@/app/my/organizations/[orgId]/tournaments/create/_components/WizardShell";
-import {
-  fromPersistedRestrictions,
-  type PersistedRestriction,
-} from "@/app/my/organizations/[orgId]/tournaments/create/_components/restrictions";
+import { fromPersistedRestrictions } from "@/app/my/organizations/[orgId]/tournaments/create/_components/restrictions";
+import { fromPersistedEntryFees } from "@/app/my/organizations/[orgId]/tournaments/create/_components/entryFees";
 
 export const metadata: Metadata = {
   title: "Edit Tournament",
   description: "Edit your tournament details.",
 };
-
-type ApiTierType =
-  | "early_bird"
-  | "titled_players"
-  | "rating_based"
-  | "age_based"
-  | "standard";
-
-interface AdditionalTier {
-  type: ApiTierType;
-  amount_cents: number;
-  valid_until?: string;
-  titles?: string[];
-  rating_from?: number;
-  rating_to?: number;
-  age_from?: number;
-  age_to?: number;
-}
 
 interface TournamentForEdit {
   id: string;
@@ -52,10 +36,7 @@ interface TournamentForEdit {
   is_fide_rated: boolean;
   is_mcf_rated: boolean;
   max_participants: number;
-  entry_fees: {
-    standard: { amount_cents: number };
-    additional?: AdditionalTier[];
-  } | null;
+  entry_fees: StoredEntryFees | null;
   prizes: {
     categories?: Array<{
       name: string;
@@ -92,23 +73,6 @@ function toLocalDatetimeString(isoString: string): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-function mapApiTierType(
-  type: ApiTierType,
-): "early-bird" | "titled" | "rating-based" | "age-based" {
-  switch (type) {
-    case "early_bird":
-      return "early-bird";
-    case "titled_players":
-      return "titled";
-    case "rating_based":
-      return "rating-based";
-    case "age_based":
-      return "age-based";
-    default:
-      return "early-bird";
-  }
-}
-
 function buildInitialData(t: TournamentForEdit): PersistedState {
   const basicInfoData = {
     name: t.name,
@@ -140,26 +104,7 @@ function buildInitialData(t: TournamentForEdit): PersistedState {
     restrictions,
   };
 
-  const additionalTiers = (t.entry_fees?.additional ?? [])
-    .filter((tier) => tier.type !== "standard")
-    .map((tier, idx) => ({
-      id: `tier-${idx}`,
-      type: mapApiTierType(tier.type),
-      amount: tier.amount_cents / 100,
-      validUntil: tier.valid_until ?? "",
-      titles: tier.titles ?? [],
-      ratingFrom: tier.rating_from ?? ("" as const),
-      ratingTo: tier.rating_to ?? ("" as const),
-      ageFrom: tier.age_from ?? ("" as const),
-      ageTo: tier.age_to ?? ("" as const),
-    }));
-
-  const feesData = {
-    standardFee: t.entry_fees?.standard
-      ? t.entry_fees.standard.amount_cents / 100
-      : ("" as const),
-    tiers: additionalTiers,
-  };
+  const feesData = fromPersistedEntryFees(t.entry_fees);
 
   const prizeCategories = (t.prizes?.categories ?? []).map((cat, ci) => ({
     id: `cat-${ci}`,

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/TournamentWizardContext.tsx
@@ -8,13 +8,14 @@ import {
   useRef,
   useState,
 } from "react";
-
-type WizardStepId = "basic-info" | "format" | "fees" | "prizes" | "review";
-
-export interface WizardStep {
-  id: WizardStepId;
-  label: string;
-}
+import type {
+  BasicInfoData,
+  FeesData,
+  FormatData,
+  PersistedState,
+  PrizesData,
+  WizardStep,
+} from "../types";
 
 export const WIZARD_STEPS: WizardStep[] = [
   { id: "basic-info", label: "Basic Info" },
@@ -24,14 +25,6 @@ export const WIZARD_STEPS: WizardStep[] = [
   { id: "review", label: "Review" },
 ];
 
-export interface BasicInfoData {
-  name: string;
-  description: string;
-  venueName: string;
-  venueState: string;
-  venueAddress: string;
-}
-
 const initialBasicInfo: BasicInfoData = {
   name: "",
   description: "",
@@ -40,79 +33,15 @@ const initialBasicInfo: BasicInfoData = {
   venueAddress: "",
 };
 
-export interface Restriction {
-  id: string;
-  type: string;
-  value: string;
-}
-
-export type TierType = "early-bird" | "titled" | "rating-based" | "age-based";
-
-export interface FeeTier {
-  id: string;
-  type: TierType;
-  amount: number | "";
-  validUntil: string;
-  titles: string[];
-  ratingFrom: number | "";
-  ratingTo: number | "";
-  ageFrom: number | "";
-  ageTo: number | "";
-}
-
-export interface FeesData {
-  standardFee: number | "";
-  tiers: FeeTier[];
-}
-
 const initialFeesData: FeesData = {
   standardFee: "",
   tiers: [],
 };
 
-export interface PrizeRow {
-  id: string;
-  placement: string;
-  amount: number | "";
-}
-
-export interface PrizeCategory {
-  id: string;
-  name: string;
-  prizes: PrizeRow[];
-}
-
-export interface SpecialPrize {
-  id: string;
-  name: string;
-  amount: number | "";
-}
-
-export interface PrizesData {
-  categories: PrizeCategory[];
-  specialPrizes: SpecialPrize[];
-}
-
 const initialPrizesData: PrizesData = {
   categories: [],
   specialPrizes: [],
 };
-
-export interface FormatData {
-  formatType: string;
-  system: string;
-  rounds: number | "";
-  baseTime: number | "";
-  increment: number | "";
-  delay: number | "";
-  startDate: string;
-  endDate: string;
-  registrationDeadline: string;
-  maxParticipants: number | "";
-  fideRated: boolean;
-  mcfRated: boolean;
-  restrictions: Restriction[];
-}
 
 const initialFormatData: FormatData = {
   formatType: "",
@@ -129,16 +58,6 @@ const initialFormatData: FormatData = {
   mcfRated: false,
   restrictions: [],
 };
-
-export interface PersistedState {
-  basicInfoData: BasicInfoData;
-  formatData: FormatData;
-  feesData: FeesData;
-  prizesData: PrizesData;
-  tournamentId: string | null;
-  currentStepIndex: number;
-  completedSteps: number[];
-}
 
 function storageKey(orgId: string, suffix?: string) {
   return `tournament-wizard-${orgId}${suffix ? `-${suffix}` : ""}`;

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/WizardShell.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/WizardShell.tsx
@@ -2,13 +2,10 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import {
-  WIZARD_STEPS,
-  useTournamentWizard,
-  type FeeTier,
-} from "./TournamentWizardContext";
+import { WIZARD_STEPS, useTournamentWizard } from "./TournamentWizardContext";
 import WizardProgressBar from "./WizardProgressBar";
 import { toPersistedRestrictions } from "./restrictions";
+import { toPersistedEntryFees } from "./entryFees";
 import BasicInfoStep from "./steps/BasicInfoStep";
 import FormatStep from "./steps/FormatStep";
 import FeesStep from "./steps/FeesStep";
@@ -29,19 +26,6 @@ interface WizardShellProps {
   title?: string;
   redirectPath?: string;
   mode?: "create" | "edit";
-}
-
-function mapTierType(t: FeeTier["type"]): string {
-  switch (t) {
-    case "early-bird":
-      return "early_bird";
-    case "titled":
-      return "titled_players";
-    case "rating-based":
-      return "rating_based";
-    case "age-based":
-      return "age_based";
-  }
 }
 
 export default function WizardShell({
@@ -74,33 +58,7 @@ export default function WizardShell({
   const StepContent = STEP_COMPONENTS[currentStepIndex];
 
   function buildDraftBody(): Record<string, unknown> {
-    const entryFees = {
-      standard: {
-        amount_cents:
-          feesData.standardFee === ""
-            ? 0
-            : Math.round(Number(feesData.standardFee) * 100),
-      },
-      additional: feesData.tiers.map((tier) => {
-        const base: Record<string, unknown> = {
-          type: mapTierType(tier.type),
-          amount_cents:
-            tier.amount === "" ? 0 : Math.round(Number(tier.amount) * 100),
-        };
-        if (tier.type === "early-bird" && tier.validUntil) {
-          base.valid_until = tier.validUntil;
-        } else if (tier.type === "titled" && tier.titles.length > 0) {
-          base.titles = tier.titles;
-        } else if (tier.type === "rating-based") {
-          if (tier.ratingFrom !== "") base.rating_from = tier.ratingFrom;
-          if (tier.ratingTo !== "") base.rating_to = tier.ratingTo;
-        } else if (tier.type === "age-based") {
-          if (tier.ageFrom !== "") base.age_from = tier.ageFrom;
-          if (tier.ageTo !== "") base.age_to = tier.ageTo;
-        }
-        return base;
-      }),
-    };
+    const entryFees = toPersistedEntryFees(feesData);
 
     const prizes =
       prizesData.categories.length > 0 || prizesData.specialPrizes.length > 0

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/__tests__/entryFees.test.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/__tests__/entryFees.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import {
+  fromPersistedEntryFees,
+  fromValidUntilTimestamp,
+  toPersistedEntryFees,
+  toValidUntilTimestamp,
+} from "../entryFees";
+import type { FeeTier, FeesData, StoredEntryFees } from "../../types";
+
+function tier(overrides: Partial<FeeTier> & Pick<FeeTier, "type">): FeeTier {
+  return {
+    amount: "",
+    validUntil: "",
+    titles: [],
+    ratingFrom: "",
+    ratingTo: "",
+    ageFrom: "",
+    ageTo: "",
+    ...overrides,
+  };
+}
+
+describe("toPersistedEntryFees", () => {
+  it("writes the canonical key names every consumer reads", () => {
+    const persisted = toPersistedEntryFees({
+      standardFee: 50,
+      tiers: [
+        tier({ type: "early_bird", amount: 40, validUntil: "2026-02-19" }),
+        tier({ type: "titled_players", amount: 0, titles: ["GM", "IM"] }),
+        tier({
+          type: "rating_based",
+          amount: 35,
+          ratingFrom: 0,
+          ratingTo: 1800,
+        }),
+        tier({ type: "age_based", amount: 30, ageFrom: 0, ageTo: 12 }),
+      ],
+    });
+
+    expect(persisted).toEqual({
+      standard: { amount_cents: 5000 },
+      additional: [
+        {
+          type: "early_bird",
+          amount_cents: 4000,
+          valid_until: "2026-02-19T23:59:59+08:00",
+        },
+        { type: "titled_players", amount_cents: 0, titles: ["GM", "IM"] },
+        {
+          type: "rating_based",
+          amount_cents: 3500,
+          rating_min: 0,
+          rating_max: 1800,
+        },
+        { type: "age_based", amount_cents: 3000, age_min: 0, age_max: 12 },
+      ],
+    });
+  });
+
+  it("omits criteria that were left blank", () => {
+    const persisted = toPersistedEntryFees({
+      standardFee: "",
+      tiers: [
+        tier({ type: "early_bird", amount: "" }),
+        tier({ type: "age_based", amount: 20, ageFrom: 8, ageTo: "" }),
+      ],
+    });
+
+    expect(persisted).toEqual({
+      standard: { amount_cents: 0 },
+      additional: [
+        { type: "early_bird", amount_cents: 0 },
+        { type: "age_based", amount_cents: 2000, age_min: 8 },
+      ],
+    });
+  });
+});
+
+describe("fromPersistedEntryFees", () => {
+  it("restores the criteria of a canonically stored tournament (#478)", () => {
+    // The shape written by db/migrations/006_seed.sql: `age_min`/`age_max` and
+    // a full timestamp for `valid_until`.
+    const stored: StoredEntryFees = {
+      standard: { amount_cents: 5000 },
+      additional: [
+        {
+          type: "early_bird",
+          amount_cents: 4000,
+          valid_until: "2026-02-19T23:59:59+08:00",
+        },
+        { type: "age_based", amount_cents: 3000, age_min: 0, age_max: 12 },
+      ],
+    };
+
+    expect(fromPersistedEntryFees(stored)).toEqual({
+      standardFee: 50,
+      tiers: [
+        {
+          type: "early_bird",
+          amount: 40,
+          validUntil: "2026-02-19",
+          titles: [],
+          ratingFrom: "",
+          ratingTo: "",
+          ageFrom: "",
+          ageTo: "",
+        },
+        {
+          type: "age_based",
+          amount: 30,
+          validUntil: "",
+          titles: [],
+          ratingFrom: "",
+          ratingTo: "",
+          ageFrom: 0,
+          ageTo: 12,
+        },
+      ],
+    });
+  });
+
+  it("skips tiers the wizard cannot edit instead of coercing them", () => {
+    const fees = fromPersistedEntryFees({
+      standard: { amount_cents: 5000 },
+      additional: [
+        { type: "standard", amount_cents: 5000 },
+        { type: "gender", amount_cents: 2500 },
+        { type: "age_based", amount_cents: 3000, age_min: 0, age_max: 12 },
+      ],
+    });
+
+    expect(fees.tiers.map((t) => t.type)).toEqual(["age_based"]);
+  });
+
+  it("falls back to an empty form for a tournament with no fees", () => {
+    expect(fromPersistedEntryFees(null)).toEqual({
+      standardFee: "",
+      tiers: [],
+    });
+  });
+});
+
+describe("entry fee round trip", () => {
+  it("survives save → resume unchanged", () => {
+    const original: FeesData = {
+      standardFee: 50,
+      tiers: [
+        tier({ type: "early_bird", amount: 40, validUntil: "2026-02-19" }),
+        tier({ type: "titled_players", amount: 0, titles: ["GM"] }),
+        tier({
+          type: "rating_based",
+          amount: 35,
+          ratingFrom: 1200,
+          ratingTo: 1800,
+        }),
+        tier({ type: "age_based", amount: 30, ageFrom: 0, ageTo: 12 }),
+      ],
+    };
+
+    expect(fromPersistedEntryFees(toPersistedEntryFees(original))).toEqual(
+      original,
+    );
+  });
+});
+
+describe("valid_until", () => {
+  it("anchors the picked date to the end of that day in the venue timezone", () => {
+    // The tier must stay usable for the whole of the 19th — storing the bare
+    // date would expire it at 08:00 local.
+    const stamp = toValidUntilTimestamp("2026-02-19");
+    expect(stamp).toBe("2026-02-19T23:59:59+08:00");
+    expect(new Date(stamp).toISOString()).toBe("2026-02-19T15:59:59.000Z");
+  });
+
+  it("reduces a stored timestamp to its venue-local calendar date", () => {
+    expect(fromValidUntilTimestamp("2026-02-19T23:59:59+08:00")).toBe(
+      "2026-02-19",
+    );
+    // Late UTC on the 19th is already the 20th in KL.
+    expect(fromValidUntilTimestamp("2026-02-19T20:00:00Z")).toBe("2026-02-20");
+  });
+
+  it("returns an empty string for missing or unparseable values", () => {
+    expect(fromValidUntilTimestamp(null)).toBe("");
+    expect(fromValidUntilTimestamp("")).toBe("");
+    expect(fromValidUntilTimestamp("not a date")).toBe("");
+  });
+});

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/__tests__/restrictions.test.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/__tests__/restrictions.test.ts
@@ -3,20 +3,21 @@ import {
   toPersistedRestrictions,
   fromPersistedRestrictions,
 } from "../restrictions";
+import type { Restriction } from "../../types";
 import { normalizeRestrictions } from "@/app/api/v1/tournaments/[slug]/registrations/validators";
 
-const stripIds = (rows: Array<{ type: string; value: string }>) =>
-  rows.map(({ type, value }) => ({ type, value }));
+const stripIds = (rows: Restriction[]) =>
+  rows.map(({ kind, value }) => ({ kind, value }));
 
 describe("toPersistedRestrictions", () => {
-  it("maps each wizard label to its normalized shape", () => {
+  it("maps each row kind to its normalized shape", () => {
     expect(
       toPersistedRestrictions([
-        { type: "Max Age", value: "18" },
-        { type: "Min Rating", value: "1000" },
-        { type: "Max Rating", value: "2000" },
-        { type: "Gender", value: "Female" },
-        { type: "Nationality", value: "Malaysia" },
+        { kind: "max_age", value: "18" },
+        { kind: "min_rating", value: "1000" },
+        { kind: "max_rating", value: "2000" },
+        { kind: "gender", value: "Female" },
+        { kind: "nationality", value: "Malaysia" },
       ]),
     ).toEqual([
       { type: "age", max: 18 },
@@ -28,7 +29,7 @@ describe("toPersistedRestrictions", () => {
   });
 
   it("stores a null number for a blank numeric value", () => {
-    expect(toPersistedRestrictions([{ type: "Max Age", value: "" }])).toEqual([
+    expect(toPersistedRestrictions([{ kind: "max_age", value: "" }])).toEqual([
       { type: "age", max: null },
     ]);
   });
@@ -47,22 +48,41 @@ describe("fromPersistedRestrictions", () => {
         ]),
       ),
     ).toEqual([
-      { type: "Max Age", value: "18" },
-      { type: "Min Rating", value: "1000" },
-      { type: "Max Rating", value: "2000" },
-      { type: "Gender", value: "female" },
-      { type: "Nationality", value: "Malaysia" },
+      { kind: "max_age", value: "18" },
+      { kind: "min_rating", value: "1000" },
+      { kind: "max_rating", value: "2000" },
+      { kind: "gender", value: "female" },
+      { kind: "nationality", value: "Malaysia" },
     ]);
+  });
+
+  it("splits a stored item carrying both rating bounds into two rows", () => {
+    expect(
+      stripIds(
+        fromPersistedRestrictions([{ type: "rating", min: 1000, max: 2000 }]),
+      ),
+    ).toEqual([
+      { kind: "min_rating", value: "1000" },
+      { kind: "max_rating", value: "2000" },
+    ]);
+  });
+
+  it("gives every row a distinct key", () => {
+    const rows = fromPersistedRestrictions([
+      { type: "rating", min: 1000, max: 2000 },
+      { type: "age", max: 18 },
+    ]);
+    expect(new Set(rows.map((r) => r.id)).size).toBe(rows.length);
   });
 });
 
 describe("round-trip", () => {
   it("preserves rows through persist → hydrate", () => {
     const rows = [
-      { type: "Max Age", value: "18" },
-      { type: "Min Rating", value: "1000" },
-      { type: "Nationality", value: "Malaysia" },
-      { type: "Gender", value: "female" },
+      { kind: "max_age" as const, value: "18" },
+      { kind: "min_rating" as const, value: "1000" },
+      { kind: "nationality" as const, value: "Malaysia" },
+      { kind: "gender" as const, value: "female" },
     ];
     const roundTripped = stripIds(
       fromPersistedRestrictions(toPersistedRestrictions(rows)),
@@ -76,8 +96,8 @@ describe("enforcement integration", () => {
     // The bug this fixes: wizard restrictions were stored as unrecognized UI
     // labels. The mapped output must normalize to enforceable fields.
     const persisted = toPersistedRestrictions([
-      { type: "Nationality", value: "Malaysia" },
-      { type: "Max Age", value: "18" },
+      { kind: "nationality", value: "Malaysia" },
+      { kind: "max_age", value: "18" },
     ]);
     expect(normalizeRestrictions(persisted)).toEqual({
       nationality: "Malaysia",

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/entryFees.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/entryFees.ts
@@ -1,0 +1,183 @@
+// Bidirectional mapping between the wizard's fee-tier rows and the canonical
+// `tournaments.entry_fees` JSON.
+//
+// The canonical shape is the one every consumer already reads — the schema
+// comment in db/migrations/001_tables.sql, the seed, EntryFees in
+// src/app/tournaments/types.ts, the public detail page, RegisterForm, checkout
+// and the registration eligibility validators: bounds are `age_min`/`age_max`
+// and `valid_until` is a full timestamp.
+//
+// The wizard used to write its own dialect (`age_from`/`age_to`,
+// `rating_from`/`rating_to`, a date-only `valid_until`), which meant resuming a
+// draft it had not written itself showed empty criteria (#478) — and, worse,
+// that wizard-written age bounds were invisible to the tier eligibility check
+// at registration time. Going through this module is what keeps the two
+// directions from drifting apart again.
+
+import { PLATFORM_TIME_ZONE } from "@/app/tournaments/utils";
+import type {
+  FeesData,
+  FeeTier,
+  PersistedEntryFees,
+  PersistedFeeTier,
+  StoredEntryFees,
+  TierType,
+} from "../types";
+
+/** The tiers the wizard can edit, in the order its "Add Fee Tier" menu lists them. */
+export const TIER_TYPES: TierType[] = [
+  "early_bird",
+  "titled_players",
+  "rating_based",
+  "age_based",
+];
+
+export const TIER_LABELS: Record<TierType, string> = {
+  early_bird: "Early Bird",
+  titled_players: "Titled Players",
+  rating_based: "Rating-Based",
+  age_based: "Age-Based",
+};
+
+const EDITABLE_TIER_TYPES = new Set<string>(TIER_TYPES);
+
+function toCents(amount: number | ""): number {
+  return amount === "" ? 0 : Math.round(Number(amount) * 100);
+}
+
+function fromCents(cents: number | null | undefined): number | "" {
+  return typeof cents === "number" && Number.isFinite(cents) ? cents / 100 : "";
+}
+
+function boundOrUndefined(value: number | ""): number | undefined {
+  return value === "" ? undefined : Number(value);
+}
+
+function boundOrEmpty(value: number | null | undefined): number | "" {
+  return typeof value === "number" && Number.isFinite(value) ? value : "";
+}
+
+// The UTC offset ("+08:00") of `timeZone` on `date`, so a calendar date picked
+// in the wizard can be anchored to the venue's day rather than the server's.
+function utcOffset(timeZone: string, date: Date): string {
+  const name =
+    new Intl.DateTimeFormat("en-US", { timeZone, timeZoneName: "longOffset" })
+      .formatToParts(date)
+      .find((p) => p.type === "timeZoneName")?.value ?? "";
+  const match = /GMT([+-])(\d{1,2})(?::(\d{2}))?/.exec(name);
+  if (!match) return "+00:00";
+  const [, sign, hours, minutes = "00"] = match;
+  return `${sign}${hours.padStart(2, "0")}:${minutes}`;
+}
+
+/**
+ * A wizard date ("2026-02-19") → the instant that day ends in the venue's
+ * timezone ("2026-02-19T23:59:59+08:00").
+ *
+ * Consumers treat `valid_until` as an instant (`new Date(valid_until) < now`),
+ * so storing the bare date would expire the tier at 08:00 local on the very day
+ * the UI promises is still included ("register on or before this date").
+ */
+export function toValidUntilTimestamp(
+  date: string,
+  timeZone: string = PLATFORM_TIME_ZONE,
+): string {
+  // Midday UTC is inside `date` in every real timezone, so the offset looked up
+  // for it is the offset that applies to that calendar day.
+  const offset = utcOffset(timeZone, new Date(`${date}T12:00:00Z`));
+  return `${date}T23:59:59${offset}`;
+}
+
+/**
+ * A stored `valid_until` → the "YYYY-MM-DD" an `<input type="date">` can show,
+ * reduced to its calendar date in the venue's timezone. Nothing constrains the
+ * column, so an unparseable value yields "" rather than a broken input.
+ */
+export function fromValidUntilTimestamp(
+  value: string | null | undefined,
+  timeZone: string = PLATFORM_TIME_ZONE,
+): string {
+  if (!value) return "";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(parsed);
+}
+
+/** Wizard fee state → canonical entry_fees for persistence. */
+export function toPersistedEntryFees(data: FeesData): PersistedEntryFees {
+  return {
+    standard: { amount_cents: toCents(data.standardFee) },
+    additional: data.tiers.map((tier) => {
+      const persisted: PersistedFeeTier = {
+        type: tier.type,
+        amount_cents: toCents(tier.amount),
+      };
+
+      switch (tier.type) {
+        case "early_bird":
+          if (tier.validUntil) {
+            persisted.valid_until = toValidUntilTimestamp(tier.validUntil);
+          }
+          break;
+        case "titled_players":
+          if (tier.titles.length > 0) persisted.titles = tier.titles;
+          break;
+        case "rating_based": {
+          const min = boundOrUndefined(tier.ratingFrom);
+          const max = boundOrUndefined(tier.ratingTo);
+          if (min !== undefined) persisted.rating_min = min;
+          if (max !== undefined) persisted.rating_max = max;
+          break;
+        }
+        case "age_based": {
+          const min = boundOrUndefined(tier.ageFrom);
+          const max = boundOrUndefined(tier.ageTo);
+          if (min !== undefined) persisted.age_min = min;
+          if (max !== undefined) persisted.age_max = max;
+          break;
+        }
+      }
+
+      return persisted;
+    }),
+  };
+}
+
+/**
+ * Canonical entry_fees (from the DB) → wizard fee state for editing.
+ *
+ * Tiers the wizard has no editor for (the canonical gender/oku tiers, or the
+ * implicit "standard" entry some rows carry) are skipped rather than coerced
+ * into an early-bird row — an unrecognised tier is not editable here and must
+ * not be silently rewritten as a different one.
+ */
+export function fromPersistedEntryFees(
+  fees: StoredEntryFees | null | undefined,
+): FeesData {
+  const tiers: FeeTier[] = [];
+
+  for (const stored of fees?.additional ?? []) {
+    if (!EDITABLE_TIER_TYPES.has(stored.type)) continue;
+
+    tiers.push({
+      type: stored.type as TierType,
+      amount: fromCents(stored.amount_cents),
+      validUntil: fromValidUntilTimestamp(stored.valid_until),
+      titles: stored.titles ?? [],
+      ratingFrom: boundOrEmpty(stored.rating_min),
+      ratingTo: boundOrEmpty(stored.rating_max),
+      ageFrom: boundOrEmpty(stored.age_min),
+      ageTo: boundOrEmpty(stored.age_max),
+    });
+  }
+
+  return {
+    standardFee: fromCents(fees?.standard?.amount_cents),
+    tiers,
+  };
+}

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/restrictions.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/restrictions.ts
@@ -1,12 +1,35 @@
-// Bidirectional mapping between the wizard's per-row restriction UI (a label +
-// free-text value, e.g. { type: "Max Age", value: "18" }) and the normalized
-// shape that is stored in the DB and consumed by normalizeRestrictions /
-// checkRestrictions at registration time (e.g. { type: "age", max: 18 }).
+// Bidirectional mapping between the wizard's per-row restriction UI and the
+// normalized shape stored in the DB and consumed by normalizeRestrictions /
+// checkRestrictions at registration time.
 //
 // Persisting the normalized shape is what makes wizard-created restrictions
-// actually enforce — the UI labels are never stored.
+// actually enforce. The two shapes still differ in one way: a row constrains
+// exactly one end of one dimension ("max_rating"), while a stored item may
+// carry both ends ({ type: "rating", min, max }), so reading expands and
+// writing does not merge.
 
-import type { PersistedRestriction, Restriction } from "../types";
+import type {
+  PersistedRestriction,
+  Restriction,
+  RestrictionKind,
+} from "../types";
+
+/** The restriction kinds on offer, in the order the row's picker lists them. */
+export const RESTRICTION_KINDS: RestrictionKind[] = [
+  "max_age",
+  "max_rating",
+  "min_rating",
+  "gender",
+  "nationality",
+];
+
+export const RESTRICTION_LABELS: Record<RestrictionKind, string> = {
+  max_age: "Max Age",
+  max_rating: "Max Rating",
+  min_rating: "Min Rating",
+  gender: "Gender",
+  nationality: "Nationality",
+};
 
 function toNumberOrNull(value: string): number | null {
   if (value.trim() === "") return null;
@@ -16,24 +39,22 @@ function toNumberOrNull(value: string): number | null {
 
 /** Wizard rows → normalized restrictions for persistence. */
 export function toPersistedRestrictions(
-  rows: ReadonlyArray<Pick<Restriction, "type" | "value">>,
+  rows: ReadonlyArray<Pick<Restriction, "kind" | "value">>,
 ): PersistedRestriction[] {
   return rows.map((r) => {
     const value = r.value.trim();
-    switch (r.type) {
-      case "Max Age":
+    switch (r.kind) {
+      case "max_age":
         return { type: "age", max: toNumberOrNull(value) };
-      case "Min Rating":
+      case "min_rating":
         return { type: "rating", min: toNumberOrNull(value) };
-      case "Max Rating":
+      case "max_rating":
         return { type: "rating", max: toNumberOrNull(value) };
-      case "Gender":
+      case "gender":
         // checkRestrictions compares against the lowercase profile gender.
         return { type: "gender", value: value.toLowerCase() };
-      case "Nationality":
+      case "nationality":
         return { type: "nationality", value };
-      default:
-        throw new Error(`Unknown restriction type: ${r.type}`);
     }
   });
 }
@@ -44,26 +65,26 @@ export function fromPersistedRestrictions(
 ): Restriction[] {
   const rows: Restriction[] = [];
   let idx = 0;
-  const push = (type: string, value: string) =>
-    rows.push({ id: `r-${idx++}`, type, value });
+  const push = (kind: RestrictionKind, value: string) =>
+    rows.push({ id: `r-${idx++}`, kind, value });
 
   for (const item of items) {
     switch (item.type) {
       case "age":
-        push("Max Age", item.max != null ? String(item.max) : "");
+        push("max_age", item.max != null ? String(item.max) : "");
         break;
       case "rating":
         // A rating row carries either a min or a max; a combined item expands to
         // both wizard rows.
-        if (item.min != null) push("Min Rating", String(item.min));
-        if (item.max != null) push("Max Rating", String(item.max));
-        if (item.min == null && item.max == null) push("Max Rating", "");
+        if (item.min != null) push("min_rating", String(item.min));
+        if (item.max != null) push("max_rating", String(item.max));
+        if (item.min == null && item.max == null) push("max_rating", "");
         break;
       case "gender":
-        push("Gender", item.value ?? "");
+        push("gender", item.value ?? "");
         break;
       case "nationality":
-        push("Nationality", item.value ?? "");
+        push("nationality", item.value ?? "");
         break;
     }
   }

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/restrictions.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/restrictions.ts
@@ -6,17 +6,7 @@
 // Persisting the normalized shape is what makes wizard-created restrictions
 // actually enforce — the UI labels are never stored.
 
-export type PersistedRestriction =
-  | { type: "age"; min?: number | null; max?: number | null }
-  | { type: "rating"; min?: number | null; max?: number | null }
-  | { type: "gender"; value: string }
-  | { type: "nationality"; value: string };
-
-interface RestrictionRow {
-  id: string;
-  type: string;
-  value: string;
-}
+import type { PersistedRestriction, Restriction } from "../types";
 
 function toNumberOrNull(value: string): number | null {
   if (value.trim() === "") return null;
@@ -26,7 +16,7 @@ function toNumberOrNull(value: string): number | null {
 
 /** Wizard rows → normalized restrictions for persistence. */
 export function toPersistedRestrictions(
-  rows: ReadonlyArray<{ type: string; value: string }>,
+  rows: ReadonlyArray<Pick<Restriction, "type" | "value">>,
 ): PersistedRestriction[] {
   return rows.map((r) => {
     const value = r.value.trim();
@@ -51,8 +41,8 @@ export function toPersistedRestrictions(
 /** Normalized restrictions (from the DB) → wizard rows for editing. */
 export function fromPersistedRestrictions(
   items: ReadonlyArray<PersistedRestriction>,
-): RestrictionRow[] {
-  const rows: RestrictionRow[] = [];
+): Restriction[] {
+  const rows: Restriction[] = [];
   let idx = 0;
   const push = (type: string, value: string) =>
     rows.push({ id: `r-${idx++}`, type, value });

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/BasicInfoStep.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { BasicInfoData } from "../TournamentWizardContext";
+import type { BasicInfoData } from "../../types";
 import { useTournamentWizard } from "../TournamentWizardContext";
 
 const MALAYSIAN_STATES = [

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FeesStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FeesStep.tsx
@@ -1,27 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { FeesData, FeeTier, TierType } from "../TournamentWizardContext";
+import type { FeesData, FeeTier, TierType } from "../../types";
 import { useTournamentWizard } from "../TournamentWizardContext";
-import { newRowId } from "../rowId";
+import { TIER_LABELS, TIER_TYPES } from "../entryFees";
 
 const COMMISSION = 0.1;
 
 const CHESS_TITLES = ["GM", "IM", "FM", "WGM", "WIM", "WFM", "CM", "WCM", "NM"];
-
-const TIER_TYPES: TierType[] = [
-  "early-bird",
-  "titled",
-  "rating-based",
-  "age-based",
-];
-
-const TIER_LABELS: Record<TierType, string> = {
-  "early-bird": "Early Bird",
-  titled: "Titled Players",
-  "rating-based": "Rating-Based",
-  "age-based": "Age-Based",
-};
 
 type TierErrors = Partial<{
   amount: string;
@@ -33,9 +19,10 @@ type TierErrors = Partial<{
   ageTo: string;
 }>;
 
+// Keyed by tier type — a tournament can hold at most one tier of each.
 type FeesErrors = {
   standardFee?: string;
-  tiers: Record<string, TierErrors>;
+  tiers: Partial<Record<TierType, TierErrors>>;
 };
 
 const NO_ERRORS: FeesErrors = { tiers: {} };
@@ -66,11 +53,11 @@ function validate(data: FeesData): FeesErrors {
       te.amount = "Fee cannot be negative.";
     }
 
-    if (tier.type === "early-bird") {
+    if (tier.type === "early_bird") {
       if (!tier.validUntil) te.validUntil = "Valid-until date is required.";
-    } else if (tier.type === "titled") {
+    } else if (tier.type === "titled_players") {
       if (tier.titles.length === 0) te.titles = "Select at least one title.";
-    } else if (tier.type === "rating-based") {
+    } else if (tier.type === "rating_based") {
       if (tier.ratingFrom === "") {
         te.ratingFrom = "Rating from is required.";
       } else if (Number(tier.ratingFrom) < 0) {
@@ -85,7 +72,7 @@ function validate(data: FeesData): FeesErrors {
       ) {
         te.ratingTo = "Must be ≥ rating from.";
       }
-    } else if (tier.type === "age-based") {
+    } else if (tier.type === "age_based") {
       if (tier.ageFrom === "") {
         te.ageFrom = "Age from is required.";
       } else if (Number(tier.ageFrom) < 0) {
@@ -103,7 +90,7 @@ function validate(data: FeesData): FeesErrors {
     }
 
     if (Object.keys(te).length > 0) {
-      errors.tiers[tier.id] = te;
+      errors.tiers[tier.type] = te;
     }
   }
 
@@ -257,7 +244,6 @@ export default function FeesStep() {
 
   const addTier = (type: TierType) => {
     const newTier: FeeTier = {
-      id: newRowId(),
       type,
       amount: "",
       validUntil: "",
@@ -271,14 +257,14 @@ export default function FeesStep() {
     setDropdownOpen(false);
   };
 
-  const removeTier = (id: string) => {
-    setForm((f) => ({ ...f, tiers: f.tiers.filter((t) => t.id !== id) }));
+  const removeTier = (type: TierType) => {
+    setForm((f) => ({ ...f, tiers: f.tiers.filter((t) => t.type !== type) }));
   };
 
-  const updateTier = (id: string, changes: Partial<FeeTier>) => {
+  const updateTier = (type: TierType, changes: Partial<FeeTier>) => {
     setForm((f) => ({
       ...f,
-      tiers: f.tiers.map((t) => (t.id === id ? { ...t, ...changes } : t)),
+      tiers: f.tiers.map((t) => (t.type === type ? { ...t, ...changes } : t)),
     }));
   };
 
@@ -355,20 +341,20 @@ export default function FeesStep() {
       {form.tiers.length > 0 && (
         <div className="mb-4 flex flex-col gap-3">
           {form.tiers.map((tier) => {
-            const te = errors.tiers[tier.id] ?? {};
+            const te = errors.tiers[tier.type] ?? {};
 
-            if (tier.type === "early-bird") {
+            if (tier.type === "early_bird") {
               return (
                 <TierCard
-                  key={tier.id}
+                  key={tier.type}
                   label={TIER_LABELS[tier.type]}
-                  onRemove={() => removeTier(tier.id)}
+                  onRemove={() => removeTier(tier.type)}
                 >
                   <div className="mb-1.5 flex flex-wrap items-start gap-3">
                     <AmountField
-                      id={`${tier.id}-amount`}
+                      id={`${tier.type}-amount`}
                       value={tier.amount}
-                      onChange={(v) => updateTier(tier.id, { amount: v })}
+                      onChange={(v) => updateTier(tier.type, { amount: v })}
                       error={showErrors ? te.amount : undefined}
                     />
                     <div>
@@ -381,7 +367,9 @@ export default function FeesStep() {
                           className={`input ${showErrors && te.validUntil ? "input-error" : ""}`}
                           value={tier.validUntil}
                           onChange={(e) =>
-                            updateTier(tier.id, { validUntil: e.target.value })
+                            updateTier(tier.type, {
+                              validUntil: e.target.value,
+                            })
                           }
                         />
                       </div>
@@ -399,18 +387,18 @@ export default function FeesStep() {
               );
             }
 
-            if (tier.type === "titled") {
+            if (tier.type === "titled_players") {
               return (
                 <TierCard
-                  key={tier.id}
+                  key={tier.type}
                   label={TIER_LABELS[tier.type]}
-                  onRemove={() => removeTier(tier.id)}
+                  onRemove={() => removeTier(tier.type)}
                 >
                   <div className="mb-3 flex flex-wrap items-start gap-3">
                     <AmountField
-                      id={`${tier.id}-amount`}
+                      id={`${tier.type}-amount`}
                       value={tier.amount}
-                      onChange={(v) => updateTier(tier.id, { amount: v })}
+                      onChange={(v) => updateTier(tier.type, { amount: v })}
                       error={showErrors ? te.amount : undefined}
                     />
                     <div className="min-w-55 flex-1">
@@ -431,7 +419,7 @@ export default function FeesStep() {
                                 const next = e.target.checked
                                   ? [...tier.titles, title]
                                   : tier.titles.filter((t) => t !== title);
-                                updateTier(tier.id, { titles: next });
+                                updateTier(tier.type, { titles: next });
                               }}
                             />
                             <span className="font-cinzel text-text-secondary text-xs font-semibold">
@@ -450,18 +438,18 @@ export default function FeesStep() {
               );
             }
 
-            if (tier.type === "rating-based") {
+            if (tier.type === "rating_based") {
               return (
                 <TierCard
-                  key={tier.id}
+                  key={tier.type}
                   label={TIER_LABELS[tier.type]}
-                  onRemove={() => removeTier(tier.id)}
+                  onRemove={() => removeTier(tier.type)}
                 >
                   <div className="mb-1.5 flex flex-wrap items-start gap-3">
                     <AmountField
-                      id={`${tier.id}-amount`}
+                      id={`${tier.type}-amount`}
                       value={tier.amount}
-                      onChange={(v) => updateTier(tier.id, { amount: v })}
+                      onChange={(v) => updateTier(tier.type, { amount: v })}
                       error={showErrors ? te.amount : undefined}
                     />
                     <div>
@@ -481,7 +469,7 @@ export default function FeesStep() {
                           min={0}
                           onChange={(e) => {
                             const raw = e.target.value;
-                            updateTier(tier.id, {
+                            updateTier(tier.type, {
                               ratingFrom: raw === "" ? "" : Number(raw),
                             });
                           }}
@@ -499,7 +487,7 @@ export default function FeesStep() {
                           min={0}
                           onChange={(e) => {
                             const raw = e.target.value;
-                            updateTier(tier.id, {
+                            updateTier(tier.type, {
                               ratingTo: raw === "" ? "" : Number(raw),
                             });
                           }}
@@ -521,18 +509,18 @@ export default function FeesStep() {
               );
             }
 
-            if (tier.type === "age-based") {
+            if (tier.type === "age_based") {
               return (
                 <TierCard
-                  key={tier.id}
+                  key={tier.type}
                   label={TIER_LABELS[tier.type]}
-                  onRemove={() => removeTier(tier.id)}
+                  onRemove={() => removeTier(tier.type)}
                 >
                   <div className="mb-1.5 flex flex-wrap items-start gap-3">
                     <AmountField
-                      id={`${tier.id}-amount`}
+                      id={`${tier.type}-amount`}
                       value={tier.amount}
-                      onChange={(v) => updateTier(tier.id, { amount: v })}
+                      onChange={(v) => updateTier(tier.type, { amount: v })}
                       error={showErrors ? te.amount : undefined}
                     />
                     <div>
@@ -550,7 +538,7 @@ export default function FeesStep() {
                           min={0}
                           onChange={(e) => {
                             const raw = e.target.value;
-                            updateTier(tier.id, {
+                            updateTier(tier.type, {
                               ageFrom: raw === "" ? "" : Number(raw),
                             });
                           }}
@@ -566,7 +554,7 @@ export default function FeesStep() {
                           min={0}
                           onChange={(e) => {
                             const raw = e.target.value;
-                            updateTier(tier.id, {
+                            updateTier(tier.type, {
                               ageTo: raw === "" ? "" : Number(raw),
                             });
                           }}

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useId, useState } from "react";
-import type { FormatData, Restriction } from "../TournamentWizardContext";
+import type { FormatData, Restriction } from "../../types";
 import { useTournamentWizard } from "../TournamentWizardContext";
 import { newRowId } from "../rowId";
 import { CountryDropdown } from "@/components/ui/country-dropdown";

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/FormatStep.tsx
@@ -1,21 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useId, useState } from "react";
-import type { FormatData, Restriction } from "../../types";
+import type { FormatData, Restriction, RestrictionKind } from "../../types";
 import { useTournamentWizard } from "../TournamentWizardContext";
 import { newRowId } from "../rowId";
+import { RESTRICTION_KINDS, RESTRICTION_LABELS } from "../restrictions";
 import { CountryDropdown } from "@/components/ui/country-dropdown";
 import { nameToAlpha3 } from "@/lib/countries";
 
 const FORMAT_TYPES = ["Rapid", "Blitz", "Classical"];
 const SYSTEMS = ["Swiss", "Round Robin", "Knockout"];
-const RESTRICTION_TYPES = [
-  "Max Age",
-  "Max Rating",
-  "Min Rating",
-  "Gender",
-  "Nationality",
-];
 
 type FieldErrors = Partial<
   Record<
@@ -115,7 +109,7 @@ export default function FormatStep() {
   const addRestriction = () => {
     const newRow: Restriction = {
       id: newRowId(),
-      type: "Max Rating",
+      kind: "max_rating",
       value: "",
     };
     setForm((f) => ({ ...f, restrictions: [...f.restrictions, newRow] }));
@@ -128,27 +122,23 @@ export default function FormatStep() {
     }));
   };
 
-  const updateRestriction = (
-    id: string,
-    key: "type" | "value",
-    val: string,
-  ) => {
+  const updateRestrictionValue = (id: string, value: string) => {
     setForm((f) => ({
       ...f,
       restrictions: f.restrictions.map((r) =>
-        r.id === id ? { ...r, [key]: val } : r,
+        r.id === id ? { ...r, value } : r,
       ),
     }));
   };
 
-  // Changing the type clears the value — a value entered for one type (e.g. a
+  // Changing the kind clears the value — a value entered for one kind (e.g. a
   // rating number) is meaningless for another (e.g. a country), and the
   // Nationality dropdown needs a clean slate rather than stale free text.
-  const changeRestrictionType = (id: string, newType: string) => {
+  const changeRestrictionKind = (id: string, kind: RestrictionKind) => {
     setForm((f) => ({
       ...f,
       restrictions: f.restrictions.map((r) =>
-        r.id === id ? { ...r, type: newType, value: "" } : r,
+        r.id === id ? { ...r, kind, value: "" } : r,
       ),
     }));
   };
@@ -463,24 +453,26 @@ export default function FormatStep() {
               <select
                 className="input"
                 style={{ width: "175px", flexShrink: 0 }}
-                value={r.type}
-                onChange={(e) => changeRestrictionType(r.id, e.target.value)}
+                value={r.kind}
+                onChange={(e) =>
+                  changeRestrictionKind(r.id, e.target.value as RestrictionKind)
+                }
                 aria-label="Restriction type"
               >
-                {RESTRICTION_TYPES.map((t) => (
-                  <option key={t} value={t}>
-                    {t}
+                {RESTRICTION_KINDS.map((k) => (
+                  <option key={k} value={k}>
+                    {RESTRICTION_LABELS[k]}
                   </option>
                 ))}
               </select>
               <div className="min-w-0 flex-1">
-                {r.type === "Nationality" ? (
+                {r.kind === "nationality" ? (
                   <CountryDropdown
                     placeholder="Select country"
                     defaultValue={nameToAlpha3(r.value)}
-                    onChange={(c) => updateRestriction(r.id, "value", c.name)}
+                    onChange={(c) => updateRestrictionValue(r.id, c.name)}
                   />
-                ) : r.type === "Gender" ? (
+                ) : r.kind === "gender" ? (
                   <select
                     className={`input ${
                       showErrors && errors.restrictions?.[r.id]
@@ -490,7 +482,7 @@ export default function FormatStep() {
                     value={r.value}
                     aria-label="Restriction value"
                     onChange={(e) =>
-                      updateRestriction(r.id, "value", e.target.value)
+                      updateRestrictionValue(r.id, e.target.value)
                     }
                   >
                     <option value="">Select…</option>
@@ -509,7 +501,7 @@ export default function FormatStep() {
                     value={r.value}
                     aria-label="Restriction value"
                     onChange={(e) =>
-                      updateRestriction(r.id, "value", e.target.value)
+                      updateRestrictionValue(r.id, e.target.value)
                     }
                   />
                 )}

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/PrizesStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/PrizesStep.tsx
@@ -6,7 +6,7 @@ import type {
   PrizeRow,
   PrizesData,
   SpecialPrize,
-} from "../TournamentWizardContext";
+} from "../../types";
 import { useTournamentWizard } from "../TournamentWizardContext";
 import { newRowId } from "../rowId";
 

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/ReviewStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/ReviewStep.tsx
@@ -2,7 +2,8 @@
 
 import React from "react";
 import { useTournamentWizard } from "../TournamentWizardContext";
-import type { FeeTier, TierType } from "../TournamentWizardContext";
+import type { FeeTier } from "../../types";
+import { TIER_LABELS } from "../entryFees";
 
 const COMMISSION = 0.1;
 
@@ -30,25 +31,18 @@ function fmtDateTime(iso: string): string {
   });
 }
 
-const TIER_LABELS: Record<TierType, string> = {
-  "early-bird": "Early Bird",
-  titled: "Titled Players",
-  "rating-based": "Rating-Based",
-  "age-based": "Age-Based",
-};
-
 function tierSubLabel(tier: FeeTier): string {
   switch (tier.type) {
-    case "early-bird":
+    case "early_bird":
       return tier.validUntil ? `until ${fmtDate(tier.validUntil)}` : "";
-    case "titled":
+    case "titled_players":
       return tier.titles.length > 0 ? tier.titles.join(", ") : "";
-    case "rating-based":
+    case "rating_based":
       if (tier.ratingFrom !== "" && tier.ratingTo !== "") {
         return `${tier.ratingFrom}–${tier.ratingTo}`;
       }
       return "";
-    case "age-based":
+    case "age_based":
       if (tier.ageFrom !== "" && tier.ageTo !== "") {
         return `${tier.ageFrom}–${tier.ageTo} yrs`;
       }
@@ -191,7 +185,7 @@ export default function ReviewStep() {
   const allTiers = [
     { id: "standard", label: "Standard", subLabel: "", organiserFee: stdFee },
     ...feesData.tiers.map((t) => ({
-      id: t.id,
+      id: t.type,
       label: TIER_LABELS[t.type],
       subLabel: tierSubLabel(t),
       organiserFee: Number(t.amount) || 0,

--- a/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/ReviewStep.tsx
+++ b/src/app/my/organizations/[orgId]/tournaments/create/_components/steps/ReviewStep.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useTournamentWizard } from "../TournamentWizardContext";
 import type { FeeTier } from "../../types";
 import { TIER_LABELS } from "../entryFees";
+import { RESTRICTION_LABELS } from "../restrictions";
 
 const COMMISSION = 0.1;
 
@@ -159,7 +160,9 @@ export default function ReviewStep() {
 
   const restrictionsSummary =
     formatData.restrictions.length > 0
-      ? formatData.restrictions.map((r) => `${r.type} ${r.value}`).join(", ")
+      ? formatData.restrictions
+          .map((r) => `${RESTRICTION_LABELS[r.kind]} ${r.value}`)
+          .join(", ")
       : null;
 
   const formatRows: [string, React.ReactNode][] = [

--- a/src/app/my/organizations/[orgId]/tournaments/create/types.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/types.ts
@@ -1,0 +1,181 @@
+// The shapes the create/edit wizard works with: the state it holds (one per
+// step, plus the snapshot persisted to sessionStorage between steps) and the
+// canonical JSON those states are translated to and from on the way to the API.
+//
+// These live outside TournamentWizardContext so the modules that translate
+// between wizard state and the API — entryFees.ts, restrictions.ts — and the
+// server component that seeds an edit session can reference them without
+// importing a "use client" module.
+
+// =============================================
+// WIZARD STATE
+// =============================================
+
+export type WizardStepId =
+  | "basic-info"
+  | "format"
+  | "fees"
+  | "prizes"
+  | "review";
+
+export interface WizardStep {
+  id: WizardStepId;
+  label: string;
+}
+
+export interface BasicInfoData {
+  name: string;
+  description: string;
+  venueName: string;
+  venueState: string;
+  venueAddress: string;
+}
+
+/** One eligibility restriction row: a UI label plus a free-text value. */
+export interface Restriction {
+  id: string;
+  type: string;
+  value: string;
+}
+
+export interface FormatData {
+  formatType: string;
+  system: string;
+  rounds: number | "";
+  baseTime: number | "";
+  increment: number | "";
+  delay: number | "";
+  startDate: string;
+  endDate: string;
+  registrationDeadline: string;
+  maxParticipants: number | "";
+  fideRated: boolean;
+  mcfRated: boolean;
+  restrictions: Restriction[];
+}
+
+/**
+ * Tier discriminator, shared by the wizard and the stored JSON. These strings
+ * are also what `registrations.fee_tier` records and what checkout matches a
+ * registration against, so they are not a display concern — see TIER_LABELS in
+ * entryFees.ts for the UI copy.
+ */
+export type TierType =
+  | "early_bird"
+  | "titled_players"
+  | "rating_based"
+  | "age_based";
+
+/**
+ * A fee tier as the wizard edits it. No row id: the tier type is unique within
+ * a tournament (FeesStep only offers types not already present), so it is the
+ * row key. Amounts are in ringgit and bounds may be "" while a field is
+ * cleared — see entryFees.ts for the conversion to the stored shape.
+ */
+export interface FeeTier {
+  type: TierType;
+  amount: number | "";
+  validUntil: string;
+  titles: string[];
+  ratingFrom: number | "";
+  ratingTo: number | "";
+  ageFrom: number | "";
+  ageTo: number | "";
+}
+
+export interface FeesData {
+  standardFee: number | "";
+  tiers: FeeTier[];
+}
+
+export interface PrizeRow {
+  id: string;
+  placement: string;
+  amount: number | "";
+}
+
+export interface PrizeCategory {
+  id: string;
+  name: string;
+  prizes: PrizeRow[];
+}
+
+export interface SpecialPrize {
+  id: string;
+  name: string;
+  amount: number | "";
+}
+
+export interface PrizesData {
+  categories: PrizeCategory[];
+  specialPrizes: SpecialPrize[];
+}
+
+export interface PersistedState {
+  basicInfoData: BasicInfoData;
+  formatData: FormatData;
+  feesData: FeesData;
+  prizesData: PrizesData;
+  tournamentId: string | null;
+  currentStepIndex: number;
+  completedSteps: number[];
+}
+
+// =============================================
+// RESTRICTIONS — normalized `tournaments.restrictions` JSON
+// See restrictions.ts for the mapping to and from Restriction rows.
+// =============================================
+
+/**
+ * The normalized shape consumed by normalizeRestrictions / checkRestrictions at
+ * registration time. Persisting this rather than the UI labels is what makes
+ * wizard-created restrictions actually enforce.
+ */
+export type PersistedRestriction =
+  | { type: "age"; min?: number | null; max?: number | null }
+  | { type: "rating"; min?: number | null; max?: number | null }
+  | { type: "gender"; value: string }
+  | { type: "nationality"; value: string };
+
+// =============================================
+// ENTRY FEES — canonical `tournaments.entry_fees` JSON
+// See entryFees.ts for the mapping to and from FeesData.
+// =============================================
+
+/** A tier as the wizard writes it. */
+export interface PersistedFeeTier {
+  type: TierType;
+  amount_cents: number;
+  valid_until?: string;
+  titles?: string[];
+  rating_min?: number;
+  rating_max?: number;
+  age_min?: number;
+  age_max?: number;
+}
+
+export interface PersistedEntryFees {
+  standard: { amount_cents: number };
+  additional: PersistedFeeTier[];
+}
+
+/**
+ * A tier as it comes back out of the jsonb column: `type` widened because tiers
+ * the wizard cannot express (gender/oku) are part of the canonical model, and
+ * every field nullable because nothing constrains the column's contents.
+ */
+export interface StoredFeeTier {
+  type: string;
+  amount_cents?: number;
+  valid_until?: string | null;
+  titles?: string[] | null;
+  rating_min?: number | null;
+  rating_max?: number | null;
+  age_min?: number | null;
+  age_max?: number | null;
+}
+
+export interface StoredEntryFees {
+  standard?: { amount_cents?: number } | null;
+  additional?: StoredFeeTier[] | null;
+}

--- a/src/app/my/organizations/[orgId]/tournaments/create/types.ts
+++ b/src/app/my/organizations/[orgId]/tournaments/create/types.ts
@@ -31,10 +31,28 @@ export interface BasicInfoData {
   venueAddress: string;
 }
 
-/** One eligibility restriction row: a UI label plus a free-text value. */
+/**
+ * What a single restriction row constrains. One kind per row, so the two ends
+ * of a rating range are two rows — which is why this is finer-grained than the
+ * stored PersistedRestriction, whose "rating" item can carry both a min and a
+ * max. See RESTRICTION_LABELS in restrictions.ts for the UI copy.
+ */
+export type RestrictionKind =
+  | "max_age"
+  | "min_rating"
+  | "max_rating"
+  | "gender"
+  | "nationality";
+
+/**
+ * One eligibility restriction row. Rows carry an id because, unlike fee tiers,
+ * the same kind may legitimately appear more than once while being edited.
+ * `value` is the raw field text for every kind — a rating, a gender, or a
+ * country name — and is normalized on the way out by restrictions.ts.
+ */
 export interface Restriction {
   id: string;
-  type: string;
+  kind: RestrictionKind;
   value: string;
 }
 

--- a/src/app/tournaments/[slug]/_components/TournamentDetail.tsx
+++ b/src/app/tournaments/[slug]/_components/TournamentDetail.tsx
@@ -193,6 +193,15 @@ export default function TournamentDetail({
                             : `Age up to ${fee.age_max}`}
                       </span>
                     )}
+                    {(fee.rating_min != null || fee.rating_max != null) && (
+                      <span className="text-text-muted block text-xs">
+                        {fee.rating_min != null && fee.rating_max != null
+                          ? `Rating ${fee.rating_min}–${fee.rating_max}`
+                          : fee.rating_min != null
+                            ? `Rating ${fee.rating_min}+`
+                            : `Rating up to ${fee.rating_max}`}
+                      </span>
+                    )}
                   </td>
                   <td className="font-cinzel text-text-primary text-right font-semibold">
                     {formatRm(fee.amount_cents)}

--- a/src/app/tournaments/[slug]/register/_components/RegisterForm.tsx
+++ b/src/app/tournaments/[slug]/register/_components/RegisterForm.tsx
@@ -9,7 +9,11 @@ import {
   toTitleCase,
   formatDeadline,
   checkAgeEligibility,
+  checkRatingEligibility,
+  describeRatingList,
+  resolvePlayerRating,
 } from "@/app/tournaments/utils";
+import type { RatingContext } from "@/app/tournaments/utils";
 import type { EntryFeeBreakdown } from "@/services/payments/fees";
 import { nationalityMatches, resolveCountry } from "@/lib/countries";
 import type { RegistrationRow, PlayerProfile } from "../types";
@@ -27,6 +31,8 @@ interface TierRestrictions {
   titles?: string[];
   age_min?: number;
   age_max?: number;
+  rating_min?: number;
+  rating_max?: number;
 }
 
 /**
@@ -40,6 +46,7 @@ function checkHardEligibility(
   restrictions: Restrictions | null,
   profile: PlayerProfile | null,
   startDate: Date,
+  rating: RatingContext,
 ): string | null {
   // Gender mismatch only blocks when gender is actually set; a null gender is
   // "missing" (collectable), not ineligible.
@@ -79,6 +86,26 @@ function checkHardEligibility(
     (!profile?.title || !restrictions.titles.includes(profile.title))
   )
     return `This tournament is for titled players only (${restrictions.titles.join(", ")}).`;
+
+  // Ratings are synced from FIDE/MCF rather than typed in, so a shortfall — or
+  // holding no rating on the list this tournament is rated under — is a hard
+  // block. Which list that is: see resolvePlayerRating.
+  const ratingMin = tier.rating_min ?? restrictions?.min_rating ?? null;
+  const ratingMax = tier.rating_max ?? restrictions?.max_rating ?? null;
+  if (ratingMin != null || ratingMax != null) {
+    const playerRating = resolvePlayerRating(profile, rating);
+    const ratingResult = checkRatingEligibility(
+      playerRating,
+      ratingMin,
+      ratingMax,
+    );
+    if (ratingResult === "below_min")
+      return playerRating == null
+        ? `This fee requires a rating of at least ${ratingMin}, and your profile has no ${describeRatingList(rating)} rating.`
+        : `This fee requires a minimum rating of ${ratingMin}.`;
+    if (ratingResult === "above_max")
+      return `Your rating exceeds the maximum for this fee (${ratingMax}).`;
+  }
 
   // Age only resolves once the date of birth is known; a null DOB is collectable.
   // Judged as of the tournament start date (see checkAgeEligibility), not today.
@@ -159,6 +186,14 @@ export default function RegisterForm({
 
   const additional = tournament.entry_fees.additional ?? [];
 
+  // Which rating list rating-based tiers/restrictions are judged against — the
+  // same context the checkout route applies server-side.
+  const ratingContext: RatingContext = {
+    formatType: tournament.format.type,
+    isFideRated: tournament.is_fide_rated,
+    isMcfRated: tournament.is_mcf_rated,
+  };
+
   const tiers = useMemo(() => {
     const raw = [
       {
@@ -172,6 +207,8 @@ export default function RegisterForm({
         titles: undefined as string[] | undefined,
         age_min: undefined as number | undefined,
         age_max: undefined as number | undefined,
+        rating_min: undefined as number | undefined,
+        rating_max: undefined as number | undefined,
       },
       ...additional.map((t) => {
         const expired = !!t.valid_until && new Date(t.valid_until) < now;
@@ -181,6 +218,11 @@ export default function RegisterForm({
           parts.push(`age ${t.age_min}–${t.age_max}`);
         else if (t.age_min != null) parts.push(`age ${t.age_min}+`);
         else if (t.age_max != null) parts.push(`up to age ${t.age_max}`);
+        if (t.rating_min != null && t.rating_max != null)
+          parts.push(`rating ${t.rating_min}–${t.rating_max}`);
+        else if (t.rating_min != null) parts.push(`rating ${t.rating_min}+`);
+        else if (t.rating_max != null)
+          parts.push(`rating up to ${t.rating_max}`);
         if (t.gender === "female") parts.push("female only");
         if (t.oku) parts.push("OKU");
         if (t.titles?.length) parts.push(t.titles.join(", "));
@@ -195,6 +237,8 @@ export default function RegisterForm({
           titles: t.titles,
           age_min: t.age_min,
           age_max: t.age_max,
+          rating_min: t.rating_min,
+          rating_max: t.rating_max,
         };
       }),
     ];
@@ -206,7 +250,13 @@ export default function RegisterForm({
         // missing self-serviceable field keeps it selectable — the prompt collects it.
         eligible:
           !t.expired &&
-          checkHardEligibility(t, restrictions, profile, startDate) === null,
+          checkHardEligibility(
+            t,
+            restrictions,
+            profile,
+            startDate,
+            ratingContext,
+          ) === null,
       }))
       .sort((a, b) => {
         if (a.eligible !== b.eligible) return a.eligible ? -1 : 1;
@@ -234,7 +284,15 @@ export default function RegisterForm({
 
   const eligibilityError = useMemo<string | null>(() => {
     if (selected.expired) return "This fee tier has expired.";
-    return checkHardEligibility(selected, restrictions, profile, now);
+    // startDate, not `now` — the same anchor the dropdown's eligible flag uses,
+    // so the message can't disagree with which options are selectable.
+    return checkHardEligibility(
+      selected,
+      restrictions,
+      profile,
+      startDate,
+      ratingContext,
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected, restrictions, profile]);
 

--- a/src/app/tournaments/[slug]/register/_components/__tests__/RegisterForm.test.tsx
+++ b/src/app/tournaments/[slug]/register/_components/__tests__/RegisterForm.test.tsx
@@ -733,6 +733,209 @@ describe("RegisterForm", () => {
     });
   });
 
+  // --- Rating ---------------------------------------------------------------
+
+  describe("eligibility — rating", () => {
+    // makeTournament's format type is "swiss" and it is rated by neither
+    // federation, so ratings resolve to the FIDE standard list, then the
+    // national one (see resolvePlayerRating).
+    const RATED_1600: PlayerProfile = {
+      ...MALE_PROFILE,
+      fide_rating: { standard: 1600 },
+    };
+    const UNRATED = MALE_PROFILE;
+    const NATIONAL_1600: PlayerProfile = {
+      ...MALE_PROFILE,
+      national_rating: 1600,
+    };
+
+    it("shows an error when the player's rating is below the tier minimum", async () => {
+      const { container } = render(
+        <RegisterForm
+          tournament={makeTournament([
+            { type: "masters", amount_cents: 2000, rating_min: 1800 },
+          ])}
+          userId="u1"
+          playerProfile={RATED_1600}
+        />,
+      );
+      await act(async () => {
+        fireEvent.change(selectEl(container), { target: { value: "masters" } });
+      });
+      expect(
+        screen.getByText("This fee requires a minimum rating of 1800."),
+      ).toBeDefined();
+    });
+
+    it("shows an error when the player's rating exceeds the tier maximum", async () => {
+      const { container } = render(
+        <RegisterForm
+          tournament={makeTournament([
+            { type: "amateur", amount_cents: 2000, rating_max: 1500 },
+          ])}
+          userId="u1"
+          playerProfile={RATED_1600}
+        />,
+      );
+      await act(async () => {
+        fireEvent.change(selectEl(container), { target: { value: "amateur" } });
+      });
+      expect(
+        screen.getByText(
+          "Your rating exceeds the maximum for this fee (1500).",
+        ),
+      ).toBeDefined();
+    });
+
+    it("marks a rating-based tier the player misses as (Ineligible)", () => {
+      const { container } = render(
+        <RegisterForm
+          tournament={makeTournament([
+            { type: "masters", amount_cents: 2000, rating_min: 1800 },
+          ])}
+          userId="u1"
+          playerProfile={RATED_1600}
+        />,
+      );
+      const option = Array.from(selectEl(container).options).find(
+        (o) => o.value === "masters",
+      );
+      expect(option?.text).toContain("(Ineligible)");
+      expect(option?.disabled).toBe(true);
+    });
+
+    it("keeps a tier the player's rating falls inside selectable", () => {
+      const { container } = render(
+        <RegisterForm
+          tournament={makeTournament([
+            {
+              type: "amateur",
+              amount_cents: 2000,
+              rating_min: 1500,
+              rating_max: 1800,
+            },
+          ])}
+          userId="u1"
+          playerProfile={RATED_1600}
+        />,
+      );
+      // Cheaper and eligible, so it sorts first and is selected by default.
+      expect(selectEl(container).value).toBe("amateur");
+      expect(screen.queryByText(/rating/i)).not.toBeNull();
+      expect(screen.queryByText(/minimum rating/)).toBeNull();
+    });
+
+    it("blocks an unrated player from a tier with a rating floor", async () => {
+      const { container } = render(
+        <RegisterForm
+          tournament={makeTournament([
+            { type: "masters", amount_cents: 2000, rating_min: 1800 },
+          ])}
+          userId="u1"
+          playerProfile={UNRATED}
+        />,
+      );
+      await act(async () => {
+        fireEvent.change(selectEl(container), { target: { value: "masters" } });
+      });
+      expect(
+        screen.getByText(/no FIDE standard or national rating/),
+      ).toBeDefined();
+    });
+
+    it("admits an unrated player to a tier that only caps the rating", () => {
+      const { container } = render(
+        <RegisterForm
+          tournament={makeTournament([
+            { type: "amateur", amount_cents: 2000, rating_max: 1500 },
+          ])}
+          userId="u1"
+          playerProfile={UNRATED}
+        />,
+      );
+      expect(selectEl(container).value).toBe("amateur");
+      expect(screen.queryByText(/exceeds the maximum/)).toBeNull();
+    });
+
+    it("describes the tier's rating range under the selector", () => {
+      const { container } = render(
+        <RegisterForm
+          tournament={makeTournament([
+            {
+              type: "amateur",
+              amount_cents: 2000,
+              rating_min: 1500,
+              rating_max: 1800,
+            },
+          ])}
+          userId="u1"
+          playerProfile={RATED_1600}
+        />,
+      );
+      expect(selectEl(container).value).toBe("amateur");
+      expect(screen.getByText("rating 1500–1800")).toBeDefined();
+    });
+
+    it("ignores a national rating on a FIDE-rated tournament", async () => {
+      // Nationally 1600 but no FIDE standard rating → unrated for a FIDE-rated
+      // event, so a tier with a floor is out of reach.
+      const { container } = render(
+        <RegisterForm
+          tournament={{
+            ...makeTournament([
+              { type: "masters", amount_cents: 2000, rating_min: 1500 },
+            ]),
+            is_fide_rated: true,
+          }}
+          userId="u1"
+          playerProfile={NATIONAL_1600}
+        />,
+      );
+      await act(async () => {
+        fireEvent.change(selectEl(container), { target: { value: "masters" } });
+      });
+      expect(screen.getByText(/no FIDE standard rating/)).toBeDefined();
+    });
+
+    it("accepts a national rating when neither federation rates the event", () => {
+      const { container } = render(
+        <RegisterForm
+          tournament={makeTournament([
+            { type: "masters", amount_cents: 2000, rating_min: 1500 },
+          ])}
+          userId="u1"
+          playerProfile={NATIONAL_1600}
+        />,
+      );
+      expect(selectEl(container).value).toBe("masters");
+      expect(screen.queryByText(/rating/i)).not.toBeNull();
+      expect(screen.queryByText(/no FIDE/)).toBeNull();
+    });
+
+    it("judges an MCF-rated tournament on the national rating", async () => {
+      const { container } = render(
+        <RegisterForm
+          tournament={{
+            ...makeTournament([
+              { type: "amateur", amount_cents: 2000, rating_max: 1500 },
+            ]),
+            is_mcf_rated: true,
+          }}
+          userId="u1"
+          playerProfile={NATIONAL_1600}
+        />,
+      );
+      await act(async () => {
+        fireEvent.change(selectEl(container), { target: { value: "amateur" } });
+      });
+      expect(
+        screen.getByText(
+          "Your rating exceeds the maximum for this fee (1500).",
+        ),
+      ).toBeDefined();
+    });
+  });
+
   // --- Submit behaviour -----------------------------------------------------
 
   describe("submit behaviour", () => {

--- a/src/app/tournaments/__tests__/utils.test.ts
+++ b/src/app/tournaments/__tests__/utils.test.ts
@@ -5,6 +5,9 @@ import {
   formatDeadline,
   calculateAge,
   checkAgeEligibility,
+  checkRatingEligibility,
+  describeRatingList,
+  resolvePlayerRating,
   getTodayInTimeZone,
   getMinFeeCents,
 } from "../utils";
@@ -222,6 +225,182 @@ describe("checkAgeEligibility", () => {
     expect(checkAgeEligibility(new Date("2000-01-01"), start, null, null)).toBe(
       null,
     );
+  });
+});
+
+describe("resolvePlayerRating", () => {
+  const fide = (formatType: string) => ({
+    formatType,
+    isFideRated: true,
+    isMcfRated: false,
+  });
+  const mcf = (formatType: string) => ({
+    formatType,
+    isFideRated: false,
+    isMcfRated: true,
+  });
+  const unratedEvent = (formatType: string) => ({
+    formatType,
+    isFideRated: false,
+    isMcfRated: false,
+  });
+
+  const profile = {
+    fide_rating: { standard: 2000, rapid: 1900, blitz: 1800 },
+    national_rating: 1500,
+  };
+
+  it("uses the blitz list for a blitz tournament", () => {
+    expect(resolvePlayerRating(profile, fide("blitz"))).toBe(1800);
+  });
+
+  it("uses the rapid list for a rapid tournament", () => {
+    expect(resolvePlayerRating(profile, fide("rapid"))).toBe(1900);
+  });
+
+  it("uses the standard list for a classical tournament", () => {
+    expect(resolvePlayerRating(profile, fide("classical"))).toBe(2000);
+  });
+
+  it("treats an unknown format as standard", () => {
+    expect(resolvePlayerRating(profile, fide("swiss"))).toBe(2000);
+  });
+
+  it("does not substitute another FIDE list when the format's own is missing", () => {
+    expect(
+      resolvePlayerRating(
+        { fide_rating: { standard: 2000 }, national_rating: 1500 },
+        fide("blitz"),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not substitute the national rating on a FIDE-rated tournament", () => {
+    expect(
+      resolvePlayerRating(
+        { fide_rating: null, national_rating: 1500 },
+        fide("classical"),
+      ),
+    ).toBeNull();
+  });
+
+  it("reads only the national rating on an MCF-rated tournament", () => {
+    expect(resolvePlayerRating(profile, mcf("classical"))).toBe(1500);
+    expect(
+      resolvePlayerRating(
+        { fide_rating: { standard: 2000 }, national_rating: null },
+        mcf("classical"),
+      ),
+    ).toBeNull();
+  });
+
+  it("takes whichever rating exists when neither federation rates the event", () => {
+    expect(resolvePlayerRating(profile, unratedEvent("classical"))).toBe(2000);
+    expect(
+      resolvePlayerRating(
+        { fide_rating: null, national_rating: 1500 },
+        unratedEvent("classical"),
+      ),
+    ).toBe(1500);
+  });
+
+  it("returns null for a player with no ratings at all", () => {
+    expect(
+      resolvePlayerRating(
+        { fide_rating: null, national_rating: null },
+        fide("classical"),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for a null profile", () => {
+    expect(resolvePlayerRating(null, fide("classical"))).toBeNull();
+  });
+
+  it("ignores a non-numeric jsonb rating rather than comparing it as a string", () => {
+    expect(
+      resolvePlayerRating(
+        {
+          fide_rating: { standard: "1800" } as unknown as Record<
+            string,
+            number
+          >,
+          national_rating: 1500,
+        },
+        fide("classical"),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("describeRatingList", () => {
+  it("names the FIDE list for a FIDE-rated tournament", () => {
+    expect(
+      describeRatingList({
+        formatType: "classical",
+        isFideRated: true,
+        isMcfRated: false,
+      }),
+    ).toBe("FIDE standard");
+    expect(
+      describeRatingList({
+        formatType: "blitz",
+        isFideRated: true,
+        isMcfRated: false,
+      }),
+    ).toBe("FIDE blitz");
+  });
+
+  it("names the national list for an MCF-rated tournament", () => {
+    expect(
+      describeRatingList({
+        formatType: "rapid",
+        isFideRated: false,
+        isMcfRated: true,
+      }),
+    ).toBe("national (MCF)");
+  });
+
+  it("names both when neither federation rates the event", () => {
+    expect(
+      describeRatingList({
+        formatType: "rapid",
+        isFideRated: false,
+        isMcfRated: false,
+      }),
+    ).toBe("FIDE rapid or national");
+  });
+});
+
+describe("checkRatingEligibility", () => {
+  it("returns null when the rating is inside the range", () => {
+    expect(checkRatingEligibility(1700, 1500, 1800)).toBeNull();
+  });
+
+  it("treats both bounds as inclusive", () => {
+    expect(checkRatingEligibility(1500, 1500, 1800)).toBeNull();
+    expect(checkRatingEligibility(1800, 1500, 1800)).toBeNull();
+  });
+
+  it("flags a rating below the floor", () => {
+    expect(checkRatingEligibility(1499, 1500, null)).toBe("below_min");
+  });
+
+  it("flags a rating above the cap", () => {
+    expect(checkRatingEligibility(1801, null, 1800)).toBe("above_max");
+  });
+
+  it("blocks an unrated player from a floor", () => {
+    expect(checkRatingEligibility(null, 1500, null)).toBe("below_min");
+  });
+
+  it("admits an unrated player under a cap", () => {
+    expect(checkRatingEligibility(null, null, 1800)).toBeNull();
+  });
+
+  it("returns null when no bounds are set", () => {
+    expect(checkRatingEligibility(null, null, null)).toBeNull();
+    expect(checkRatingEligibility(2400, null, null)).toBeNull();
   });
 });
 

--- a/src/app/tournaments/types.ts
+++ b/src/app/tournaments/types.ts
@@ -28,8 +28,8 @@ export interface EntryFees {
     valid_until?: string;
     age_min?: number;
     age_max?: number;
-    // Rating bounds are written by the create/edit wizard but not yet checked
-    // by the tier eligibility validator or shown on the public tier list.
+    // Judged against the rating list matching the tournament's format — see
+    // resolvePlayerRating / checkRatingEligibility in ../utils.
     rating_min?: number;
     rating_max?: number;
     gender?: "female";

--- a/src/app/tournaments/types.ts
+++ b/src/app/tournaments/types.ts
@@ -28,6 +28,10 @@ export interface EntryFees {
     valid_until?: string;
     age_min?: number;
     age_max?: number;
+    // Rating bounds are written by the create/edit wizard but not yet checked
+    // by the tier eligibility validator or shown on the public tier list.
+    rating_min?: number;
+    rating_max?: number;
     gender?: "female";
     oku?: boolean;
     titles?: ChessTitle[];

--- a/src/app/tournaments/utils.ts
+++ b/src/app/tournaments/utils.ts
@@ -97,7 +97,7 @@ export function getMinFeeCents(fees: EntryFees | null | undefined): number {
 // Tournament dates/times are anchored to the venue's timezone. The platform is
 // Malaysia-only today, so this defaults to KL; the `timeZone` param lets a
 // per-tournament timezone drop in for the planned ASEAN expansion.
-const PLATFORM_TIME_ZONE = "Asia/Kuala_Lumpur";
+export const PLATFORM_TIME_ZONE = "Asia/Kuala_Lumpur";
 
 // Returns the calendar date ("YYYY-MM-DD") for `now` in the given timezone.
 // Used so the discovery ongoing/upcoming/past buckets are judged against the

--- a/src/app/tournaments/utils.ts
+++ b/src/app/tournaments/utils.ts
@@ -11,7 +11,11 @@ export function calculateAge(dob: Date, now: Date): number {
 
 function subtractYearsUTC(date: Date, years: number): Date {
   return new Date(
-    Date.UTC(date.getUTCFullYear() - years, date.getUTCMonth(), date.getUTCDate()),
+    Date.UTC(
+      date.getUTCFullYear() - years,
+      date.getUTCMonth(),
+      date.getUTCDate(),
+    ),
   );
 }
 
@@ -42,12 +46,106 @@ export function checkAgeEligibility(
     dob.getUTCMonth(),
     dob.getUTCDate(),
   );
-  if (ageMax != null && dobDay < subtractYearsUTC(startDate, ageMax).getTime()) {
+  if (
+    ageMax != null &&
+    dobDay < subtractYearsUTC(startDate, ageMax).getTime()
+  ) {
     return "too_old";
   }
-  if (ageMin != null && dobDay > subtractYearsUTC(startDate, ageMin).getTime()) {
+  if (
+    ageMin != null &&
+    dobDay > subtractYearsUTC(startDate, ageMin).getTime()
+  ) {
     return "too_young";
   }
+  return null;
+}
+
+/** The subset of a player profile eligibility checks judge a rating from. */
+export interface RatedProfile {
+  fide_rating?: Record<string, number> | null;
+  national_rating?: number | null;
+}
+
+/** Which rating list an eligibility check judges a player against. */
+export interface RatingContext {
+  /** The tournament's format type — "classical" | "rapid" | "blitz". */
+  formatType: string;
+  isFideRated: boolean;
+  isMcfRated: boolean;
+}
+
+/** The FIDE rating list a tournament format is played under. */
+function ratingListForFormat(
+  formatType: string,
+): "standard" | "rapid" | "blitz" {
+  return formatType === "blitz"
+    ? "blitz"
+    : formatType === "rapid"
+      ? "rapid"
+      : "standard";
+}
+
+/**
+ * Names the rating a check reads, for messages telling a player which rating
+ * they're missing — e.g. "FIDE standard", "national (MCF)".
+ */
+export function describeRatingList({
+  formatType,
+  isFideRated,
+  isMcfRated,
+}: RatingContext): string {
+  if (isFideRated) return `FIDE ${ratingListForFormat(formatType)}`;
+  if (isMcfRated) return "national (MCF)";
+  return `FIDE ${ratingListForFormat(formatType)} or national`;
+}
+
+function numericOrNull(value: unknown): number | null {
+  // Both sources are jsonb-backed, so a non-numeric value is treated as absent
+  // rather than compared as a string.
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+// The rating a player is judged on, taken from the list the tournament is
+// actually rated under — never substituted from another one:
+//
+//   FIDE-rated → the FIDE list matching the format (classical → standard).
+//   MCF-rated  → the national rating.
+//
+// A player without a rating on that list is unrated for this tournament, even if
+// they hold one elsewhere: a classical FIDE event can't rank a player by their
+// blitz or national rating. An event rated by neither federation has no list of
+// its own to insist on, so it accepts whichever rating the player has (FIDE for
+// the format first, then national) — that's the only case where both are read.
+export function resolvePlayerRating(
+  profile: RatedProfile | null | undefined,
+  { formatType, isFideRated, isMcfRated }: RatingContext,
+): number | null {
+  const fide = numericOrNull(
+    profile?.fide_rating?.[ratingListForFormat(formatType)],
+  );
+  const national = numericOrNull(profile?.national_rating);
+
+  if (isFideRated) return fide;
+  if (isMcfRated) return national;
+  return fide ?? national;
+}
+
+export type RatingEligibility = "below_min" | "above_max" | null;
+
+// Rating eligibility for a fee tier or a tournament restriction. An unrated
+// player cannot show they clear a floor, so a `min` blocks them; a `max` (an
+// "under 1800" tier) still admits them — unrated players are exactly who those
+// categories are for.
+export function checkRatingEligibility(
+  rating: number | null,
+  ratingMin: number | null,
+  ratingMax: number | null,
+): RatingEligibility {
+  if (ratingMin != null && (rating == null || rating < ratingMin))
+    return "below_min";
+  if (ratingMax != null && rating != null && rating > ratingMax)
+    return "above_max";
   return null;
 }
 


### PR DESCRIPTION
Closes #478

## The bug

Reopening a draft cleared the early-bird "valid until" date and the age-based tier's age range. Amounts survived, the criteria did not.

## Root cause

The wizard wrote its own dialect of `entry_fees` while every consumer read the canonical one:

| | wizard wrote | everyone else reads |
|---|---|---|
| age bounds | `age_from` / `age_to` | `age_min` / `age_max` |
| rating bounds | `rating_from` / `rating_to` | `rating_min` / `rating_max` |
| `valid_until` | `"2026-02-19"` | a full timestamp |

The canonical shape is fixed by `db/migrations/001_tables.sql:166`, the seed, `EntryFees` in `src/app/tournaments/types.ts`, `TournamentDetail`, `RegisterForm`, the checkout route, and the registration eligibility validators.

So the edit page looked for `age_from` on a tournament storing `age_min` → blank, and fed an ISO timestamp into `<input type="date">`, which renders empty → blank. `amount_cents` was the one key both sides agreed on, which is why the money came back.

The same mismatch had a quieter consequence: `validators.ts` gates tier eligibility on `age_min`/`age_max`, so an age-based tier created in the wizard was **enforced as unrestricted**.

## The fix

`entryFees.ts` is now the single bidirectional mapping, so the two directions cannot drift apart again.

- `valid_until` is stored as an instant anchored to the venue day (`2026-02-19T23:59:59+08:00`). Consumers compare it with `new Date(valid_until) < now`, so a bare date expired the tier at 08:00 local on the day the UI promises is still included.
- Tiers the wizard has no editor for (gender/oku) are skipped on read rather than coerced into an early-bird row and silently rewritten on save.

Folded into the same commit, since the fix required them:

- Wizard state types moved out of `TournamentWizardContext` into `create/types.ts`, so `entryFees.ts` — imported by the server-rendered edit page — no longer reaches into a `"use client"` module.
- Wizard tier state uses the canonical snake_case discriminator. Those strings are what `registrations.fee_tier` records and what checkout matches on, so kebab-case was the wizard's alone; the two translation tables it needed are gone.
- `FeeTier` drops its row id — `FeesStep` only offers types not already present, so the type is already unique per tournament.

## Second commit

`refactor(wizard): key restriction rows by kind, not by their display label` — independent of the bug, so kept separate. A restriction row's discriminator was the string shown in its dropdown (`{ type: "Max Age", value: "18" }`), which made UI copy load-bearing and made the mapper `throw` on anything it did not recognise. Rows now carry a `RestrictionKind` and the label is applied at render.

## Third commit

`feat(registration): enforce rating-based fee tiers` — closes the gap this PR previously only documented. Rating bounds were written by the wizard and read by nobody: checkout let any player claim a rating-based tier, and neither the public tier list nor the registration form showed the range.

**Which rating counts.** Resolution now lives in one place (`resolvePlayerRating`) and takes the list from the federation that rates the tournament, with no substitution between lists:

| tournament | rating used |
|---|---|
| FIDE-rated | the FIDE list for its format only — classical → standard, rapid → rapid, blitz → blitz |
| MCF-rated | the national rating only |
| rated by neither | the FIDE list for its format, else the national rating |

A player holding no rating on that list is **unrated for this tournament**, even if they are rated elsewhere — a classical FIDE event cannot rank someone by their blitz or national rating. An event rated by neither federation has no list of its own to insist on, so it accepts whichever rating the player has.

`checkRestrictions` moves onto the same helper, which drops the national-rating stand-in it used to allow on a FIDE-rated event and the standard-list stand-in it allowed on a rapid/blitz one. That is a deliberate behaviour change to existing tournament-level restrictions, not just to the new tier path.

**How a bound is applied.** An unrated player fails a `rating_min` but still clears a `rating_max` — an "under 1800" tier is exactly who they are for.

- `checkFeeTierEligibility` rejects a mismatched tier with `INVALID_FEE_TIER` (400), naming the missing list ("no FIDE standard rating") when the player has no rating at all. A rating is not self-serviceable, so this is a hard block rather than a fixable `VALIDATION_ERROR`.
- The checkout route builds the context from `format.type` + `is_fide_rated`/`is_mcf_rated`, and now pulls the player profile when a tier carries rating bounds — previously it did not fetch one at all for a rating-only tier.
- The public fee table and the register dropdown both show the range ("Rating 1500–1800"), and an out-of-range tier is disabled client-side instead of failing at pay time.

Also in that commit: the selected-tier eligibility message was anchored to `now` while the dropdown's own eligible flag used the tournament start date, so the two could disagree about an age-based tier. Both use the start date now.

## Verification

All three commits typecheck, lint clean, and pass the suite standalone. 1578 tests pass; 56 new tests cover the seeded shape, the round trip, tier skipping, the timezone edges, and rating resolution/enforcement across FIDE-rated, MCF-rated and unrated events.

Typecheck reports the same 39 errors as before, all pre-existing and unrelated (missing `slug` in tournament test fixtures after #514, plus `session-cookie.test.ts`).

## Open question

For a tournament rated by **neither** federation, the third commit accepts whichever rating the player holds. That case was not specified; if such events should demand a particular list, it is a one-line change in `resolvePlayerRating`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
