### PR TITLE
Payout Phase 2 — Legal: Organizer Agreement + ToS with versioned acceptance

### DIFF
--- a/db/migrations/001_tables.sql
+++ b/db/migrations/001_tables.sql
@@ -39,18 +39,29 @@ CREATE TABLE role_permissions (
 -- without rewriting the id across registrations/payments/refunds/audit_logs.
 -- NULL = a record with no login yet. Today every row has one (written by
 -- handle_new_user), so nothing depends on the nullability yet.
+-- terms_version records WHICH Terms of Service the user agreed to, not merely
+-- that they ticked a box. The version is written by the signup route from
+-- src/lib/legal.ts (TERMS_VERSION) via handle_new_user — never from the request
+-- body, since a client-supplied version is not evidence of anything. NULL on
+-- rows created outside signup (seeds, admin-created players).
 CREATE TABLE users (
-  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  auth_user_id  uuid UNIQUE,
-  email         varchar(255) NOT NULL,  -- uniqueness enforced via partial index in 002_indexes.sql
-  first_name    varchar(255) NOT NULL,
-  last_name     varchar(255) NOT NULL,
-  avatar_url    varchar(255),
-  is_verified   boolean NOT NULL DEFAULT false,
-  verified_at   timestamptz,
-  created_at    timestamptz NOT NULL DEFAULT now(),
-  updated_at    timestamptz NOT NULL DEFAULT now(),
-  deleted_at    timestamptz
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  auth_user_id      uuid UNIQUE,
+  email             varchar(255) NOT NULL,  -- uniqueness enforced via partial index in 002_indexes.sql
+  first_name        varchar(255) NOT NULL,
+  last_name         varchar(255) NOT NULL,
+  avatar_url        varchar(255),
+  is_verified       boolean NOT NULL DEFAULT false,
+  verified_at       timestamptz,
+  terms_version     varchar(20),
+  terms_accepted_at timestamptz,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  deleted_at        timestamptz,
+  -- A version with no timestamp (or the reverse) is a half-written acceptance
+  -- and proves nothing. Both or neither.
+  CONSTRAINT chk_terms_shape
+    CHECK ((terms_version IS NULL) = (terms_accepted_at IS NULL))
 );
 
 -- Global roles (e.g. platform admin)
@@ -121,6 +132,24 @@ CREATE TABLE organizations (
   -- organization_bank_accounts, which is RLS-gated on bank_account.manage and
   -- superseded (not updated) on change so verification can't go stale.
   past_tournament_refs  text,
+  -- Which version of the Organizer Agreement this organization is bound by.
+  -- Written server-side from src/lib/legal.ts (ORGANIZER_AGREEMENT_VERSION) at
+  -- application and on every re-acceptance; the request body never supplies it.
+  --
+  -- Bumping the constant is the re-acceptance mechanism: an organization whose
+  -- version is older is shown a blocking panel, and the payout functions
+  -- (queue_payout / request_early_payout, Phases 5-6) MUST refuse when this is
+  -- not the current version, so a stale agreement stops money rather than
+  -- failing silently.
+  --
+  -- Unlike bank details (see the note above), these three are safe on this row
+  -- despite the column-unrestricted public SELECT policy in 004_rls.sql: a
+  -- version string, a timestamp, and an opaque user id no more revealing than
+  -- created_by / reviewed_by already are. This is not a precedent for anything
+  -- that would actually leak.
+  agreement_version     varchar(20),
+  agreement_accepted_at timestamptz,
+  agreement_accepted_by uuid REFERENCES users(id) ON DELETE SET NULL,
   approval_status       approval_status NOT NULL DEFAULT 'pending',
   reviewed_by           uuid REFERENCES users(id) ON DELETE SET NULL,
   reviewed_at           timestamptz,
@@ -128,7 +157,10 @@ CREATE TABLE organizations (
   created_by            uuid REFERENCES users(id) ON DELETE SET NULL,
   created_at            timestamptz NOT NULL DEFAULT now(),
   updated_at            timestamptz NOT NULL DEFAULT now(),
-  deleted_at            timestamptz
+  deleted_at            timestamptz,
+  -- Both or neither — a version with no timestamp is not an acceptance.
+  CONSTRAINT chk_agreement_shape
+    CHECK ((agreement_version IS NULL) = (agreement_accepted_at IS NULL))
 );
 
 -- =============================================

--- a/db/migrations/003_functions_triggers.sql
+++ b/db/migrations/003_functions_triggers.sql
@@ -38,16 +38,30 @@ CREATE TRIGGER set_updated_at BEFORE UPDATE ON tournament_cancellation_requests
 -- The two being equal here is an implementation detail of self-signup, NOT an
 -- invariant — a record created for someone without a login (see #504) will have
 -- a generated id and a NULL auth_user_id until it is claimed.
+-- terms_version comes through raw_user_meta_data the same way the names do, but
+-- the signup route puts it there from a server constant (src/lib/legal.ts), not
+-- from the request body. Writing it here rather than in a follow-up UPDATE keeps
+-- the acceptance in the same statement that creates the account, so there is no
+-- window in which a user exists with no record of what they agreed to.
+-- The timestamp is derived, never taken from metadata, and stays NULL when no
+-- version was supplied so chk_terms_shape holds for rows created outside signup.
 CREATE OR REPLACE FUNCTION handle_new_user()
 RETURNS TRIGGER AS $$
+DECLARE
+  v_terms_version varchar(20) := NULLIF(NEW.raw_user_meta_data->>'terms_version', '');
 BEGIN
-  INSERT INTO public.users (id, auth_user_id, email, first_name, last_name)
+  INSERT INTO public.users (
+    id, auth_user_id, email, first_name, last_name,
+    terms_version, terms_accepted_at
+  )
   VALUES (
     NEW.id,
     NEW.id,
     NEW.email,
     COALESCE(NEW.raw_user_meta_data->>'first_name', ''),
-    COALESCE(NEW.raw_user_meta_data->>'last_name', '')
+    COALESCE(NEW.raw_user_meta_data->>'last_name', ''),
+    v_terms_version,
+    CASE WHEN v_terms_version IS NULL THEN NULL ELSE now() END
   );
 
   INSERT INTO public.player_profiles (user_id)

--- a/db/migrations/006_seed.sql
+++ b/db/migrations/006_seed.sql
@@ -323,7 +323,11 @@ BEGIN
     'review@chip.com', pwd_hash,
     now(),
     '{"provider":"email","providers":["email"]}',
-    json_build_object('first_name', 'CHIP', 'last_name', 'Review'),
+    -- terms_version rides in the metadata exactly as the signup route sends it,
+    -- so handle_new_user records the acceptance the same way it does in
+    -- production. Keep in step with TERMS_VERSION in src/lib/legal.ts.
+    json_build_object('first_name', 'CHIP', 'last_name', 'Review',
+                      'terms_version', '2026-08-02'),
     now(), now(),
     '', '', '', '', '', '', '', ''
   );
@@ -378,7 +382,8 @@ BEGIN
       org_emails[i], pwd_hash,
       now(),
       '{"provider":"email","providers":["email"]}',
-      json_build_object('first_name', org_first[i], 'last_name', org_last[i]),
+      json_build_object('first_name', org_first[i], 'last_name', org_last[i],
+                        'terms_version', '2026-08-02'),
       now(), now(),
       '', '', '', '', '', '', '', ''
     );
@@ -406,15 +411,21 @@ BEGIN
 
     org_user_ids := array_append(org_user_ids, new_user_id);
 
+    -- Seeded organizations accept the current Organizer Agreement, otherwise
+    -- every seeded dashboard opens behind the re-acceptance gate. Keep this
+    -- literal in step with ORGANIZER_AGREEMENT_VERSION in src/lib/legal.ts —
+    -- a mismatch here surfaces as the gate appearing on every seeded org.
     INSERT INTO public.organizations (
       name, description, email,
       phone, approval_status, reviewed_at,
-      reviewed_by, created_by
+      reviewed_by, created_by,
+      agreement_version, agreement_accepted_at, agreement_accepted_by
     ) VALUES (
       org_names[i], org_descs[i], org_emails[i],
       '+601' || (i + 1)::text || '-' || (1000000 + i * 123456)::text,
       'approved', now(),
-      new_user_id, new_user_id
+      new_user_id, new_user_id,
+      '2026-08-02', now(), new_user_id
     ) RETURNING id INTO new_org_id;
 
     org_profile_ids := array_append(org_profile_ids, new_org_id);
@@ -469,7 +480,8 @@ BEGIN
       p_email, pwd_hash,
       now(),
       '{"provider":"email","providers":["email"]}',
-      json_build_object('first_name', p_first, 'last_name', p_last),
+      json_build_object('first_name', p_first, 'last_name', p_last,
+                        'terms_version', '2026-08-02'),
       now() - (i || ' days')::interval,
       now() - (i || ' days')::interval,
       '', '', '', '', '', '', '', ''

--- a/db/tests/legal_acceptance.sql
+++ b/db/tests/legal_acceptance.sql
@@ -1,0 +1,161 @@
+-- =============================================================================
+-- Regression test for versioned legal acceptance (#517 / payout Phase 2).
+--
+-- Acceptance of the Terms of Service and the Organizer Agreement is evidence
+-- that a specific document version was agreed to, and the payout machinery
+-- (Phases 5-6) refuses to move money when an organization's agreement_version
+-- is not current. That makes the shape of these columns load-bearing: a version
+-- without a timestamp, or a timestamp without a version, is not an acceptance
+-- and must not be storable.
+--
+-- Covers:
+--   L1  users.chk_terms_shape rejects a version with no timestamp
+--   L2  users.chk_terms_shape rejects a timestamp with no version
+--   L3  both NULL and both set are accepted
+--   L4  organizations.chk_agreement_shape rejects half-written acceptances
+--   L5  a full organization acceptance (version + timestamp + acceptor) stores
+--   L6  agreement_accepted_by survives the acceptor being deleted (SET NULL) —
+--       the acceptance itself must not vanish with the user record
+--   L7  handle_new_user persists terms_version from auth metadata and stamps
+--       terms_accepted_at itself
+--   L8  handle_new_user leaves BOTH columns NULL when no version was supplied,
+--       so rows created outside signup still satisfy chk_terms_shape
+--
+-- HOW TO RUN: paste into the Supabase SQL editor (service role) AFTER applying
+-- the current migrations. Runs inside a transaction that ROLLBACKs, so it builds
+-- throwaway fixtures and persists NOTHING. A failing assertion RAISEs (and rolls
+-- back); on success it prints "ALL SCENARIOS PASSED" via NOTICE.
+--
+-- L7/L8 insert into auth.users directly to fire on_auth_user_created; that is
+-- what the signup route does through the Auth API.
+-- =============================================================================
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_user     uuid;
+  v_acceptor uuid;
+  v_org      uuid;
+  v_auth     uuid := gen_random_uuid();
+  v_auth2    uuid := gen_random_uuid();
+  v_version  text;
+  v_at       timestamptz;
+  v_by       uuid;
+BEGIN
+  -- ---- L1: version without timestamp is not an acceptance -----------------
+  BEGIN
+    INSERT INTO users (auth_user_id, email, first_name, last_name, terms_version)
+      VALUES (gen_random_uuid(), 'legal-l1@test.local', 'L', 'One', '2026-08-02');
+    RAISE EXCEPTION 'L1 FAIL: users accepted a terms_version with no terms_accepted_at';
+  EXCEPTION
+    WHEN check_violation THEN
+      RAISE NOTICE 'L1 PASS — terms_version without a timestamp rejected';
+  END;
+
+  -- ---- L2: timestamp without version is not an acceptance either ----------
+  BEGIN
+    INSERT INTO users (auth_user_id, email, first_name, last_name, terms_accepted_at)
+      VALUES (gen_random_uuid(), 'legal-l2@test.local', 'L', 'Two', now());
+    RAISE EXCEPTION 'L2 FAIL: users accepted a terms_accepted_at with no terms_version';
+  EXCEPTION
+    WHEN check_violation THEN
+      RAISE NOTICE 'L2 PASS — terms_accepted_at without a version rejected';
+  END;
+
+  -- ---- L3: both NULL and both set are fine --------------------------------
+  INSERT INTO users (auth_user_id, email, first_name, last_name)
+    VALUES (gen_random_uuid(), 'legal-l3a@test.local', 'L', 'ThreeA');
+
+  INSERT INTO users (auth_user_id, email, first_name, last_name,
+                     terms_version, terms_accepted_at)
+    VALUES (gen_random_uuid(), 'legal-l3b@test.local', 'L', 'ThreeB',
+            '2026-08-02', now())
+    RETURNING id INTO v_acceptor;
+  RAISE NOTICE 'L3 PASS — neither-or-both accepted';
+
+  -- ---- L4: the same rule on organizations ---------------------------------
+  BEGIN
+    INSERT INTO organizations (name, agreement_version)
+      VALUES ('LEGAL ORG L4', '2026-08-02');
+    RAISE EXCEPTION 'L4 FAIL: organizations accepted an agreement_version with no timestamp';
+  EXCEPTION
+    WHEN check_violation THEN
+      NULL;
+  END;
+
+  BEGIN
+    INSERT INTO organizations (name, agreement_accepted_at)
+      VALUES ('LEGAL ORG L4b', now());
+    RAISE EXCEPTION 'L4 FAIL: organizations accepted an agreement_accepted_at with no version';
+  EXCEPTION
+    WHEN check_violation THEN
+      RAISE NOTICE 'L4 PASS — half-written organization acceptances rejected';
+  END;
+
+  -- ---- L5: a complete acceptance stores -----------------------------------
+  INSERT INTO organizations (name, agreement_version, agreement_accepted_at,
+                             agreement_accepted_by)
+    VALUES ('LEGAL ORG', '2026-08-02', now(), v_acceptor)
+    RETURNING id INTO v_org;
+
+  SELECT agreement_version, agreement_accepted_at, agreement_accepted_by
+    INTO v_version, v_at, v_by
+  FROM organizations WHERE id = v_org;
+
+  IF v_version <> '2026-08-02' OR v_at IS NULL OR v_by <> v_acceptor THEN
+    RAISE EXCEPTION 'L5 FAIL: stored acceptance = (%, %, %)', v_version, v_at, v_by;
+  END IF;
+  RAISE NOTICE 'L5 PASS — full acceptance stored';
+
+  -- ---- L6: deleting the acceptor must not erase the acceptance ------------
+  DELETE FROM users WHERE id = v_acceptor;
+
+  SELECT agreement_version, agreement_accepted_at, agreement_accepted_by
+    INTO v_version, v_at, v_by
+  FROM organizations WHERE id = v_org;
+
+  IF v_version IS NULL OR v_at IS NULL THEN
+    RAISE EXCEPTION 'L6 FAIL: acceptance lost when the acceptor was deleted';
+  END IF;
+  IF v_by IS NOT NULL THEN
+    RAISE EXCEPTION 'L6 FAIL: agreement_accepted_by=% (expected NULL after ON DELETE SET NULL)', v_by;
+  END IF;
+  RAISE NOTICE 'L6 PASS — acceptance survives acceptor deletion, FK nulled';
+
+  -- ---- L7: handle_new_user carries the version through --------------------
+  INSERT INTO auth.users (id, email, raw_user_meta_data)
+    VALUES (v_auth, 'legal-l7@test.local',
+            '{"first_name":"L","last_name":"Seven","terms_version":"2026-08-02"}'::jsonb);
+
+  SELECT id, terms_version, terms_accepted_at INTO v_user, v_version, v_at
+  FROM users WHERE auth_user_id = v_auth;
+
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'L7 FAIL: handle_new_user did not create a users row';
+  END IF;
+  IF v_version <> '2026-08-02' THEN
+    RAISE EXCEPTION 'L7 FAIL: terms_version=% (expected 2026-08-02)', v_version;
+  END IF;
+  IF v_at IS NULL THEN
+    RAISE EXCEPTION 'L7 FAIL: terms_accepted_at was not stamped';
+  END IF;
+  RAISE NOTICE 'L7 PASS — signup persists the accepted terms version';
+
+  -- ---- L8: no version supplied leaves both NULL ---------------------------
+  INSERT INTO auth.users (id, email, raw_user_meta_data)
+    VALUES (v_auth2, 'legal-l8@test.local',
+            '{"first_name":"L","last_name":"Eight"}'::jsonb);
+
+  SELECT terms_version, terms_accepted_at INTO v_version, v_at
+  FROM users WHERE auth_user_id = v_auth2;
+
+  IF v_version IS NOT NULL OR v_at IS NOT NULL THEN
+    RAISE EXCEPTION 'L8 FAIL: expected both NULL, got (%, %)', v_version, v_at;
+  END IF;
+  RAISE NOTICE 'L8 PASS — no metadata version leaves both columns NULL';
+
+  RAISE NOTICE 'ALL SCENARIOS PASSED';
+END $$;
+
+ROLLBACK;

--- a/src/app/api/v1/auth/signup/create-account/__tests__/route.test.ts
+++ b/src/app/api/v1/auth/signup/create-account/__tests__/route.test.ts
@@ -62,6 +62,7 @@ vi.mock("@/services/email/email", () => ({
 }));
 
 import { POST } from "../route";
+import { TERMS_VERSION } from "@/lib/legal";
 
 // ---------------------------------------------------------------------------
 // Fixtures & helpers
@@ -72,6 +73,7 @@ const validBody = {
   password: "Password1!",
   firstName: "Ahmad",
   lastName: "Razif",
+  termsAccepted: true,
 };
 
 const NEW_USER_ID = "new-user-id";
@@ -140,6 +142,49 @@ describe("POST /api/v1/auth/signup/create-account", () => {
         }),
       }),
     );
+  });
+
+  // --- Terms acceptance -----------------------------------------------------
+
+  it("records the accepted terms version from the server constant", async () => {
+    await POST(makeRequest(validBody));
+
+    expect(mockCreateUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_metadata: expect.objectContaining({
+          terms_version: TERMS_VERSION,
+        }),
+      }),
+    );
+  });
+
+  it("ignores a terms version supplied in the request body", async () => {
+    // A client-supplied version is not evidence of anything — whatever the body
+    // claims, the recorded version must be the server's own constant.
+    await POST(
+      makeRequest({
+        ...validBody,
+        terms_version: "1999-01-01",
+        termsVersion: "1999-01-01",
+      }),
+    );
+
+    const metadata = mockCreateUser.mock.calls[0][0].user_metadata;
+    expect(metadata.terms_version).toBe(TERMS_VERSION);
+    expect(JSON.stringify(metadata)).not.toContain("1999-01-01");
+  });
+
+  it("rejects a signup that does not accept the terms", async () => {
+    for (const termsAccepted of [undefined, false, "true", 1]) {
+      vi.clearAllMocks();
+      const res = await POST(makeRequest({ ...validBody, termsAccepted }));
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json.error.code).toBe("VALIDATION_ERROR");
+      expect(json.error.message).toMatch(/must accept the terms/i);
+      expect(mockCreateUser).not.toHaveBeenCalled();
+    }
   });
 
   // --- Per-IP rate limiting (anti-enumeration) ------------------------------

--- a/src/app/api/v1/auth/signup/create-account/route.ts
+++ b/src/app/api/v1/auth/signup/create-account/route.ts
@@ -11,6 +11,7 @@ import {
   checkPasswordRequirements,
 } from "@/services/auth/auth-validation";
 import { SIGNUP_STEP_COOKIE, SIGNUP_STEP_MAX_AGE } from "@/lib/signup-cookie";
+import { TERMS_VERSION } from "@/lib/legal";
 import { getClientIp } from "@/lib/request-ip";
 import { generateCode } from "@/services/auth/verification-code";
 
@@ -76,11 +77,12 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { email, password, firstName, lastName } = body as {
+  const { email, password, firstName, lastName, termsAccepted } = body as {
     email?: string;
     password?: string;
     firstName?: string;
     lastName?: string;
+    termsAccepted?: boolean;
   };
 
   if (!email || typeof email !== "string") {
@@ -109,6 +111,21 @@ export async function POST(request: NextRequest) {
   if (!lastName || typeof lastName !== "string") {
     return NextResponse.json(
       { error: { code: "VALIDATION_ERROR", message: "Last name is required" } },
+      { status: 400 },
+    );
+  }
+
+  // Consent is a condition of creating the account, so it is enforced here and
+  // not only by the checkbox in auth-validation.ts — a direct API call must not
+  // be able to create an account with no acceptance on file.
+  if (termsAccepted !== true) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "You must accept the Terms of Service and Privacy Policy",
+        },
+      },
       { status: 400 },
     );
   }
@@ -207,6 +224,12 @@ export async function POST(request: NextRequest) {
       user_metadata: {
         first_name: firstName,
         last_name: lastName,
+        // handle_new_user copies this onto users.terms_version and stamps
+        // terms_accepted_at, so the record of WHICH terms were accepted is
+        // written in the same statement that creates the row. The value is the
+        // server's constant — a client-supplied version would be evidence of
+        // nothing.
+        terms_version: TERMS_VERSION,
       },
     });
 

--- a/src/app/api/v1/organizations/[orgId]/agreement/__tests__/route.test.ts
+++ b/src/app/api/v1/organizations/[orgId]/agreement/__tests__/route.test.ts
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockOrgBuilder,
+  mockUpdateBuilder,
+  mockMembershipBuilder,
+  mockFrom,
+  mockGetClaims,
+  mockGetAuthClaims,
+  mockHasOrgPermission,
+} = vi.hoisted(() => {
+  function makeBuilder(finalResult: {
+    data?: unknown;
+    count?: unknown;
+    error?: unknown;
+  }) {
+    const b: Record<string, unknown> = {};
+    for (const m of ["select", "eq", "is", "single", "maybeSingle", "update"]) {
+      b[m] = vi.fn(() => b);
+    }
+    b.then = (
+      onfulfilled: (v: unknown) => unknown,
+      onrejected?: (r: unknown) => unknown,
+    ) => Promise.resolve(finalResult).then(onfulfilled, onrejected);
+    return b;
+  }
+
+  const mockOrgBuilder = makeBuilder({ data: null, error: null });
+  const mockUpdateBuilder = makeBuilder({ data: null, error: null });
+  const mockMembershipBuilder = makeBuilder({ count: 1, error: null });
+
+  // The route reads the org and then updates it; route update() to its own
+  // builder so the read result and the write result can be set independently.
+  (mockOrgBuilder as Record<string, unknown>).update = vi.fn(
+    () => mockUpdateBuilder,
+  );
+
+  const mockFrom = vi.fn((table: string) => {
+    if (table === "organization_memberships") return mockMembershipBuilder;
+    return mockOrgBuilder;
+  });
+
+  const mockGetClaims = vi.fn();
+  const mockGetAuthClaims = vi.fn(async () => {
+    const { data } = await mockGetClaims();
+    const claims = data?.claims;
+    if (!claims) return null;
+    return {
+      id: claims.sub,
+      email: claims.email ?? "",
+      userMetadata: claims.user_metadata ?? {},
+      role: claims.role,
+    };
+  });
+  const mockHasOrgPermission = vi.fn().mockResolvedValue(true);
+
+  return {
+    mockOrgBuilder,
+    mockUpdateBuilder,
+    mockMembershipBuilder,
+    mockFrom,
+    mockGetClaims,
+    mockGetAuthClaims,
+    mockHasOrgPermission,
+  };
+});
+
+vi.mock("@/services/supabase/admin", () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock("@/services/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getClaims: mockGetClaims },
+  }),
+}));
+
+vi.mock("@/services/supabase/permission", () => ({
+  hasOrgPermission: mockHasOrgPermission,
+  getAuthClaims: mockGetAuthClaims,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+  }),
+}));
+
+import { POST } from "../route";
+import { ORGANIZER_AGREEMENT_VERSION } from "@/lib/legal";
+
+// ---------------------------------------------------------------------------
+// Fixtures & helpers
+// ---------------------------------------------------------------------------
+
+const USER_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const ORG_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+const STALE_VERSION = "2025-01-01";
+
+function makeRequest(
+  orgId: string = ORG_ID,
+  body: unknown = { agreement_accepted: true },
+): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/v1/organizations/${orgId}/agreement`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function params(orgId: string = ORG_ID) {
+  return { params: Promise.resolve({ orgId }) };
+}
+
+function setUser(id = USER_ID) {
+  mockGetClaims.mockResolvedValue({
+    data: { claims: { sub: id } },
+    error: null,
+  });
+}
+
+function setNoUser() {
+  mockGetClaims.mockResolvedValue({ data: { claims: null }, error: null });
+}
+
+function setOrgResult(data: unknown, error: unknown = null) {
+  (mockOrgBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setUpdateResult(data: unknown, error: unknown = null) {
+  (mockUpdateBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+}
+
+function setMembershipResult(count: number | null, error: unknown = null) {
+  (mockMembershipBuilder as Record<string, unknown>).then = (
+    onfulfilled: (v: unknown) => unknown,
+    onrejected?: (r: unknown) => unknown,
+  ) => Promise.resolve({ count, error }).then(onfulfilled, onrejected);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/organizations/[orgId]/agreement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setUser();
+    setMembershipResult(1);
+    mockHasOrgPermission.mockResolvedValue(true);
+    setOrgResult({
+      id: ORG_ID,
+      agreement_version: STALE_VERSION,
+      agreement_accepted_at: "2025-01-01T00:00:00Z",
+    });
+    setUpdateResult({
+      agreement_version: ORGANIZER_AGREEMENT_VERSION,
+      agreement_accepted_at: "2026-08-02T00:00:00Z",
+    });
+  });
+
+  // --- Validation -----------------------------------------------------------
+
+  it("returns 400 for a non-UUID organization id", async () => {
+    const res = await POST(makeRequest("not-a-uuid"), params("not-a-uuid"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when the body is not valid JSON", async () => {
+    const req = new NextRequest(
+      `http://localhost/api/v1/organizations/${ORG_ID}/agreement`,
+      { method: "POST", body: "not json" },
+    );
+    const res = await POST(req, params());
+    expect(res.status).toBe(400);
+  });
+
+  it.each([undefined, false, "true", 1])(
+    "returns 400 when agreement_accepted is %s",
+    async (agreement_accepted) => {
+      const res = await POST(
+        makeRequest(ORG_ID, { agreement_accepted }),
+        params(),
+      );
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.message).toMatch(/organizer agreement/i);
+    },
+  );
+
+  // --- Access control -------------------------------------------------------
+
+  it("returns 401 when unauthenticated", async () => {
+    setNoUser();
+    const res = await POST(makeRequest(), params());
+    expect(res.status).toBe(401);
+    expect((await res.json()).error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 404 when the organization does not exist", async () => {
+    setOrgResult(null, { code: "PGRST116", message: "No rows" });
+    const res = await POST(makeRequest(), params());
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 403 when the caller is not a member", async () => {
+    setMembershipResult(0);
+    const res = await POST(makeRequest(), params());
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.message).toMatch(/access denied/i);
+  });
+
+  it("returns 403 without the org.manage permission", async () => {
+    mockHasOrgPermission.mockResolvedValue(false);
+    const res = await POST(makeRequest(), params());
+    expect(res.status).toBe(403);
+    expect(mockHasOrgPermission).toHaveBeenCalledWith(
+      USER_ID,
+      ORG_ID,
+      "org.manage",
+    );
+  });
+
+  it("lets a pending organization accept a new version", async () => {
+    // A version bump must not strand an org that has not been approved yet —
+    // there is deliberately no approval_status gate on this route.
+    setOrgResult({
+      id: ORG_ID,
+      approval_status: "pending",
+      agreement_version: STALE_VERSION,
+      agreement_accepted_at: "2025-01-01T00:00:00Z",
+    });
+
+    const res = await POST(makeRequest(), params());
+    expect(res.status).toBe(200);
+  });
+
+  // --- Recording the acceptance ---------------------------------------------
+
+  it("records the current version, timestamp and acceptor", async () => {
+    const res = await POST(makeRequest(), params());
+    expect(res.status).toBe(200);
+
+    const updateMock = mockOrgBuilder.update as ReturnType<typeof vi.fn>;
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agreement_version: ORGANIZER_AGREEMENT_VERSION,
+        agreement_accepted_by: USER_ID,
+        agreement_accepted_at: expect.any(String),
+      }),
+    );
+
+    const json = await res.json();
+    expect(json.data.agreement_version).toBe(ORGANIZER_AGREEMENT_VERSION);
+  });
+
+  it("ignores an agreement version supplied in the request body", async () => {
+    await POST(
+      makeRequest(ORG_ID, {
+        agreement_accepted: true,
+        agreement_version: "1999-01-01",
+        agreement_accepted_by: "cccccccc-0000-0000-0000-000000000009",
+      }),
+      params(),
+    );
+
+    const updateMock = mockOrgBuilder.update as ReturnType<typeof vi.fn>;
+    const written = updateMock.mock.calls[0][0];
+    expect(written.agreement_version).toBe(ORGANIZER_AGREEMENT_VERSION);
+    expect(written.agreement_accepted_by).toBe(USER_ID);
+    expect(JSON.stringify(written)).not.toContain("1999-01-01");
+  });
+
+  it("is a no-op when the current version is already accepted", async () => {
+    // Re-accepting would only move the timestamp, and the timestamp is the
+    // evidence of when THIS version was agreed to.
+    setOrgResult({
+      id: ORG_ID,
+      agreement_version: ORGANIZER_AGREEMENT_VERSION,
+      agreement_accepted_at: "2026-08-02T09:00:00Z",
+    });
+
+    const res = await POST(makeRequest(), params());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.agreement_accepted_at).toBe("2026-08-02T09:00:00Z");
+    expect(mockOrgBuilder.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the update fails", async () => {
+    setUpdateResult(null, { message: "DB down" });
+    const res = await POST(makeRequest(), params());
+    expect(res.status).toBe(500);
+    expect((await res.json()).error.code).toBe("INTERNAL_ERROR");
+  });
+});

--- a/src/app/api/v1/organizations/[orgId]/agreement/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/agreement/route.ts
@@ -1,0 +1,162 @@
+import { supabaseAdmin } from "@/services/supabase/admin";
+import {
+  hasOrgPermission,
+  getAuthClaims,
+} from "@/services/supabase/permission";
+import { NextRequest, NextResponse } from "next/server";
+import { ORGANIZER_AGREEMENT_VERSION } from "@/lib/legal";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Records this organization's acceptance of the current Organizer Agreement.
+ *
+ * Bumping ORGANIZER_AGREEMENT_VERSION is how a new document is published: every
+ * organization whose stored version is older is then behind the re-acceptance
+ * gate, and the payout functions refuse to move money until it matches. This
+ * route is the only way out of that state.
+ *
+ * The version written is the server's constant. The request body carries a
+ * declaration of acceptance and nothing else — a client-supplied version would
+ * let an organization claim to have accepted a document it was never shown.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+): Promise<NextResponse> {
+  const { orgId } = await params;
+
+  if (!UUID_RE.test(orgId)) {
+    return NextResponse.json(
+      {
+        error: { code: "VALIDATION_ERROR", message: "Invalid organization ID" },
+      },
+      { status: 400 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body" } },
+      { status: 400 },
+    );
+  }
+
+  if (
+    !body ||
+    typeof body !== "object" ||
+    (body as Record<string, unknown>).agreement_accepted !== true
+  ) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "You must accept the Organizer Agreement",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const claims = await getAuthClaims();
+
+  if (!claims) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required" } },
+      { status: 401 },
+    );
+  }
+
+  const [
+    { data: org, error: orgError },
+    { count: memberCount, error: memberError },
+  ] = await Promise.all([
+    supabaseAdmin
+      .from("organizations")
+      .select("id, agreement_version, agreement_accepted_at")
+      .eq("id", orgId)
+      .is("deleted_at", null)
+      .single(),
+    supabaseAdmin
+      .from("organization_memberships")
+      .select("*", { count: "exact", head: true })
+      .eq("organization_id", orgId)
+      .eq("user_id", claims.id),
+  ]);
+
+  if (orgError) {
+    if (orgError.code === "PGRST116") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Organization not found" } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: orgError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (memberError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: memberError.message } },
+      { status: 500 },
+    );
+  }
+
+  if (!memberCount) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied" } },
+      { status: 403 },
+    );
+  }
+
+  // Deliberately no approval_status check, unlike the other org routes: a
+  // pending or rejected organization must still be able to accept a new version
+  // of the agreement, otherwise a version bump would strand it permanently.
+  const allowed = await hasOrgPermission(claims.id, orgId, "org.manage");
+  if (!allowed) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Insufficient permissions" } },
+      { status: 403 },
+    );
+  }
+
+  // Already on the current version — accepting again would only move the
+  // timestamp, and the timestamp is evidence of when this version was accepted.
+  if (org.agreement_version === ORGANIZER_AGREEMENT_VERSION) {
+    return NextResponse.json(
+      {
+        data: {
+          agreement_version: org.agreement_version,
+          agreement_accepted_at: org.agreement_accepted_at,
+        },
+      },
+      { status: 200 },
+    );
+  }
+
+  const { data: updated, error: updateError } = await supabaseAdmin
+    .from("organizations")
+    .update({
+      agreement_version: ORGANIZER_AGREEMENT_VERSION,
+      agreement_accepted_at: new Date().toISOString(),
+      agreement_accepted_by: claims.id,
+    })
+    .eq("id", orgId)
+    .select("agreement_version, agreement_accepted_at")
+    .single();
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: updateError.message } },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ data: updated }, { status: 200 });
+}

--- a/src/app/api/v1/organizations/[orgId]/dashboard/__tests__/route.test.ts
+++ b/src/app/api/v1/organizations/[orgId]/dashboard/__tests__/route.test.ts
@@ -119,6 +119,7 @@ const APPROVED_ORG = {
   id: ORG_ID,
   name: "KL Chess Association",
   approval_status: "approved",
+  agreement_version: "2026-08-02",
   created_by: USER_ID,
 };
 
@@ -380,6 +381,27 @@ describe("GET /api/v1/organizations/:orgId/dashboard", () => {
       expect(data.organization.id).toBe(ORG_ID);
       expect(data.organization.name).toBe("KL Chess Association");
       expect(data.organization.approval_status).toBe("approved");
+    });
+
+    it("exposes agreement_version so the dashboard can gate on it", async () => {
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.organization.agreement_version).toBe("2026-08-02");
+    });
+
+    it("passes through a null agreement_version rather than omitting it", async () => {
+      // An org that predates the agreement must reach the gate as "stale", not
+      // as "field missing" — those read the same to the component only because
+      // it normalises undefined, and relying on that is how gaps get missed.
+      setOrgResult({ ...APPROVED_ORG, agreement_version: null });
+
+      const res = await GET(makeRequest(), {
+        params: Promise.resolve({ orgId: ORG_ID }),
+      });
+      const { data } = await res.json();
+      expect(data.organization.agreement_version).toBeNull();
     });
 
     it("includes all four stats fields", async () => {

--- a/src/app/api/v1/organizations/[orgId]/dashboard/route.ts
+++ b/src/app/api/v1/organizations/[orgId]/dashboard/route.ts
@@ -55,7 +55,7 @@ export async function GET(
   ] = await Promise.all([
     supabaseAdmin
       .from("organizations")
-      .select("id, name, approval_status")
+      .select("id, name, approval_status, agreement_version")
       .eq("id", orgId)
       .is("deleted_at", null)
       .single(),
@@ -208,6 +208,10 @@ export async function GET(
           id: org.id,
           name: org.name,
           approval_status: org.approval_status,
+          // Drives the re-acceptance gate on the dashboard. NULL for
+          // organizations created before the agreement existed, which the gate
+          // treats the same as a stale version.
+          agreement_version: org.agreement_version,
         },
         stats: {
           active_tournaments: activeTournaments,

--- a/src/app/api/v1/organizations/applications/__tests__/route.test.ts
+++ b/src/app/api/v1/organizations/applications/__tests__/route.test.ts
@@ -55,6 +55,7 @@ vi.mock("next/headers", () => ({
 }));
 
 import { GET, POST } from "../route";
+import { ORGANIZER_AGREEMENT_VERSION } from "@/lib/legal";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -66,6 +67,7 @@ const ORG_ID = "bbbbbbbb-0000-0000-0000-000000000001";
 const VALID_BODY = {
   name: "KL Chess Association",
   email: "chess@klca.com",
+  agreement_accepted: true,
 };
 
 function makeOrg(overrides: Record<string, unknown> = {}) {
@@ -346,6 +348,19 @@ describe("POST /api/v1/organizations/applications", () => {
       const json = await res.json();
       expect(json.error.message).toMatch(/url/i);
     });
+
+    it.each([undefined, false, "true", 1])(
+      "returns 400 when agreement_accepted is %s",
+      async (agreement_accepted) => {
+        const res = await POST(
+          makePostRequest({ ...VALID_BODY, agreement_accepted }),
+        );
+        expect(res.status).toBe(400);
+        const json = await res.json();
+        expect(json.error.code).toBe("VALIDATION_ERROR");
+        expect(json.error.message).toMatch(/organizer agreement/i);
+      },
+    );
   });
 
   // -------------------------------------------------------------------------
@@ -417,9 +432,66 @@ describe("POST /api/v1/organizations/applications", () => {
         phone: "+60123456789",
         past_tournament_refs: "KL Open 2025",
         links: [{ label: "Facebook", url: "https://facebook.com/klchess" }],
+        agreement_accepted: true,
       };
       const res = await POST(makePostRequest(body));
       expect(res.status).toBe(201);
+    });
+
+    it("records the agreement version from the server constant", async () => {
+      let callIndex = 0;
+      (mockBuilder as Record<string, unknown>).then = (
+        onfulfilled: (v: unknown) => unknown,
+        onrejected?: (r: unknown) => unknown,
+      ) => {
+        const result =
+          callIndex++ === 0
+            ? { data: null, error: null }
+            : { data: makeOrg(), error: null };
+        return Promise.resolve(result).then(onfulfilled, onrejected);
+      };
+
+      await POST(makePostRequest());
+
+      const insertMock = mockBuilder.insert as ReturnType<typeof vi.fn>;
+      expect(insertMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agreement_version: ORGANIZER_AGREEMENT_VERSION,
+          agreement_accepted_by: appIdFor(USER_ID),
+          agreement_accepted_at: expect.any(String),
+        }),
+      );
+    });
+
+    it("ignores an agreement version supplied in the request body", async () => {
+      // The recorded version must name the document the platform served, so a
+      // body-supplied version can never reach the row.
+      let callIndex = 0;
+      (mockBuilder as Record<string, unknown>).then = (
+        onfulfilled: (v: unknown) => unknown,
+        onrejected?: (r: unknown) => unknown,
+      ) => {
+        const result =
+          callIndex++ === 0
+            ? { data: null, error: null }
+            : { data: makeOrg(), error: null };
+        return Promise.resolve(result).then(onfulfilled, onrejected);
+      };
+
+      await POST(
+        makePostRequest({
+          ...VALID_BODY,
+          agreement_version: "1999-01-01",
+          agreement_accepted_at: "1999-01-01T00:00:00Z",
+          agreement_accepted_by: "cccccccc-0000-0000-0000-000000000009",
+        }),
+      );
+
+      const insertMock = mockBuilder.insert as ReturnType<typeof vi.fn>;
+      const inserted = insertMock.mock.calls[0][0];
+      expect(inserted.agreement_version).toBe(ORGANIZER_AGREEMENT_VERSION);
+      expect(inserted.agreement_accepted_by).toBe(appIdFor(USER_ID));
+      expect(JSON.stringify(inserted)).not.toContain("1999-01-01");
     });
 
     it("returns 500 on an unexpected insert error", async () => {

--- a/src/app/api/v1/organizations/applications/route.ts
+++ b/src/app/api/v1/organizations/applications/route.ts
@@ -2,6 +2,7 @@ import { supabaseAdmin } from "@/services/supabase/admin";
 import { getAuthClaims } from "@/services/supabase/permission";
 import { NextRequest, NextResponse } from "next/server";
 import { validateApplyRequest } from "./validators";
+import { ORGANIZER_AGREEMENT_VERSION } from "@/lib/legal";
 
 export async function GET(_request: NextRequest): Promise<NextResponse> {
   const claims = await getAuthClaims();
@@ -94,6 +95,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       phone: body.phone ?? null,
       past_tournament_refs: body.past_tournament_refs ?? null,
       created_by: claims.id,
+      // Written from the server constant, never from the request — the point of
+      // recording a version is that it names the document the platform served.
+      agreement_version: ORGANIZER_AGREEMENT_VERSION,
+      agreement_accepted_at: new Date().toISOString(),
+      agreement_accepted_by: claims.id,
     })
     .select()
     .single();

--- a/src/app/api/v1/organizations/applications/validators.ts
+++ b/src/app/api/v1/organizations/applications/validators.ts
@@ -6,6 +6,11 @@ interface OrgLink {
   label: string;
 }
 
+// Deliberately no agreement_version field. The applicant declares that they
+// accept the Organizer Agreement; WHICH version that acceptance is recorded
+// against is decided by the server from src/lib/legal.ts. Because this shape is
+// what the route inserts, a version in the request body cannot reach the
+// database even by accident.
 export interface ApplyRequest {
   name: string;
   description?: string | null;
@@ -66,6 +71,22 @@ export function validateApplyRequest(
           error: {
             code: "VALIDATION_ERROR",
             message: "Invalid email address",
+          },
+        },
+        { status: 400 },
+      ),
+    };
+  }
+
+  // The agreement governs money movement and carries a claw-back obligation, so
+  // an application without an explicit acceptance is not an application.
+  if (b.agreement_accepted !== true) {
+    return {
+      error: NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "You must accept the Organizer Agreement",
           },
         },
         { status: 400 },

--- a/src/app/auth/signup/_components/PrivacyModal.tsx
+++ b/src/app/auth/signup/_components/PrivacyModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { TERMS_VERSION, formatLegalVersion } from "@/lib/legal";
 
 interface PrivacyModalProps {
   onClose: () => void;
@@ -50,7 +51,7 @@ export default function PrivacyModal({ onClose }: PrivacyModalProps) {
 
         <div className="modal-body">
           <p className="modal-paragraph">
-            <strong>Effective Date: 1 June 2025</strong>
+            <strong>Effective Date: {formatLegalVersion(TERMS_VERSION)}</strong>
           </p>
           <p className="modal-paragraph">
             MY Chess Tour (&quot;MCT&quot;, &quot;we&quot;, &quot;us&quot;, or
@@ -99,6 +100,22 @@ export default function PrivacyModal({ onClose }: PrivacyModalProps) {
             <li>Bank account number</li>
             <li>Bank account holder name</li>
             <li>Bank name</li>
+          </ul>
+
+          <p className="modal-paragraph">
+            <strong>Business Verification Data</strong> (organisers only)
+          </p>
+          <ul className="modal-list">
+            <li>
+              SSM or ROS registration documents, and supporting evidence of the
+              organisation&apos;s standing
+            </li>
+            <li>Registered business address and contact details</li>
+            <li>
+              Name and role of the authorised representative accepting the
+              Organizer Agreement
+            </li>
+            <li>Bank account details used to receive tournament payouts</li>
           </ul>
 
           <p className="modal-paragraph">
@@ -193,6 +210,10 @@ export default function PrivacyModal({ onClose }: PrivacyModalProps) {
                   facts retained for 7 years
                 </td>
               </tr>
+              <tr>
+                <td>Business verification documents (organisers)</td>
+                <td>7 years after the organiser relationship ends</td>
+              </tr>
             </tbody>
           </table>
 
@@ -203,15 +224,31 @@ export default function PrivacyModal({ onClose }: PrivacyModalProps) {
           </p>
           <ul className="modal-list">
             <li>
-              Sensitive personal data (OKU status, date of birth, gender) and
-              financial data (bank details) are encrypted at rest.
-            </li>
-            <li>
               All data is transmitted over encrypted connections (HTTPS/TLS).
             </li>
             <li>
-              Access to personal data is restricted to authorised personnel
-              only.
+              Our database and file storage are hosted on encrypted storage
+              volumes. We do not additionally encrypt individual fields such as
+              bank account numbers, and we would rather state that plainly than
+              overstate the protection.
+            </li>
+            <li>
+              Access is enforced at the database level by row-level security, so
+              one user&apos;s records are not readable by another.
+            </li>
+            <li>
+              Sensitive personal data (OKU status, date of birth, gender) and
+              financial data (bank details) are restricted to the specific
+              features that need them, and to authorised personnel.
+            </li>
+            <li>
+              Bank account numbers and document paths are masked in our internal
+              change logs, so historical copies of them are not retained there.
+            </li>
+            <li>
+              Verification documents are held in private storage that is not
+              publicly reachable, and are reviewed only by platform
+              administrators.
             </li>
           </ul>
 
@@ -263,10 +300,17 @@ export default function PrivacyModal({ onClose }: PrivacyModalProps) {
               rating for pairing and certification purposes.
             </li>
             <li>
-              <strong>Payment processors</strong> — for processing entry fees
-              and prize disbursements.
+              <strong>CHIP (chip-in.asia)</strong> — our licensed payment
+              processor, which receives the details needed to collect entry fees
+              and to disburse organiser payouts and prizes, including bank
+              account details.
             </li>
           </ul>
+          <p className="modal-paragraph">
+            Business verification documents are not shared with third parties.
+            They are reviewed by platform administrators and disclosed further
+            only where the law requires it.
+          </p>
 
           <h3 className="modal-section-title">8. Cookies</h3>
           <p className="modal-paragraph">

--- a/src/app/auth/signup/_components/SignUpForm.tsx
+++ b/src/app/auth/signup/_components/SignUpForm.tsx
@@ -52,6 +52,9 @@ export default function SignUpForm() {
           password: form.password,
           firstName: form.firstName,
           lastName: form.lastName,
+          // The consent itself has to reach the server — the version it is
+          // recorded against comes from the server's own constant, not from here.
+          termsAccepted: form.termsAccepted,
         }),
       });
       const data = await res.json();
@@ -93,7 +96,7 @@ export default function SignUpForm() {
 
           {hasErrors && (
             <div className="error-banner" role="alert">
-              <span className="text-sm shrink-0 mt-px">&#9888;</span>
+              <span className="mt-px shrink-0 text-sm">&#9888;</span>
               <p className="error-text">
                 Please correct the errors below before continuing.
               </p>
@@ -102,7 +105,7 @@ export default function SignUpForm() {
 
           {submitError && (
             <div className="error-banner" role="alert">
-              <span className="text-sm shrink-0 mt-px">&#9888;</span>
+              <span className="mt-px shrink-0 text-sm">&#9888;</span>
               <p className="error-text">{submitError}</p>
             </div>
           )}

--- a/src/app/auth/signup/_components/TermsModal.tsx
+++ b/src/app/auth/signup/_components/TermsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { TERMS_VERSION, formatLegalVersion } from "@/lib/legal";
 
 interface TermsModalProps {
   onClose: () => void;
@@ -50,7 +51,7 @@ export default function TermsModal({ onClose }: TermsModalProps) {
 
         <div className="modal-body">
           <p className="modal-paragraph">
-            <strong>Effective Date: 1 June 2025</strong>
+            <strong>Effective Date: {formatLegalVersion(TERMS_VERSION)}</strong>
           </p>
           <p className="modal-paragraph">
             Welcome to MY Chess Tour (&quot;MCT&quot;, &quot;we&quot;,
@@ -111,26 +112,54 @@ export default function TermsModal({ onClose }: TermsModalProps) {
           <h3 className="modal-section-title">4. Payment & Refund Policy</h3>
           <p className="modal-paragraph">
             Tournament entry fees are stated on the event page and are collected
-            by the tournament organiser. Refund eligibility is determined by the
-            organiser&apos;s policy for that event, which will be displayed
-            during registration. MY Chess Tour is not liable for any disputes
-            between players and organisers regarding refunds.
+            by MY Chess Tour on the organiser&apos;s behalf, then paid out to
+            them under our Organizer Agreement. Refund eligibility is determined
+            by the organiser&apos;s policy for that event, which is displayed
+            during registration.
           </p>
           <ul className="modal-list">
             <li>
-              Prize money disbursement is the sole responsibility of the
-              tournament organiser.
+              Your entry fee pays for the running of the event — venue,
+              arbiters, equipment and rating fees. It is not a stake, and no
+              part of it is paid out to another player as prize money.
             </li>
             <li>
-              MY Chess Tour may collect a platform service fee, which will be
-              disclosed at the time of registration.
+              Prize money is funded separately by the organiser, a sponsor or a
+              grant, and is distributed by the organiser — unless they have
+              appointed MY Chess Tour to distribute a fully funded prize pool
+              for that event.
+            </li>
+            <li>
+              MY Chess Tour collects a platform service fee of up to 10%. The
+              total you pay is always shown in full before you pay.
+            </li>
+            <li>
+              If an event is cancelled with our approval, every confirmed player
+              is refunded in full, including the service fee.
             </li>
             <li>
               All fees are in Malaysian Ringgit (MYR) unless stated otherwise.
             </li>
           </ul>
 
-          <h3 className="modal-section-title">5. Code of Conduct</h3>
+          <h3 className="modal-section-title">5. Organisers</h3>
+          <p className="modal-paragraph">
+            Organising tournaments on MY Chess Tour requires an approved
+            organization and acceptance of our{" "}
+            <a
+              href="/organizer-agreement"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="modal-trigger-link"
+            >
+              Organizer Agreement
+            </a>
+            , which governs commission, payout timing, refunds, prize funding
+            and liability. Nothing in that agreement reduces our obligations to
+            players under these Terms.
+          </p>
+
+          <h3 className="modal-section-title">6. Code of Conduct</h3>
           <p className="modal-paragraph">
             We are committed to a respectful and inclusive environment. All
             users must:
@@ -156,7 +185,7 @@ export default function TermsModal({ onClose }: TermsModalProps) {
             FIDE.
           </p>
 
-          <h3 className="modal-section-title">6. Intellectual Property</h3>
+          <h3 className="modal-section-title">7. Intellectual Property</h3>
           <p className="modal-paragraph">
             All content on the MY Chess Tour platform — including logos,
             graphics, software, and tournament data — is owned by or licensed to
@@ -164,7 +193,7 @@ export default function TermsModal({ onClose }: TermsModalProps) {
             without our written permission.
           </p>
 
-          <h3 className="modal-section-title">7. Limitation of Liability</h3>
+          <h3 className="modal-section-title">8. Limitation of Liability</h3>
           <p className="modal-paragraph">
             MY Chess Tour provides its platform on an &quot;as is&quot; basis.
             To the fullest extent permitted by Malaysian law, we are not liable
@@ -172,7 +201,7 @@ export default function TermsModal({ onClose }: TermsModalProps) {
             your use of the platform or participation in any event.
           </p>
 
-          <h3 className="modal-section-title">8. Amendments</h3>
+          <h3 className="modal-section-title">9. Amendments</h3>
           <p className="modal-paragraph">
             We may update these Terms from time to time. We will notify you of
             material changes via email or a prominent notice on the platform.
@@ -180,14 +209,14 @@ export default function TermsModal({ onClose }: TermsModalProps) {
             of the revised Terms.
           </p>
 
-          <h3 className="modal-section-title">9. Governing Law</h3>
+          <h3 className="modal-section-title">10. Governing Law</h3>
           <p className="modal-paragraph">
             These Terms are governed by the laws of Malaysia. Any disputes shall
             be subject to the exclusive jurisdiction of the courts of Kuala
             Lumpur, Malaysia.
           </p>
 
-          <h3 className="modal-section-title">10. Contact Us</h3>
+          <h3 className="modal-section-title">11. Contact Us</h3>
           <p className="modal-paragraph">
             For questions about these Terms, please contact us at{" "}
             <strong>support@mychesstour.com</strong>.

--- a/src/app/my/organizations/[orgId]/_components/AgreementGate.tsx
+++ b/src/app/my/organizations/[orgId]/_components/AgreementGate.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ORGANIZER_AGREEMENT_HISTORY,
+  ORGANIZER_AGREEMENT_VERSION,
+  changesSince,
+} from "@/lib/legal";
+
+interface Props {
+  organizationId: string;
+  /** What the organization last accepted. NULL = never accepted anything. */
+  agreementVersion: string | null;
+}
+
+/**
+ * Blocking notice shown when an organization is not on the current Organizer
+ * Agreement — either because the version was bumped or because the org predates
+ * the agreement entirely.
+ *
+ * It lives on the dashboard because that is the organizer's first screen; when
+ * the payouts page arrives it should move (or be rendered there too), since a
+ * stale agreement is exactly what stops a payout.
+ *
+ * Only an owner (org.manage) can accept. The API enforces that; here a failure
+ * simply surfaces the message, which for an admin reads as "ask your owner".
+ *
+ * The panel names what actually changed since the version this organization
+ * accepted, taken from ORGANIZER_AGREEMENT_HISTORY. Asking someone to re-accept
+ * a money-movement document without telling them what moved is how you get a
+ * reflexive tick, which is worth nothing when the claw-back clause is tested.
+ * An organization that skipped a version sees every version it missed.
+ */
+export default function AgreementGate({
+  organizationId,
+  agreementVersion,
+}: Props) {
+  const router = useRouter();
+  const [accepted, setAccepted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (agreementVersion === ORGANIZER_AGREEMENT_VERSION) return null;
+
+  const changes = changesSince(ORGANIZER_AGREEMENT_HISTORY, agreementVersion);
+
+  async function handleAccept() {
+    if (submitting || !accepted) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(
+        `/api/v1/organizations/${organizationId}/agreement`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agreement_accepted: true }),
+        },
+      );
+
+      if (!res.ok) {
+        const json = await res.json();
+        setError(
+          json.error?.message ?? "Could not record your acceptance. Try again.",
+        );
+        return;
+      }
+
+      router.refresh();
+    } catch {
+      setError("A network error occurred. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="agreement-gate-heading"
+      className="border-warning/40 bg-warning/10 mb-8 rounded-md border p-5"
+    >
+      <h2
+        id="agreement-gate-heading"
+        className="font-cinzel text-text-primary mb-2 text-base font-bold tracking-wide"
+      >
+        {agreementVersion
+          ? "The Organizer Agreement has been updated"
+          : "Accept the Organizer Agreement"}
+      </h2>
+
+      <p className="font-lato text-text-secondary mb-3 text-sm">
+        Version {ORGANIZER_AGREEMENT_VERSION} covers how entry fees are
+        collected, how and when payouts are made, and what you owe back if a
+        tournament is cancelled after you have been paid.{" "}
+        <strong className="text-text-primary">
+          Payouts are held until it is accepted.
+        </strong>
+      </p>
+
+      {changes.length > 0 && (
+        <div className="border-border bg-bg-sunken mb-4 rounded-md border p-4">
+          <p className="font-lato text-text-primary mb-2 text-sm font-semibold">
+            {agreementVersion
+              ? `What changed since version ${agreementVersion}`
+              : "What it covers"}
+          </p>
+          <ul className="font-lato text-text-secondary list-disc space-y-1 pl-5 text-sm">
+            {changes.map((change) => (
+              <li key={change}>{change}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="check-row">
+        <input
+          id="agreement-gate"
+          type="checkbox"
+          className="checkbox"
+          checked={accepted}
+          onChange={(e) => setAccepted(e.target.checked)}
+          aria-label="I have read and accept the Organizer Agreement"
+        />
+        <label className="check-label" htmlFor="agreement-gate">
+          I have read and accept the{" "}
+          <a
+            href="/organizer-agreement"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="modal-trigger-link"
+          >
+            Organizer Agreement
+          </a>{" "}
+          on behalf of this organization.
+        </label>
+      </div>
+
+      {error && (
+        <p className="font-lato text-error mt-2 text-sm" role="alert">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleAccept}
+        disabled={!accepted || submitting}
+        className="btn-primary mt-4 rounded-md"
+      >
+        {submitting ? "Recording…" : "Accept Agreement"}
+      </button>
+    </section>
+  );
+}

--- a/src/app/my/organizations/[orgId]/_components/DashboardClient.tsx
+++ b/src/app/my/organizations/[orgId]/_components/DashboardClient.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { formatCalendarDate } from "@/lib/datetime";
+import AgreementGate from "./AgreementGate";
 
 type TournamentStatus =
   | "draft"
@@ -27,7 +28,7 @@ interface Stats {
 }
 
 interface DashboardData {
-  organization: { id: string; name: string };
+  organization: { id: string; name: string; agreement_version?: string | null };
   stats: Stats;
   recent_tournaments: RecentTournament[];
 }
@@ -174,6 +175,12 @@ export default function DashboardClient({ data }: Props) {
           + Create
         </Link>
       </div>
+
+      {/* Agreement gate — renders nothing when the current version is accepted */}
+      <AgreementGate
+        organizationId={organization.id}
+        agreementVersion={organization.agreement_version ?? null}
+      />
 
       {/* Stats */}
       <div className="mb-8 grid grid-cols-2 gap-3">

--- a/src/app/my/organizations/[orgId]/_components/__tests__/AgreementGate.test.tsx
+++ b/src/app/my/organizations/[orgId]/_components/__tests__/AgreementGate.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  act,
+} from "@testing-library/react";
+import AgreementGate from "../AgreementGate";
+import {
+  ORGANIZER_AGREEMENT_HISTORY,
+  ORGANIZER_AGREEMENT_VERSION,
+  changesSince,
+} from "@/lib/legal";
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+const ORG_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+
+function renderGate(agreementVersion: string | null) {
+  return render(
+    <AgreementGate
+      organizationId={ORG_ID}
+      agreementVersion={agreementVersion}
+    />,
+  );
+}
+
+function getAcceptButton() {
+  return screen.getByRole("button", {
+    name: "Accept Agreement",
+  }) as HTMLButtonElement;
+}
+
+function tickCheckbox() {
+  fireEvent.click(
+    screen.getByLabelText("I have read and accept the Organizer Agreement"),
+  );
+}
+
+describe("AgreementGate", () => {
+  it("renders nothing when the current version is already accepted", () => {
+    const { container } = renderGate(ORGANIZER_AGREEMENT_VERSION);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("blocks when the stored version is stale", () => {
+    renderGate("2025-01-01");
+    expect(screen.getByText(/has been updated/i)).toBeDefined();
+  });
+
+  it("blocks when nothing has ever been accepted", () => {
+    // An organization that predates the agreement has accepted nothing, which
+    // is not the same message as "we changed it".
+    renderGate(null);
+    expect(screen.getByText("Accept the Organizer Agreement")).toBeDefined();
+  });
+
+  it("cannot be accepted without ticking the box", () => {
+    renderGate(null);
+    expect(getAcceptButton().disabled).toBe(true);
+
+    tickCheckbox();
+    expect(getAcceptButton().disabled).toBe(false);
+  });
+
+  it("says plainly that payouts are held until it is accepted", () => {
+    renderGate("2025-01-01");
+    expect(
+      screen.getByText(/Payouts are held until it is accepted/i),
+    ).toBeDefined();
+  });
+
+  it("lists what changed since the version the org accepted", () => {
+    // A re-acceptance prompt that doesn't say what moved buys a reflexive tick,
+    // which is worth nothing when the claw-back clause is tested.
+    renderGate("2025-01-01");
+
+    const expected = changesSince(ORGANIZER_AGREEMENT_HISTORY, "2025-01-01");
+    expect(expected.length).toBeGreaterThan(0);
+    for (const change of expected) {
+      expect(screen.getByText(change)).toBeDefined();
+    }
+    expect(
+      screen.getByText("What changed since version 2025-01-01"),
+    ).toBeDefined();
+  });
+
+  it("frames a first-time acceptance as 'what it covers'", () => {
+    renderGate(null);
+
+    expect(screen.getByText("What it covers")).toBeDefined();
+    expect(screen.queryByText(/What changed since/)).toBeNull();
+    const items = document.querySelectorAll("li");
+    expect(items).toHaveLength(
+      changesSince(ORGANIZER_AGREEMENT_HISTORY, null).length,
+    );
+  });
+
+  it("posts the acceptance and refreshes on success", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: vi.fn() });
+    renderGate("2025-01-01");
+    tickCheckbox();
+
+    await act(async () => {
+      fireEvent.click(getAcceptButton());
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      `/api/v1/organizations/${ORG_ID}/agreement`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ agreement_accepted: true });
+    expect(mockRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("never sends a version — the server decides that", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: vi.fn() });
+    renderGate("2025-01-01");
+    tickCheckbox();
+
+    await act(async () => {
+      fireEvent.click(getAcceptButton());
+    });
+
+    expect(mockFetch.mock.calls[0][1].body).not.toContain("version");
+  });
+
+  it("surfaces the API error and does not refresh", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: vi.fn().mockResolvedValue({
+        error: { message: "Insufficient permissions" },
+      }),
+    });
+    renderGate("2025-01-01");
+    tickCheckbox();
+
+    await act(async () => {
+      fireEvent.click(getAcceptButton());
+    });
+
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Insufficient permissions",
+    );
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a network failure", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+    renderGate("2025-01-01");
+    tickCheckbox();
+
+    await act(async () => {
+      fireEvent.click(getAcceptButton());
+    });
+
+    expect(screen.getByRole("alert").textContent).toMatch(/network error/i);
+    expect(getAcceptButton().disabled).toBe(false);
+  });
+
+  it("links to the agreement so it can be read before accepting", () => {
+    renderGate(null);
+    const link = screen.getByRole("link", { name: "Organizer Agreement" });
+    expect(link.getAttribute("href")).toBe("/organizer-agreement");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+});

--- a/src/app/my/organizations/[orgId]/page.tsx
+++ b/src/app/my/organizations/[orgId]/page.tsx
@@ -11,7 +11,12 @@ export const metadata: Metadata = {
 };
 
 interface DashboardData {
-  organization: { id: string; name: string; approval_status: string };
+  organization: {
+    id: string;
+    name: string;
+    approval_status: string;
+    agreement_version: string | null;
+  };
   stats: {
     active_tournaments: number;
     total_registrations: number;

--- a/src/app/my/organizations/__tests__/navigationLinks.test.tsx
+++ b/src/app/my/organizations/__tests__/navigationLinks.test.tsx
@@ -4,6 +4,12 @@ import * as React from "react";
 
 import { discoverRouteTemplates, isValidRoute } from "@/test/appRoutes";
 
+// DashboardClient renders the agreement gate, which is a client component using
+// useRouter. Static rendering has no app router mounted, so stub it.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
 // Render <Link> as a plain <a> so hrefs land in the static markup.
 vi.mock("next/link", () => ({
   default: ({
@@ -34,7 +40,13 @@ const ORG_ID = "org-1111-2222";
 const TOURNAMENT_ID = "tour-3333-4444";
 
 const dashboardData = {
-  organization: { id: ORG_ID, name: "Test Organization" },
+  // Deliberately stale, so the agreement gate renders and its /organizer-agreement
+  // link is included in the route check below.
+  organization: {
+    id: ORG_ID,
+    name: "Test Organization",
+    agreement_version: "2025-01-01",
+  },
   stats: {
     active_tournaments: 1,
     total_registrations: 0,

--- a/src/app/organizations/apply/_components/ApplyForm.tsx
+++ b/src/app/organizations/apply/_components/ApplyForm.tsx
@@ -33,6 +33,7 @@ export default function ApplyForm() {
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
   const [pastTournamentRefs, setPastTournamentRefs] = useState("");
+  const [agreementAccepted, setAgreementAccepted] = useState(false);
   const [status, setStatus] = useState<FormStatus>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingOrg, setPendingOrg] = useState<PendingOrg | null>(null);
@@ -87,6 +88,8 @@ export default function ApplyForm() {
           email: email.trim(),
           phone: phone.trim() || null,
           past_tournament_refs: pastTournamentRefs.trim() || null,
+          // The version this is recorded against is the server's, not ours.
+          agreement_accepted: agreementAccepted,
         }),
       });
 
@@ -280,6 +283,35 @@ export default function ApplyForm() {
           </p>
         </div>
 
+        {/* Organizer Agreement */}
+        <div className="check-row">
+          <input
+            id="agreement"
+            type="checkbox"
+            className="checkbox"
+            checked={agreementAccepted}
+            onChange={(e) => setAgreementAccepted(e.target.checked)}
+            aria-label="I have read and accept the Organizer Agreement"
+          />
+          <label className="check-label" htmlFor="agreement">
+            I have read and accept the{" "}
+            <a
+              href="/organizer-agreement"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="modal-trigger-link"
+            >
+              Organizer Agreement
+            </a>{" "}
+            on behalf of this organization.
+          </label>
+        </div>
+        <p className="font-lato text-text-muted -mt-3 text-xs">
+          It covers how entry fees are collected, how and when payouts are made,
+          and what happens if a tournament is cancelled after you have been
+          paid.
+        </p>
+
         {/* Error */}
         {status === "error" && errorMessage && (
           <p className="font-lato text-error text-center text-sm">
@@ -290,7 +322,7 @@ export default function ApplyForm() {
         {/* Submit */}
         <button
           type="submit"
-          disabled={status === "submitting"}
+          disabled={status === "submitting" || !agreementAccepted}
           className="btn-primary w-full rounded-md"
         >
           {status === "submitting" ? "Submitting…" : "Submit Application"}

--- a/src/app/organizations/apply/_components/__tests__/ApplyForm.test.tsx
+++ b/src/app/organizations/apply/_components/__tests__/ApplyForm.test.tsx
@@ -59,6 +59,16 @@ function getSubmitButton() {
   }) as HTMLButtonElement;
 }
 
+function getAgreementCheckbox() {
+  return screen.getByLabelText(
+    "I have read and accept the Organizer Agreement",
+  ) as HTMLInputElement;
+}
+
+function acceptAgreement() {
+  fireEvent.click(getAgreementCheckbox());
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -70,10 +80,21 @@ describe("ApplyForm", () => {
       expect(screen.getByText("Apply as Tournament Organizer")).toBeDefined();
     });
 
-    it("renders the submit button in idle state", () => {
+    it("cannot be submitted until the Organizer Agreement is accepted", () => {
+      // The agreement is what makes the payout terms and the claw-back binding,
+      // so it is a precondition of applying, not a footnote.
       render(<ApplyForm />);
-      expect(getSubmitButton()).toBeDefined();
+      expect(getSubmitButton().disabled).toBe(true);
+
+      acceptAgreement();
       expect(getSubmitButton().disabled).toBe(false);
+    });
+
+    it("links to the agreement so it can be read before accepting", () => {
+      render(<ApplyForm />);
+      const link = screen.getByRole("link", { name: "Organizer Agreement" });
+      expect(link.getAttribute("href")).toBe("/organizer-agreement");
+      expect(link.getAttribute("target")).toBe("_blank");
     });
 
     it("renders no link rows initially", () => {
@@ -243,6 +264,19 @@ describe("ApplyForm", () => {
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(body.links).toBeNull();
     });
+
+    it("sends the acceptance but never a version — the server decides that", async () => {
+      render(<ApplyForm />);
+      acceptAgreement();
+
+      await act(async () => {
+        fireEvent.submit(document.querySelector("form")!);
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.agreement_accepted).toBe(true);
+      expect(body).not.toHaveProperty("agreement_version");
+    });
   });
 
   describe("handleSubmit — error", () => {
@@ -289,6 +323,7 @@ describe("ApplyForm", () => {
     it("re-enables the submit button after an error", async () => {
       mockFetch.mockResolvedValueOnce(makeErrorFetch("Bad request"));
       render(<ApplyForm />);
+      acceptAgreement();
 
       await act(async () => {
         fireEvent.submit(document.querySelector("form")!);

--- a/src/app/organizer-agreement/page.tsx
+++ b/src/app/organizer-agreement/page.tsx
@@ -1,0 +1,384 @@
+import NavBar from "@/components/NavBar";
+import { ORGANIZER_AGREEMENT_VERSION, formatLegalVersion } from "@/lib/legal";
+
+export const metadata = {
+  title: "Organizer Agreement",
+  description:
+    "The agreement between MY Chess Tour and tournament organizers — entry fees, commission, payouts, refunds and liability.",
+};
+
+const H2 =
+  "font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3";
+const UL = "list-disc pl-5 space-y-1 text-text-secondary";
+
+export default function OrganizerAgreementPage() {
+  return (
+    <div className="bg-bg-base min-h-screen">
+      <NavBar />
+      <main className="mx-auto max-w-3xl px-6 py-16">
+        <div className="card card--featured p-8">
+          <div className="mb-8 text-center">
+            <span className="auth-logo">MY Chess Tour</span>
+            <h1 className="auth-heading">Organizer Agreement</h1>
+            <p className="auth-subheading">
+              Version {ORGANIZER_AGREEMENT_VERSION} — Effective{" "}
+              {formatLegalVersion(ORGANIZER_AGREEMENT_VERSION)}
+            </p>
+            <hr className="divider-gold" />
+          </div>
+
+          <div className="font-lato text-text-body space-y-6 text-sm leading-relaxed">
+            <p className="text-text-secondary">
+              This Agreement is between MY Chess Tour (&quot;MCT&quot;,
+              &quot;we&quot;, &quot;us&quot;) and the organization accepting it
+              (&quot;you&quot;, &quot;the organizer&quot;). It governs how entry
+              fees are collected on your behalf, what we deduct, when and how
+              you are paid, and what you owe back if a tournament does not go
+              ahead. It applies in addition to our Terms of Service and Privacy
+              Policy. Accepting it is a condition of listing a tournament and of
+              receiving any payout.
+            </p>
+
+            <section>
+              <h2 className={H2}>1. Nature of Entry Fees</h2>
+              <p className="text-text-secondary mb-2">
+                Entry fees collected through the platform are an{" "}
+                <strong>administration fee</strong> paid by each player in
+                exchange for you organizing the event — venue, arbiters,
+                equipment, staffing, and national or FIDE rating fees. They are
+                consideration for a service rendered.
+              </p>
+              <p className="text-text-secondary">
+                Entry fees are not a stake, a wager, or a contribution to a pool
+                that any competitor may win. They do not fund prizes, and no
+                portion of any player&apos;s entry fee is redistributed to
+                another player as winnings.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>2. Prize Funding</h2>
+              <p className="text-text-secondary mb-2">
+                Every prize you declare must be funded from a source outside the
+                entry fees. When you create a tournament you must name that
+                source for each prize:
+              </p>
+              <ul className={UL}>
+                <li>a sponsor;</li>
+                <li>a grant or government funding; or</li>
+                <li>your organization&apos;s own funds.</li>
+              </ul>
+              <p className="text-text-secondary mt-2">
+                You warrant that the source you declare is accurate and that the
+                money is or will be available. A tournament whose declared
+                prizes have no external source cannot be published. Misdeclaring
+                a funding source is a material breach of this Agreement.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>3. Commission and Fees</h2>
+              <p className="text-text-secondary mb-2">
+                MCT charges a platform commission of up to <strong>10%</strong>{" "}
+                of the entry fee you set. For each tournament you choose how
+                that commission is borne, by setting the share your organization
+                absorbs against the share added to the player&apos;s price:
+              </p>
+              <ul className={UL}>
+                <li>
+                  absorb none, and the full commission is added on top of your
+                  entry fee at checkout;
+                </li>
+                <li>
+                  absorb all of it, and the player pays exactly your entry fee
+                  while the commission is deducted from your revenue; or
+                </li>
+                <li>any split between the two.</li>
+              </ul>
+              <p className="text-text-secondary mt-2">
+                The price a player pays is always shown in full before they pay.
+                Payment processing charges levied by our payment processor are
+                borne by MCT out of the commission, except where a transfer
+                fails because of details you supplied (see clause 11).
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>4. Payout Schedule</h2>
+              <p className="text-text-secondary mb-2">
+                Your payout is your net revenue in full — entry fees collected,
+                less the commission, less any refunds issued. Prize money is
+                never deducted from it.
+              </p>
+              <ul className={UL}>
+                <li>
+                  Payouts are disbursed automatically{" "}
+                  <strong>
+                    three days after the tournament&apos;s final scheduled
+                    session
+                  </strong>
+                  , calculated in the venue&apos;s own timezone.
+                </li>
+                <li>
+                  Payouts are made in Malaysian Ringgit (MYR) only, to a
+                  verified bank account held in Malaysia.
+                </li>
+                <li>
+                  A payout is only released once the balance reaches a minimum
+                  of <strong>RM 10.00</strong>. Amounts below that are carried
+                  forward.
+                </li>
+                <li>
+                  A zero balance is a normal outcome, not an error — it means
+                  nothing is currently payable.
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className={H2}>5. Early Payouts</h2>
+              <p className="text-text-secondary mb-2">
+                You may request payment of part of your revenue before the
+                tournament ends. Early payouts are granted{" "}
+                <strong>at the platform&apos;s sole discretion</strong> and are
+                subject to all of the following:
+              </p>
+              <ul className={UL}>
+                <li>registration for the tournament must have closed;</li>
+                <li>
+                  the total advanced must not exceed <strong>50%</strong> of net
+                  revenue at the time of the request;
+                </li>
+                <li>
+                  at most <strong>two</strong> early payouts per tournament;
+                </li>
+                <li>
+                  no early payout is available where a third-party beneficiary
+                  has been nominated (clause 6); and
+                </li>
+                <li>
+                  no early payout is available while a cancellation request or
+                  an unresolved refund is outstanding.
+                </li>
+              </ul>
+              <p className="text-text-secondary mt-2">
+                A refused request is not a breach by us and creates no
+                entitlement to reasons.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>6. Nominating a Beneficiary</h2>
+              <p className="text-text-secondary">
+                You may nominate another organization approved on the platform
+                to receive the payout for a tournament in your place. The
+                nominated organization must be in good standing and hold a
+                verified bank account. Nominating a beneficiary changes only who
+                receives the money:{" "}
+                <strong>
+                  you remain fully liable under this Agreement regardless of who
+                  is paid
+                </strong>
+                , including for refunds, claw-back and any shortfall. Payment to
+                the beneficiary discharges our obligation to you in full, and
+                any dispute between you and the beneficiary is a matter between
+                you.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>7. Refunds and Cancellation</h2>
+              <p className="text-text-secondary mb-2">
+                Cancelling a published tournament requires our approval. Where a
+                cancellation is approved:
+              </p>
+              <ul className={UL}>
+                <li>
+                  every confirmed player is refunded{" "}
+                  <strong>in full, including commission</strong> — the player is
+                  made whole for everything they paid;
+                </li>
+                <li>
+                  your revenue for that tournament goes to zero, and no payout
+                  is made; and
+                </li>
+                <li>
+                  MCT does not retain its commission on a cancelled tournament.
+                </li>
+              </ul>
+              <p className="text-text-secondary mt-2">
+                Refunds to individual players outside a cancellation are
+                governed by the refund policy shown on your tournament page at
+                the time of registration.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>8. Claw-back of Advances</h2>
+              <p className="text-text-secondary">
+                An early payout is an{" "}
+                <strong>
+                  advance against revenue that has not yet been earned
+                </strong>
+                , not a final settlement. If the tournament is subsequently
+                cancelled, or refunds reduce your net revenue below the amount
+                already advanced, the difference becomes immediately repayable
+                by you on demand. We may recover it by deducting from payouts
+                due to you on any other tournament, by invoicing you directly,
+                or by both. This obligation survives termination of this
+                Agreement and applies regardless of whether a beneficiary
+                received the funds.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>9. Platform-Managed Prize Distribution</h2>
+              <p className="text-text-secondary mb-2">
+                By default you pay your winners directly and MCT is not
+                involved. You may instead appoint MCT to collect and distribute
+                the prize pool for a tournament. Where you do:
+              </p>
+              <ul className={UL}>
+                <li>
+                  the full declared prize pool must be paid to MCT and cleared{" "}
+                  <strong>before any winner is paid</strong>; a partially funded
+                  pool is not distributed;
+                </li>
+                <li>
+                  prize money is held separately from your entry-fee revenue and
+                  is never applied against your payouts, commission or
+                  claw-back;
+                </li>
+                <li>
+                  distribution follows the final results as certified by the
+                  tournament arbiter;
+                </li>
+                <li>
+                  a prize that remains unclaimed twelve months after the
+                  tournament ends is returned to the party that funded it, less
+                  any transfer costs; and
+                </li>
+                <li>
+                  if the tournament is cancelled before results are certified,
+                  the entire pool is returned to the funder.
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className={H2}>10. Changes to a Tournament</h2>
+              <p className="text-text-secondary mb-2">
+                Players commit money on the strength of what your listing says,
+                so a listing freezes in two stages:
+              </p>
+              <ul className={UL}>
+                <li>
+                  as soon as one player has paid, the{" "}
+                  <strong>money fields lock</strong> — entry fees, commission
+                  settings, and declared prizes can no longer be changed; and
+                </li>
+                <li>
+                  when the tournament starts,{" "}
+                  <strong>everything else locks</strong>.
+                </li>
+              </ul>
+              <p className="text-text-secondary mt-2">
+                A change that would materially disadvantage players who have
+                already paid — a different venue, a different date, a reduced
+                prize fund — must be handled as a cancellation and refund, not
+                as an edit.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>11. Bank Details and Verification</h2>
+              <p className="text-text-secondary mb-2">
+                You are responsible for the accuracy of the bank details you
+                provide, and for keeping them current.
+              </p>
+              <ul className={UL}>
+                <li>
+                  A transfer that fails, is delayed, or reaches the wrong
+                  recipient because of details you supplied is your cost, not
+                  ours, including any charge levied by the receiving bank.
+                </li>
+                <li>
+                  Business verification documents (SSM or ROS registration and
+                  supporting evidence) must be current, genuine, and
+                  legitimately yours. Submitting a false or altered document
+                  terminates this Agreement immediately.
+                </li>
+                <li>
+                  We may re-verify your organization or bank details at any time
+                  and may hold payouts while verification is outstanding.
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className={H2}>12. Payment Processor</h2>
+              <p className="text-text-secondary">
+                Collection from players and disbursement to you are performed by
+                CHIP (chip-in.asia), our licensed payment processor. Funds are
+                held by the processor, not by MCT, until disbursed. The
+                processor&apos;s own record of a transaction is authoritative as
+                to whether and when a payment or transfer occurred. Your use of
+                the platform is additionally subject to the processor&apos;s
+                terms where they apply to you.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>13. Withholding and Suspension</h2>
+              <p className="text-text-secondary mb-2">
+                We may withhold a payout, suspend your ability to publish
+                tournaments, or both, where:
+              </p>
+              <ul className={UL}>
+                <li>we reasonably suspect fraud or misrepresentation;</li>
+                <li>
+                  a player dispute, chargeback or refund claim is unresolved;
+                </li>
+                <li>
+                  business verification has failed, lapsed, or is under review;
+                </li>
+                <li>a repayable amount under clause 8 is outstanding; or</li>
+                <li>we are required to do so by law or by our processor.</li>
+              </ul>
+              <p className="text-text-secondary mt-2">
+                We will tell you why, and release the payout once the reason is
+                resolved. Withholding is not forfeiture: money that is properly
+                yours remains yours.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>14. Amendments and Re-acceptance</h2>
+              <p className="text-text-secondary">
+                This Agreement is versioned and dated. When we publish a new
+                version we will notify you, and your organization must accept it
+                before further payouts are released. Continuing to use the
+                platform does not by itself constitute acceptance of a new
+                version — an explicit acceptance is recorded against your
+                organization, together with the version, the time, and the
+                person who accepted it. Tournaments already published continue
+                to run under the terms of the version in force when they were
+                published.
+              </p>
+            </section>
+
+            <section>
+              <h2 className={H2}>15. Governing Law and Contact</h2>
+              <p className="text-text-secondary">
+                This Agreement is governed by the laws of Malaysia, and the
+                courts of Kuala Lumpur have exclusive jurisdiction over any
+                dispute arising from it. For questions about this Agreement,
+                contact us at <strong>support@mychesstour.com</strong>.
+              </p>
+            </section>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,5 @@
 import NavBar from "@/components/NavBar";
+import { TERMS_VERSION, formatLegalVersion } from "@/lib/legal";
 
 export const metadata = {
   title: "Privacy Policy",
@@ -8,18 +9,20 @@ export const metadata = {
 
 export default function PrivacyPage() {
   return (
-    <div className="min-h-screen bg-bg-base">
+    <div className="bg-bg-base min-h-screen">
       <NavBar />
-      <main className="max-w-3xl mx-auto px-6 py-16">
+      <main className="mx-auto max-w-3xl px-6 py-16">
         <div className="card card--featured p-8">
-          <div className="text-center mb-8">
+          <div className="mb-8 text-center">
             <span className="auth-logo">MY Chess Tour</span>
             <h1 className="auth-heading">Privacy Policy</h1>
-            <p className="auth-subheading">Effective Date: 1 June 2025</p>
+            <p className="auth-subheading">
+              Effective Date: {formatLegalVersion(TERMS_VERSION)}
+            </p>
             <hr className="divider-gold" />
           </div>
 
-          <div className="font-lato text-sm text-text-body leading-relaxed space-y-6">
+          <div className="font-lato text-text-body space-y-6 text-sm leading-relaxed">
             <p className="text-text-secondary">
               MY Chess Tour (&quot;MCT&quot;, &quot;we&quot;, &quot;us&quot;, or
               &quot;our&quot;) is committed to protecting your personal data in
@@ -30,13 +33,13 @@ export default function PrivacyPage() {
             </p>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 1. Data We Collect
               </h2>
               <p className="text-text-secondary mb-2 font-semibold">
                 Account Data
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-4">
+              <ul className="text-text-secondary mb-4 list-disc space-y-1 pl-5">
                 <li>First name, last name</li>
                 <li>Email address</li>
                 <li>Profile avatar</li>
@@ -45,7 +48,7 @@ export default function PrivacyPage() {
               <p className="text-text-secondary mb-2 font-semibold">
                 Player Profile Data
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-4">
+              <ul className="text-text-secondary mb-4 list-disc space-y-1 pl-5">
                 <li>Nationality</li>
                 <li>FIDE ID and MCF ID</li>
                 <li>
@@ -61,23 +64,39 @@ export default function PrivacyPage() {
               <p className="text-text-secondary mb-2 font-semibold">
                 Financial Data (collected only for prize payout purposes)
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-4">
+              <ul className="text-text-secondary mb-4 list-disc space-y-1 pl-5">
                 <li>Bank account number</li>
                 <li>Bank account holder name</li>
                 <li>Bank name</li>
               </ul>
 
               <p className="text-text-secondary mb-2 font-semibold">
+                Business Verification Data (organisers only)
+              </p>
+              <ul className="text-text-secondary mb-4 list-disc space-y-1 pl-5">
+                <li>
+                  SSM or ROS registration documents, and supporting evidence of
+                  the organisation&apos;s standing
+                </li>
+                <li>Registered business address and contact details</li>
+                <li>
+                  Name and role of the authorised representative accepting the
+                  Organizer Agreement
+                </li>
+                <li>Bank account details used to receive tournament payouts</li>
+              </ul>
+
+              <p className="text-text-secondary mb-2 font-semibold">
                 Tournament &amp; Registration Data
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+              <ul className="text-text-secondary list-disc space-y-1 pl-5">
                 <li>Tournament registration records</li>
                 <li>Payment records (amounts, dates, transaction IDs)</li>
               </ul>
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 2. Sensitive Personal Data
               </h2>
               <p className="text-text-secondary mb-3">
@@ -88,34 +107,34 @@ export default function PrivacyPage() {
                 <table className="w-full border-collapse text-xs">
                   <thead>
                     <tr>
-                      <th className="font-cinzel tracking-widest uppercase text-gold-muted text-left px-3 py-2 border-b border-border">
+                      <th className="font-cinzel text-gold-muted border-border border-b px-3 py-2 text-left tracking-widest uppercase">
                         Data Field
                       </th>
-                      <th className="font-cinzel tracking-widest uppercase text-gold-muted text-left px-3 py-2 border-b border-border">
+                      <th className="font-cinzel text-gold-muted border-border border-b px-3 py-2 text-left tracking-widest uppercase">
                         Reason for Collection
                       </th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         OKU (disability) status
                       </td>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         Event accessibility and FIDE Special Needs registration
                       </td>
                     </tr>
                     <tr>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         Date of birth
                       </td>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         Age-category eligibility; identity verification
                       </td>
                     </tr>
                     <tr>
-                      <td className="px-3 py-2 text-text-secondary">Gender</td>
-                      <td className="px-3 py-2 text-text-secondary">
+                      <td className="text-text-secondary px-3 py-2">Gender</td>
+                      <td className="text-text-secondary px-3 py-2">
                         Gender-restricted event categories (e.g. Women&apos;s
                         Open)
                       </td>
@@ -130,10 +149,10 @@ export default function PrivacyPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 3. How We Use Your Data
               </h2>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-2">
+              <ul className="text-text-secondary mb-2 list-disc space-y-1 pl-5">
                 <li>To create and manage your MCT account.</li>
                 <li>To register you for tournaments and verify eligibility.</li>
                 <li>To submit ratings to FIDE and MCF on your behalf.</li>
@@ -151,7 +170,7 @@ export default function PrivacyPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 4. Data Retention
               </h2>
               <p className="text-text-secondary mb-3">
@@ -161,47 +180,55 @@ export default function PrivacyPage() {
                 <table className="w-full border-collapse text-xs">
                   <thead>
                     <tr>
-                      <th className="font-cinzel tracking-widest uppercase text-gold-muted text-left px-3 py-2 border-b border-border">
+                      <th className="font-cinzel text-gold-muted border-border border-b px-3 py-2 text-left tracking-widest uppercase">
                         Data Type
                       </th>
-                      <th className="font-cinzel tracking-widest uppercase text-gold-muted text-left px-3 py-2 border-b border-border">
+                      <th className="font-cinzel text-gold-muted border-border border-b px-3 py-2 text-left tracking-widest uppercase">
                         Retention Period
                       </th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         Personal profile data
                       </td>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         30 days after account deletion request
                       </td>
                     </tr>
                     <tr>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         Financial / payment records
                       </td>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         7 years from transaction date (Income Tax Act
                         requirement)
                       </td>
                     </tr>
                     <tr>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         Tournament results &amp; pairings
                       </td>
-                      <td className="px-3 py-2 border-b border-border text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         Kept indefinitely (not personal data)
                       </td>
                     </tr>
                     <tr>
-                      <td className="px-3 py-2 text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         Registration records
                       </td>
-                      <td className="px-3 py-2 text-text-secondary">
+                      <td className="border-border text-text-secondary border-b px-3 py-2">
                         Personal fields anonymised after account deletion;
                         financial facts retained for 7 years
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="text-text-secondary px-3 py-2">
+                        Business verification documents (organisers)
+                      </td>
+                      <td className="text-text-secondary px-3 py-2">
+                        7 years after the organiser relationship ends
                       </td>
                     </tr>
                   </tbody>
@@ -210,37 +237,55 @@ export default function PrivacyPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 5. Data Security
               </h2>
               <p className="text-text-secondary mb-2">
                 We implement appropriate technical and organisational measures
                 to protect your data:
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
-                <li>
-                  Sensitive personal data (OKU status, date of birth, gender)
-                  and financial data (bank details) are encrypted at rest.
-                </li>
+              <ul className="text-text-secondary list-disc space-y-1 pl-5">
                 <li>
                   All data is transmitted over encrypted connections
                   (HTTPS/TLS).
                 </li>
                 <li>
-                  Access to personal data is restricted to authorised personnel
-                  only.
+                  Our database and file storage are hosted on encrypted storage
+                  volumes. We do not additionally encrypt individual fields such
+                  as bank account numbers, and we would rather state that
+                  plainly than overstate the protection.
+                </li>
+                <li>
+                  Access is enforced at the database level by row-level
+                  security, so one user&apos;s records are not readable by
+                  another.
+                </li>
+                <li>
+                  Sensitive personal data (OKU status, date of birth, gender)
+                  and financial data (bank details) are restricted to the
+                  specific features that need them, and to authorised personnel.
+                </li>
+                <li>
+                  Bank account numbers and document paths are masked in our
+                  internal change logs, so historical copies of them are not
+                  retained there.
+                </li>
+                <li>
+                  Verification documents are held in private storage that is not
+                  publicly reachable, and are reviewed only by platform
+                  administrators.
                 </li>
               </ul>
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 6. Your Rights Under PDPA
               </h2>
               <p className="text-text-secondary mb-2">
                 As a data subject under the PDPA, you have the right to:
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary mb-2">
+              <ul className="text-text-secondary mb-2 list-disc space-y-1 pl-5">
                 <li>
                   <strong>Access</strong> — request a copy of the personal data
                   we hold about you.
@@ -268,14 +313,14 @@ export default function PrivacyPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 7. Sharing of Data
               </h2>
               <p className="text-text-secondary mb-2">
                 We may share your data with the following third parties only
                 where necessary:
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+              <ul className="text-text-secondary list-disc space-y-1 pl-5">
                 <li>
                   <strong>FIDE</strong> — for rating submission and player
                   registration.
@@ -289,14 +334,21 @@ export default function PrivacyPage() {
                   and rating for pairing and certification purposes.
                 </li>
                 <li>
-                  <strong>Payment processors</strong> — for processing entry
-                  fees and prize disbursements.
+                  <strong>CHIP (chip-in.asia)</strong> — our licensed payment
+                  processor, which receives the details needed to collect entry
+                  fees and to disburse organiser payouts and prizes, including
+                  bank account details.
                 </li>
               </ul>
+              <p className="text-text-secondary mt-2">
+                Business verification documents are not shared with third
+                parties. They are reviewed by platform administrators and
+                disclosed further only where the law requires it.
+              </p>
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 8. Cookies
               </h2>
               <p className="text-text-secondary">
@@ -306,7 +358,7 @@ export default function PrivacyPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 9. Changes to This Policy
               </h2>
               <p className="text-text-secondary">
@@ -317,7 +369,7 @@ export default function PrivacyPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 10. Contact Us
               </h2>
               <p className="text-text-secondary">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,4 +1,5 @@
 import NavBar from "@/components/NavBar";
+import { TERMS_VERSION, formatLegalVersion } from "@/lib/legal";
 
 export const metadata = {
   title: "Terms of Service",
@@ -8,18 +9,20 @@ export const metadata = {
 
 export default function TermsPage() {
   return (
-    <div className="min-h-screen bg-bg-base">
+    <div className="bg-bg-base min-h-screen">
       <NavBar />
-      <main className="max-w-3xl mx-auto px-6 py-16">
+      <main className="mx-auto max-w-3xl px-6 py-16">
         <div className="card card--featured p-8">
-          <div className="text-center mb-8">
+          <div className="mb-8 text-center">
             <span className="auth-logo">MY Chess Tour</span>
             <h1 className="auth-heading">Terms of Service</h1>
-            <p className="auth-subheading">Effective Date: 1 June 2025</p>
+            <p className="auth-subheading">
+              Effective Date: {formatLegalVersion(TERMS_VERSION)}
+            </p>
             <hr className="divider-gold" />
           </div>
 
-          <div className="font-lato text-sm text-text-body leading-relaxed space-y-6">
+          <div className="font-lato text-text-body space-y-6 text-sm leading-relaxed">
             <p className="text-text-secondary">
               Welcome to MY Chess Tour (&quot;MCT&quot;, &quot;we&quot;,
               &quot;us&quot;, or &quot;our&quot;). These Terms of Service govern
@@ -28,7 +31,7 @@ export default function TermsPage() {
             </p>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 1. Acceptance of Terms
               </h2>
               <p className="text-text-secondary">
@@ -41,7 +44,7 @@ export default function TermsPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 2. Account Registration
               </h2>
               <p className="text-text-secondary mb-2">
@@ -50,7 +53,7 @@ export default function TermsPage() {
                 national identity card (MyKad) or passport, as it is used for
                 official tournament records and FIDE/MCF registration.
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+              <ul className="text-text-secondary list-disc space-y-1 pl-5">
                 <li>
                   You are responsible for maintaining the security of your
                   account.
@@ -67,7 +70,7 @@ export default function TermsPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 3. Tournament Participation
               </h2>
               <p className="text-text-secondary mb-2">
@@ -76,7 +79,7 @@ export default function TermsPage() {
                 tournament arbiter. By registering for a tournament, you agree
                 to:
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+              <ul className="text-text-secondary list-disc space-y-1 pl-5">
                 <li>
                   Abide by all rules and decisions made by the chief arbiter.
                 </li>
@@ -96,25 +99,35 @@ export default function TermsPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
                 4. Payment &amp; Refund Policy
               </h2>
               <p className="text-text-secondary mb-2">
                 Tournament entry fees are stated on the event page and are
-                collected by the tournament organiser. Refund eligibility is
-                determined by the organiser&apos;s policy for that event, which
-                will be displayed during registration. MY Chess Tour is not
-                liable for any disputes between players and organisers regarding
-                refunds.
+                collected by MY Chess Tour on the organiser&apos;s behalf, then
+                paid out to them under our Organizer Agreement. Refund
+                eligibility is determined by the organiser&apos;s policy for
+                that event, which is displayed during registration.
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+              <ul className="text-text-secondary list-disc space-y-1 pl-5">
                 <li>
-                  Prize money disbursement is the sole responsibility of the
-                  tournament organiser.
+                  Your entry fee pays for the running of the event — venue,
+                  arbiters, equipment and rating fees. It is not a stake, and no
+                  part of it is paid out to another player as prize money.
                 </li>
                 <li>
-                  MY Chess Tour may collect a platform service fee, which will
-                  be disclosed at the time of registration.
+                  Prize money is funded separately by the organiser, a sponsor
+                  or a grant, and is distributed by the organiser — unless they
+                  have appointed MY Chess Tour to distribute a fully funded
+                  prize pool for that event.
+                </li>
+                <li>
+                  MY Chess Tour collects a platform service fee of up to 10%.
+                  The total you pay is always shown in full before you pay.
+                </li>
+                <li>
+                  If an event is cancelled with our approval, every confirmed
+                  player is refunded in full, including the service fee.
                 </li>
                 <li>
                   All fees are in Malaysian Ringgit (MYR) unless stated
@@ -124,14 +137,36 @@ export default function TermsPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
-                5. Code of Conduct
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
+                5. Organisers
+              </h2>
+              <p className="text-text-secondary mb-2">
+                Organising tournaments on MY Chess Tour requires an approved
+                organization and acceptance of our{" "}
+                <a href="/organizer-agreement" className="modal-trigger-link">
+                  Organizer Agreement
+                </a>
+                , which governs commission, payout timing, refunds, prize
+                funding and liability. That agreement is versioned; when a new
+                version is published, organisers must accept it before further
+                payouts are released.
+              </p>
+              <p className="text-text-secondary">
+                Nothing in the Organizer Agreement reduces our obligations to
+                players under these Terms. Where the two conflict as they apply
+                to a player, these Terms prevail.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
+                6. Code of Conduct
               </h2>
               <p className="text-text-secondary mb-2">
                 We are committed to a respectful and inclusive environment. All
                 users must:
               </p>
-              <ul className="list-disc pl-5 space-y-1 text-text-secondary">
+              <ul className="text-text-secondary list-disc space-y-1 pl-5">
                 <li>
                   Treat fellow players, organisers, and arbiters with respect.
                 </li>
@@ -156,8 +191,8 @@ export default function TermsPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
-                6. Intellectual Property
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
+                7. Intellectual Property
               </h2>
               <p className="text-text-secondary">
                 All content on the MY Chess Tour platform — including logos,
@@ -168,8 +203,8 @@ export default function TermsPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
-                7. Limitation of Liability
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
+                8. Limitation of Liability
               </h2>
               <p className="text-text-secondary">
                 MY Chess Tour provides its platform on an &quot;as is&quot;
@@ -181,8 +216,8 @@ export default function TermsPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
-                8. Amendments
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
+                9. Amendments
               </h2>
               <p className="text-text-secondary">
                 We may update these Terms from time to time. We will notify you
@@ -193,8 +228,8 @@ export default function TermsPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
-                9. Governing Law
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
+                10. Governing Law
               </h2>
               <p className="text-text-secondary">
                 These Terms are governed by the laws of Malaysia. Any disputes
@@ -204,8 +239,8 @@ export default function TermsPage() {
             </section>
 
             <section>
-              <h2 className="font-cinzel text-sm font-semibold tracking-widest uppercase text-gold-muted mb-3">
-                10. Contact Us
+              <h2 className="font-cinzel text-gold-muted mb-3 text-sm font-semibold tracking-widest uppercase">
+                11. Contact Us
               </h2>
               <p className="text-text-secondary">
                 For questions about these Terms, please contact us at{" "}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -28,6 +28,9 @@ export default function Footer() {
               <Link href="/privacy" className="footer-link">
                 Privacy Policy
               </Link>
+              <Link href="/organizer-agreement" className="footer-link">
+                Organizer Agreement
+              </Link>
             </nav>
           </div>
 

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -49,6 +49,12 @@ describe("Footer", () => {
     expect(html).toContain("Privacy Policy");
   });
 
+  it("renders the Organizer Agreement link", () => {
+    const html = renderToStaticMarkup(<Footer />);
+    expect(html).toContain('href="/organizer-agreement"');
+    expect(html).toContain("Organizer Agreement");
+  });
+
   it("renders the Facebook social link", () => {
     const html = renderToStaticMarkup(<Footer />);
     expect(html).toContain("facebook.com/mychesstour");

--- a/src/lib/__tests__/legal.test.ts
+++ b/src/lib/__tests__/legal.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import {
+  ORGANIZER_AGREEMENT_HISTORY,
+  ORGANIZER_AGREEMENT_VERSION,
+  TERMS_HISTORY,
+  TERMS_VERSION,
+  changesSince,
+  formatLegalVersion,
+} from "../legal";
+
+const VERSIONS = {
+  TERMS_VERSION,
+  ORGANIZER_AGREEMENT_VERSION,
+};
+
+const HISTORIES = {
+  TERMS_HISTORY,
+  ORGANIZER_AGREEMENT_HISTORY,
+};
+
+describe("legal version constants", () => {
+  it.each(Object.entries(VERSIONS))("%s is date-shaped", (_name, version) => {
+    // The value is written verbatim into a varchar(20) column and compared for
+    // equality to decide whether a payout may proceed, so its shape is a
+    // contract, not cosmetics.
+    expect(version).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it.each(Object.entries(VERSIONS))(
+    "%s fits the varchar(20) column",
+    (_name, version) => {
+      expect(version.length).toBeGreaterThan(0);
+      expect(version.length).toBeLessThanOrEqual(20);
+    },
+  );
+
+  it.each(Object.entries(VERSIONS))(
+    "%s is a real calendar date",
+    (_name, version) => {
+      const [year, month, day] = version.split("-").map(Number);
+      const parsed = new Date(Date.UTC(year, month - 1, day));
+      expect(parsed.getUTCFullYear()).toBe(year);
+      expect(parsed.getUTCMonth()).toBe(month - 1);
+      expect(parsed.getUTCDate()).toBe(day);
+    },
+  );
+});
+
+describe("formatLegalVersion", () => {
+  it("renders a version as the date shown under a document title", () => {
+    expect(formatLegalVersion("2026-08-02")).toBe("2 August 2026");
+    expect(formatLegalVersion("2025-06-01")).toBe("1 June 2025");
+    expect(formatLegalVersion("2026-12-25")).toBe("25 December 2026");
+  });
+
+  it("does not shift the day (calendar date, not an instant)", () => {
+    // Parsing "2026-01-01" into a Date and formatting it in a negative-offset
+    // zone would print 31 December. These are calendar dates and must not move.
+    expect(formatLegalVersion("2026-01-01")).toBe("1 January 2026");
+    expect(formatLegalVersion("2026-12-31")).toBe("31 December 2026");
+  });
+
+  it("renders both live constants without falling back", () => {
+    for (const version of Object.values(VERSIONS)) {
+      expect(formatLegalVersion(version)).not.toBe(version);
+    }
+  });
+
+  it("returns malformed input unchanged rather than throwing", () => {
+    // A bad constant should surface as odd text on the page, never as a render
+    // crash on a document users are required to read.
+    expect(formatLegalVersion("v1.2.3")).toBe("v1.2.3");
+    expect(formatLegalVersion("")).toBe("");
+    expect(formatLegalVersion("2026-13-02")).toBe("2026-13-02");
+  });
+});
+
+describe("version histories", () => {
+  it.each(Object.entries(HISTORIES))("%s is newest first", (_name, history) => {
+    // changesSince relies on string comparison of ISO dates and on entry 0
+    // being current. An out-of-order history would silently send the wrong
+    // changelog to everyone.
+    const versions = history.map((entry) => entry.version);
+    const sorted = [...versions].sort().reverse();
+    expect(versions).toEqual(sorted);
+  });
+
+  it.each(Object.entries(HISTORIES))(
+    "%s has no duplicate versions",
+    (_name, history) => {
+      const versions = history.map((entry) => entry.version);
+      expect(new Set(versions).size).toBe(versions.length);
+    },
+  );
+
+  it.each(Object.entries(HISTORIES))(
+    "%s describes every version",
+    (_name, history) => {
+      for (const entry of history) {
+        expect(entry.version).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(entry.changes.length).toBeGreaterThan(0);
+        for (const change of entry.changes) {
+          expect(change.trim().length).toBeGreaterThan(0);
+        }
+      }
+    },
+  );
+
+  it("derives the current version from the newest entry", () => {
+    expect(TERMS_VERSION).toBe(TERMS_HISTORY[0].version);
+    expect(ORGANIZER_AGREEMENT_VERSION).toBe(
+      ORGANIZER_AGREEMENT_HISTORY[0].version,
+    );
+  });
+});
+
+describe("changesSince", () => {
+  const HISTORY = [
+    { version: "2026-08-02", changes: ["c3a", "c3b"] },
+    { version: "2026-03-01", changes: ["c2"] },
+    { version: "2025-06-01", changes: ["c1"] },
+  ];
+
+  it("returns nothing for a reader already on the current version", () => {
+    expect(changesSince(HISTORY, "2026-08-02")).toEqual([]);
+  });
+
+  it("covers every version a reader skipped, not just the latest", () => {
+    // The whole reason the history exists: someone two versions behind must be
+    // told about both, and a single-release summary would be wrong for them.
+    expect(changesSince(HISTORY, "2025-06-01")).toEqual(["c3a", "c3b", "c2"]);
+  });
+
+  it("returns the whole history when no version was ever accepted", () => {
+    expect(changesSince(HISTORY, null)).toEqual(["c3a", "c3b", "c2", "c1"]);
+  });
+
+  it("treats an unknown older version as behind everything after it", () => {
+    expect(changesSince(HISTORY, "2020-01-01")).toEqual([
+      "c3a",
+      "c3b",
+      "c2",
+      "c1",
+    ]);
+  });
+
+  it("orders changes newest first", () => {
+    const [first] = changesSince(HISTORY, "2025-06-01");
+    expect(first).toBe("c3a");
+  });
+
+  it("works on the real histories without throwing", () => {
+    expect(changesSince(TERMS_HISTORY, TERMS_VERSION)).toEqual([]);
+    expect(changesSince(TERMS_HISTORY, null).length).toBeGreaterThan(0);
+    expect(
+      changesSince(ORGANIZER_AGREEMENT_HISTORY, ORGANIZER_AGREEMENT_VERSION),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/legal.ts
+++ b/src/lib/legal.ts
@@ -1,0 +1,165 @@
+// The versions of the documents a user or an organization can be bound by, and
+// the one place that decides what "current" means.
+//
+// Acceptance used to be a checkbox and nothing else: the signup form validated
+// termsAccepted client-side and threw it away, so there was no record that
+// anyone had agreed to anything and no version pinned to the agreement they saw.
+// Tolerable for a free signup; not for a document that governs money movement
+// and makes a claw-back enforceable.
+//
+// Every legal surface renders its effective date from the same constant that
+// gets written to the database, so the rendered document and the recorded
+// version cannot drift apart. Before this module the date was a hardcoded
+// literal in four files, which is exactly the drift this prevents.
+//
+// Bumping a constant IS the re-acceptance mechanism. An organization whose
+// agreement_version is older than ORGANIZER_AGREEMENT_VERSION is shown a
+// blocking panel, and the payout machinery (Phases 5-6) refuses to move money
+// until it matches — a stale agreement stops a payout rather than failing
+// silently.
+//
+// The values are date-stamped rather than semver: a legal document has an
+// effective date, not a feature level, and "which wording did they agree to?"
+// is answered by a date. varchar(20) in the schema; ISO first so string
+// comparison and chronological order agree.
+//
+// Each document is a HISTORY, not a bare constant, and the current version is
+// derived from the newest entry so the two cannot disagree. The history exists
+// because "what changed?" is a question about the gap between the version
+// someone accepted and the current one — not about whatever the last release
+// happened to touch. A notice that hardcodes one release's changes is wrong for
+// everyone who skipped a version, and silently rots the moment the next version
+// ships.
+//
+// Both documents are at their FIRST version. Nothing has been published, so
+// there is no earlier wording anyone could have agreed to and nothing to diff
+// against — the entries below summarise what each document says, which is the
+// honest answer to the only question a reader can have today. The second entry
+// added to either list is a delta against the one before it.
+
+export interface LegalVersion {
+  /** Effective date, ISO. This is the value stored in the database. */
+  version: string;
+  /**
+   * Written for the person who has to read it, not as a commit log.
+   *
+   * The FIRST version of a document summarises what the document says, because
+   * there is nothing to compare it to. Every version after it lists what that
+   * version changed relative to the one before.
+   */
+  changes: readonly string[];
+}
+
+/**
+ * Terms of Service, newest first. Accepted at signup; stored on
+ * users.terms_version.
+ */
+export const TERMS_HISTORY: readonly LegalVersion[] = [
+  {
+    version: "2026-08-02",
+    changes: [
+      "You must be at least 13 years old, or have a parent's consent, and your name must match your MyKad or passport — it is used for official tournament records and FIDE/MCF registration.",
+      "Tournaments follow the FIDE Laws of Chess. You agree to abide by the arbiter's decisions, to compete without computer assistance, and to accept results as final unless you appeal within the time the arbiter sets.",
+      "Entry fees are collected by MY Chess Tour on the organiser's behalf and paid out to them under a written Organizer Agreement.",
+      "Your entry fee pays for running the event — venue, arbiters, equipment and rating fees. It is not a stake, and no part of it is paid out to another player as prize money. Prize money is funded separately by the organiser, a sponsor or a grant.",
+      "MY Chess Tour collects a platform service fee of up to 10%. The total you pay is always shown in full before you pay, in Malaysian Ringgit.",
+      "If an event is cancelled with our approval, every confirmed player is refunded in full, including the service fee. Refunds outside a cancellation follow the organiser's policy shown at registration.",
+      "Organising tournaments requires an approved organization and acceptance of the versioned Organizer Agreement. Nothing in that agreement reduces our obligations to players.",
+      "A code of conduct covering respect, harassment, cheating and rating manipulation, enforced by suspension, disqualification, or reporting to the MCF and FIDE.",
+      "Platform content is ours or licensed to us, liability is limited as far as Malaysian law permits, and disputes are governed by Malaysian law in the courts of Kuala Lumpur.",
+      "Privacy Policy: what we collect (account, player profile, financial, business verification and tournament data), how long we keep it, and your rights under the PDPA.",
+      "Privacy Policy: how your data is protected. It is transmitted over HTTPS, held on encrypted storage with row-level access control, and bank numbers are masked in our change logs — but individual fields are not separately encrypted, and we would rather say so plainly than overstate it.",
+      "Privacy Policy: who your data is shared with — FIDE and the MCF for rating and registration, organisers for pairing, and CHIP as our payment processor. Business verification documents are not shared with third parties.",
+    ],
+  },
+];
+
+/**
+ * Organizer Agreement, newest first. Accepted when applying to organize and
+ * again whenever a new version is published; stored on
+ * organizations.agreement_version.
+ */
+export const ORGANIZER_AGREEMENT_HISTORY: readonly LegalVersion[] = [
+  {
+    version: "2026-08-02",
+    changes: [
+      "Entry fees are an administration fee for running the event. They never fund prizes, and every declared prize must name an external source — a sponsor, a grant, or your own funds.",
+      "Commission is up to 10%, and you choose per tournament how much your organization absorbs against how much is added to the player's price.",
+      "Payouts are your net revenue in full, disbursed automatically three days after the tournament's final scheduled session in the venue's timezone. MYR only, minimum RM 10.",
+      "Early payouts are capped at 50% of net revenue, limited to two per tournament, available only after registration closes, and granted at the platform's discretion.",
+      "Early payouts are advances: if a tournament is later cancelled or refunded, the shortfall is repayable.",
+      "You may nominate another approved organization to receive a payout, but you remain fully liable regardless of who is paid.",
+      "On an approved cancellation, every confirmed player is refunded in full including commission, and your revenue for that tournament goes to zero.",
+      "Entry fees and prizes lock once a player has paid; everything else locks at tournament start.",
+      "Bank details and verification documents are your responsibility, and failed transfers caused by wrong details are your cost.",
+    ],
+  },
+];
+
+/** The version currently in force. Derived, so it cannot drift from the history. */
+export const TERMS_VERSION = TERMS_HISTORY[0].version;
+
+/** The version currently in force. Derived, so it cannot drift from the history. */
+export const ORGANIZER_AGREEMENT_VERSION =
+  ORGANIZER_AGREEMENT_HISTORY[0].version;
+
+/**
+ * What changed between the version someone accepted and the current one.
+ *
+ * Takes the version they are ON, and returns the changes from every version
+ * published since — so a reader who skipped two versions is told about both,
+ * and a reader who is already current is told nothing. A null `acceptedVersion`
+ * (accepted before we recorded versions, or never accepted) returns the whole
+ * history, which is the honest answer to "what am I agreeing to?".
+ *
+ * Newest changes first, matching the order of the history itself.
+ */
+export function changesSince(
+  history: readonly LegalVersion[],
+  acceptedVersion: string | null,
+): string[] {
+  const relevant =
+    acceptedVersion === null
+      ? history
+      : // ISO dates compare correctly as strings, which is why the format is ISO.
+        history.filter((entry) => entry.version > acceptedVersion);
+
+  return relevant.flatMap((entry) => [...entry.changes]);
+}
+
+const LEGAL_VERSION_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+/**
+ * Renders a version constant as the human date shown under a document's title —
+ * "2026-08-02" becomes "2 August 2026".
+ *
+ * Deliberately not Intl.DateTimeFormat: these strings are calendar dates, not
+ * instants, and parsing one into a Date would read it in the server's zone and
+ * can shift the day. Returns the input unchanged if it isn't date-shaped, so a
+ * malformed constant shows up in the page rather than throwing during render.
+ */
+export function formatLegalVersion(version: string): string {
+  const match = LEGAL_VERSION_PATTERN.exec(version);
+  if (!match) return version;
+
+  const [, year, month, day] = match;
+  const monthName = MONTHS[Number(month) - 1];
+  if (!monthName) return version;
+
+  return `${Number(day)} ${monthName} ${year}`;
+}


### PR DESCRIPTION
Closes #517. Part of #515.

## Why

Nothing recorded that anyone had agreed to anything. `termsAccepted` was a client-side checkbox validated in `auth-validation.ts` and never sent to the server; `organizations` had no agreement columns; and no Organizer Agreement existed. Fine for a free signup — not for documents that govern money movement and make a claw-back enforceable. This must reach production **before** Phase 3's application form, or early organizers onboard with no agreement on file.

Two statements in the existing documents were also untrue, and both are corrected here.

## What changed

**Versioned acceptance** — `src/lib/legal.ts` holds a history per document, with the current version *derived* from the newest entry so the two cannot disagree, plus `changesSince(history, acceptedVersion)`. Acceptance is persisted on `users.terms_version` and `organizations.agreement_version`, each with a `chk_*_shape` CHECK so a version without a timestamp cannot be stored. `handle_new_user` writes it in the same statement that creates the account, so there is no window where a user exists with no record of what they agreed to.

**The version is always the server's.** Written from the constant at signup (via `user_metadata`), at application, and on re-acceptance — never from the request body, because a client-supplied version would let a caller claim to have accepted wording they were never shown. Tests pin that a body-supplied version is ignored at every entry point.

**The document** — new `/organizer-agreement`, fifteen clauses each tied to something the code does, so the document and the implementation cannot say different things. Footer link added (note: `Footer` is currently rendered by no layout, so it is not yet visible).

**Re-acceptance** — bumping the constant is how a new version is published, so `POST /api/v1/organizations/[orgId]/agreement` is the way out of the state that creates. Gated on `org.manage`. `AgreementGate` blocks the org dashboard and lists what actually changed since the version that organization accepted — asking someone to re-accept a money-movement document without saying what moved buys a reflexive tick, which is worth nothing the day the claw-back clause is tested.

**Corrections**
- ToS §4 said entry fees are "collected by the tournament organiser" and prize disbursement is "the sole responsibility of the tournament organiser". Neither survives the payout design. Now: platform collection under the agreement, the fee is not a stake and never becomes another player's winnings, the service fee is stated, and cancellation refunds everyone in full including commission.
- The Privacy Policy claimed bank details are "encrypted at rest". Nothing is column- or application-encrypted — that was Supabase disk encryption only. Replaced with what is true (TLS, encrypted volumes, RLS, bank numbers masked in audit snapshots, private document storage) and says plainly that individual fields are not separately encrypted. KYB documents are disclosed ahead of Phase 3 collecting them.

## Decisions worth reviewing

| Decision | Why |
|---|---|
| Wired into the **existing** application route, not deferred to Phase 3's RPC | The route already exists; organizers onboarding before Phase 3 get an agreement on file, which is the reason this phase precedes that form |
| Gate on the **dashboard**, not the payouts page | That page arrives in Phase 5. `AgreementGate` is standalone so the move is one line |
| Agreement route does **not** require `approval_status === 'approved'` | A version bump must not permanently strand an unreviewed organization |
| Re-accepting the current version is a **no-op** | It would only move the timestamp, and the timestamp is the evidence of when *this* version was agreed to |
| Agreement columns on `organizations` despite the column-unrestricted public SELECT policy | A version string, a timestamp and an opaque user id are no worse than the existing `created_by`/`reviewed_by`. Commented so it is not read as a precedent for the bank columns that policy keeps off |
| Privacy wording **softened** rather than implementing column encryption | Phase 3 is where org bank details land; overstating protection while shipping payouts is the thing to avoid now |

## Deferred

Notifying organizers by email when a version is published. Built as a script, then removed rather than left as scaffolding — it would have been replaced wholesale by an admin-area button, and the CI alternative meant putting the service-role key in a public repo's secrets. Audience rules, the per-recipient `changesSince` content rule, and the enqueue-not-inline constraint are [recorded on #515](https://github.com/nzmksk/my-chess-tour/issues/515#issuecomment-5156241058) for Phase 5.

## Contract for later phases

`queue_payout` (Phase 5) and `request_early_payout` (Phase 6) must both refuse when `agreement_version` is not current, so a stale agreement stops money rather than failing silently. Recorded as a comment on the columns in `001_tables.sql`.

## Verification

- `npm run test` — 112 files, 1738 tests
- `npm run lint`, `npm run build`
- `db/tests/legal_acceptance.sql` — 8 scenarios covering both CHECK constraints, the trigger with and without a version, and an acceptance surviving its acceptor's deletion. Run it in the Supabase SQL editor after re-applying `001` → `007`; also re-run `identity_indirection.sql` and `audit_redaction.sql`, which touch `users`
- Manual: sign up and confirm `terms_version` is stored; submit an application with a bogus `agreement_version` in the body and confirm the stored value is the server constant; bump `ORGANIZER_AGREEMENT_VERSION` and confirm the gate appears, accepts, and clears

## Note for reviewers

`terms/page.tsx` and `privacy/page.tsx` were not Prettier-clean before this branch, so formatting them alongside the content edits reformatted each file. The class-order churn in those two is not a content change. Happy to revert to hand-formatted edits if the diff noise is not worth it.

⚠️ The legal wording is not lawyer-reviewed. This PR builds the machinery and covers the clause checklist; the prose still needs qualified review — tracked as Risk 2 on #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)